### PR TITLE
Add getStatLevels() netscript function

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -662,6 +662,21 @@ function NetscriptFunctions(workerScript) {
             workerScript.scriptRef.log("getHackingLevel() returned " + Player.hacking_skill);
             return Player.hacking_skill;
         },
+        getStatLevels : function(){
+            if (Player.bitNodeN != 4) {
+                if (!(hasSingularitySF && singularitySFLvl >= 2)) {
+                    throw makeRuntimeRejectMsg(workerScript, "Cannot run getStatLevels(). It is a Singularity Function and requires SourceFile-4 (level 2) to run.");
+                    return false;
+                }
+            }
+            return {
+                strength: Player.strength,
+                defense: Player.defense,
+                dexterity: Player.dexterity,
+                agility: Player.agility,
+                charisma: Player.charisma
+            }
+        },
         getIntelligence : function () {
             if (!hasAISF) {
                 throw makeRuntimeRejectMsg(workerScript, "Cannot run getIntelligence(). It requires Source-File 5 to run.");

--- a/src/Script.js
+++ b/src/Script.js
@@ -310,6 +310,7 @@ function calculateRamUsage(codeCopy) {
                        numOccurrences(codeCopy, "purchaseProgram(");
     var singFn2Count = numOccurrences(codeCopy, "upgradeHomeRam(") +
                        numOccurrences(codeCopy, "getUpgradeHomeRamCost(") +
+                       numOccurrences(codeCopy, "getStatLevels(") +
                        numOccurrences(codeCopy, "workForCompany(") +
                        numOccurrences(codeCopy, "applyToCompany(") +
                        numOccurrences(codeCopy, "getCompanyRep(") +


### PR DESCRIPTION
`getStatLevels()` costs 2GB of RAM and requires SourceFile-4 (level 2). It returns an object 

```
{
    strength: Player.strength,
    defense: Player.defense,
    dexterity: Player.dexterity,
    agility: Player.agility,
    charisma: Player.charisma
}
```

Resolves #149 