### PR TITLE
Fix documentation to include grep parameter to ls() netscript function

### DIFF
--- a/doc/source/netscriptfunctions.rst
+++ b/doc/source/netscriptfunctions.rst
@@ -326,9 +326,10 @@ scp
 ls
 ^^
 
-.. js:function:: ls(hostname/ip)
+.. js:function:: ls(hostname/ip, [grep])
 
     :param string hostname/ip: Hostname or IP of the target server
+    :param string grep: a substring to search for in the filename.
 
     Returns an array with the filenames of all files on the specified server (as strings). The returned array
     is sorted in alphabetic order


### PR DESCRIPTION
Noticed an undocumented parameter to `ls` that would've been handy to know about to save on how long it takes to iterate through loops.