### PR TITLE
Fix some stuff with ls() and cat

### DIFF
--- a/doc/source/netscriptfunctions.rst
+++ b/doc/source/netscriptfunctions.rst
@@ -326,9 +326,10 @@ scp
 ls
 ^^
 
-.. js:function:: ls(hostname/ip)
+.. js:function:: ls(hostname/ip, [grep])
 
     :param string hostname/ip: Hostname or IP of the target server
+    :param string grep: a substring to search for in the filename.
 
     Returns an array with the filenames of all files on the specified server (as strings). The returned array
     is sorted in alphabetic order

--- a/src/Message.js
+++ b/src/Message.js
@@ -42,7 +42,7 @@ function showMessage(msg) {
     var txt = "Message received from unknown sender: <br><br>" +
               "<i>" + msg.msg + "</i><br><br>" +
               "This message was saved as " + msg.filename + " onto your home computer.";
-    dialogBoxCreate(txt);
+    dialogBoxCreate(txt, true);
 }
 
 //Adds a message to a server

--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -816,6 +816,16 @@ function NetscriptFunctions(workerScript) {
                 }
             }
 
+            for (var i = 0; i < server.textFiles.length; i++) {
+                if (filter) {
+                    if (server.textFiles[i].fn.includes(filter)) {
+                        allFiles.push(server.textFiles[i].fn);
+                    }
+                } else {
+                    allFiles.push(server.textFiles[i].fn);
+                }
+            }
+
             //Sort the files alphabetically then print each
             allFiles.sort();
             return allFiles;

--- a/utils/DialogBox.js
+++ b/utils/DialogBox.js
@@ -32,7 +32,7 @@ $(document).on('click', '.dialog-box-close-button', function( event ) {
 
 var dialogBoxOpened = false;
 
-function dialogBoxCreate(txt) {
+function dialogBoxCreate(txt, preformatted) {
     var container = document.createElement("div");
     container.setAttribute("class", "dialog-box-container");
 
@@ -43,8 +43,16 @@ function dialogBoxCreate(txt) {
     closeButton.setAttribute("class", "dialog-box-close-button");
     closeButton.innerHTML = "&times;"
 
-    var textE = document.createElement("p");
-    textE.innerHTML = txt.replace(/(?:\r\n|\r|\n)/g, '<br>');
+    var textE;
+    if (preformatted) {
+        // For text files as they are often computed data that
+        // shouldn't be wrapped and should retain tabstops.
+        textE = document.createElement("pre");
+        textE.innerHTML = txt;
+    } else {
+        textE = document.createElement("p");
+        textE.innerHTML = txt.replace(/(?:\r\n|\r|\n)/g, '<br>');
+    }
 
     content.appendChild(closeButton);
     content.appendChild(textE);


### PR DESCRIPTION
Wanted to be able to clean up after a few scripts, but found I couldn't find the files programmatically and peeked in to see the `ls` netscript function was missing the chunk looking through `server.textFiles`

Also fixed some missing documentation. Will keep adding small stuff to this branch as I complete them.

Changed .txt files to be rendered using `<pre>` instead of `<p>` and removed the newline conversion to `<br>` since it wouldn't be needed. This way `\t` is retained and data which shouldn't be wrapped since newlines can be significant, doesn't get wrapped.