### PR TITLE
Account for negative money

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -326,7 +326,7 @@ a:link, a:visited {
     /*margin: 50% auto;*/
     padding: 5px;
     border: 2px solid var(--my-highlight-color);
-    width: 18%;
+    width: 19%;
     overflow: auto; /* Enable scroll if needed */
     background-color: #444; /* Fallback color */
     z-index: 1;


### PR DESCRIPTION
After taking a course that costs more than the total income, the money balance went negative. That forced the `character-overview-container` **div** to use scrolling bars.

Proposed solution is to use *19%* instead of *18%* for *width*.

![lightscreen 1500961810](https://user-images.githubusercontent.com/2027447/28557709-6815a6c0-70e4-11e7-8a41-34998c85d72a.png)