### PR TITLE
fileExists netscript function now works with txt files

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -828,6 +828,10 @@ function NetscriptFunctions(workerScript) {
                     return true;
                 }
             }
+            var txtFile = getTextFile(filename, server);
+            if (txtFile !== null) {
+              return true;
+            }
             return false;
         },
         isRunning : function(filename,ip){


### PR DESCRIPTION
I was looking through the wiki and noticed that you can `read`/`write` to `*.txt` files, but `fileExists` always returned false on those. This should fix it, but please also test to make sure!