### PR TITLE
Commit crime log

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -40,8 +40,7 @@ let CONSTANTS = {
 
     /* Netscript Constants */
     //RAM Costs for different commands
-    ScriptWhileRamCost:             0.2,
-    ScriptForRamCost:               0.2,
+    ScriptLoopRamCost:              0.2,
     ScriptIfRamCost:                0.15,
     ScriptHackRamCost:              0.1,
     ScriptGrowRamCost:              0.15,

--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -72,7 +72,53 @@ var hasCorporationSF=false,     //Source-File 3
     hasWallStreetSF=false,      //Source-File 8
     hasBn11SF=false;            //Source-File 11
 
-
+var possibleLogs = {
+    ALL: true,
+    scan: true,
+    hack: true,
+    sleep: true,
+    grow: true,
+    weaken: true,
+    nuke: true,
+    brutessh: true,
+    ftpcrack: true,
+    relaysmtp: true,
+    httpworm: true,
+    sqlinject: true,
+    spawn: true,
+    kill: true,
+    killall: true,
+    scp: true,
+    getHackingLevel: true,
+    getServerMoneyAvailable: true,
+    getServerSecurityLevel: true,
+    getServerBaseSecurityLevel: true,
+    getServerMinSecurityLevel: true,
+    getServerRequiredHackingLevel: true,
+    getServerMaxMoney: true,
+    getServerGrowth: true,
+    getServerNumPortsRequired: true,
+    getServerRam: true,
+    buyStock: true,
+    sellStock: true,
+    purchaseServer: true,
+    deleteServer: true,
+    universityCourse: true,
+    gymWorkout: true,
+    travelToCity: true,
+    purchaseTor: true,
+    purchaseProgram: true,
+    stopAction: true,
+    upgradeHomeRam: true,
+    workForCompany: true,
+    applyToCompany: true,
+    joinFaction: true,
+    workForFaction: true,
+    createProgram: true,
+    commitCrime: true,
+    shortStock: true,
+    sellShort: true,
+}
 
 var singularitySFLvl=1, wallStreetSFLvl=1;
 
@@ -353,11 +399,18 @@ function NetscriptFunctions(workerScript) {
         },
         disableLog : function(fn) {
             if (workerScript.checkingRam) {return 0;}
+            if(possibleLogs[fn]===undefined) {
+                throw makeRuntimeRejectMsg(workerScript, "invalid argument to disableLog: "+fn);
+            }
+
             workerScript.disableLogs[fn] = true;
             workerScript.scriptRef.log("Disabled logging for " + fn);
         },
         enableLog : function(fn) {
             if (workerScript.checkingRam) {return 0;}
+            if(possibleLogs[fn]===undefined) {
+                throw makeRuntimeRejectMsg(workerScript, "invalid argument to enableLog: "+fn);
+            }
             delete workerScript.disableLogs[fn];
             workerScript.scriptRef.log("Enabled logging for " + fn);
         },
@@ -3298,41 +3351,42 @@ function NetscriptFunctions(workerScript) {
             }
 
             crime = crime.toLowerCase();
+            let disableCommitCrimeLog = workerScript.disableLogs.ALL == null && workerScript.disableLogs.commitCrime == null
             if (crime.includes("shoplift")) {
-                workerScript.scriptRef.log("Attempting to shoplift...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to shoplift...");}
                 return commitShopliftCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("rob") && crime.includes("store")) {
-                workerScript.scriptRef.log("Attempting to rob a store...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to rob a store...");}
                 return commitRobStoreCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("mug")) {
-                workerScript.scriptRef.log("Attempting to mug someone...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to mug someone...");}
                 return commitMugCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("larceny")) {
-                workerScript.scriptRef.log("Attempting to commit larceny...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to commit larceny...");}
                 return commitLarcenyCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("drugs")) {
-                workerScript.scriptRef.log("Attempting to deal drugs...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to deal drugs...");}
                 return commitDealDrugsCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("bond") && crime.includes("forge")) {
-                workerScript.scriptRef.log("Attempting to forge corporate bonds...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to forge corporate bonds...");}
                 return commitBondForgeryCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("traffick") && crime.includes("arms")) {
-                workerScript.scriptRef.log("Attempting to traffick illegal arms...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to traffick illegal arms...");}
                 return commitTraffickArmsCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("homicide")) {
-                workerScript.scriptRef.log("Attempting to commit homicide...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to commit homicide...");}
                 return commitHomicideCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("grand") && crime.includes("auto")) {
-                workerScript.scriptRef.log("Attempting to commit grand theft auto...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to commit grand theft auto...");}
                 return commitGrandTheftAutoCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("kidnap")) {
-                workerScript.scriptRef.log("Attempting to kidnap and ransom a high-profile target...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to kidnap and ransom a high-profile target...");}
                 return commitKidnapCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else if (crime.includes("assassinate")) {
-                workerScript.scriptRef.log("Attempting to assassinate a high-profile target...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to assassinate a high-profile target...");}
                 return commitAssassinationCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript})
             } else if (crime.includes("heist")) {
-                workerScript.scriptRef.log("Attempting to pull off a heist...");
+                if(disableCommitCrimeLog) {workerScript.scriptRef.log("Attempting to pull off a heist...");}
                 return commitHeistCrime(CONSTANTS.CrimeSingFnDivider, {workerscript: workerScript});
             } else {
                 throw makeRuntimeRejectMsg(workerScript, "Invalid crime passed into commitCrime(): " + crime);

--- a/src/Player.js
+++ b/src/Player.js
@@ -1582,7 +1582,8 @@ PlayerObject.prototype.finishCrime = function(cancelled) {
             this.workAgiExpGained   *= 2;
             this.workChaExpGained   *= 2;
             if (this.committingCrimeThruSingFn) {
-                this.singFnCrimeWorkerScript.scriptRef.log("Crime successful! Gained " +
+                if(this.singFnCrimeWorkerScript.disableLogs.ALL == null && this.singFnCrimeWorkerScript.disableLogs.commitCrime == null) {
+                    this.singFnCrimeWorkerScript.scriptRef.log("Crime successful! Gained " +
                                                            numeral(this.workMoneyGained).format("$0.000a") + ", " +
                                                            formatNumber(this.workHackExpGained, 3) + " hack exp, " +
                                                            formatNumber(this.workStrExpGained, 3) + " str exp, " +
@@ -1590,6 +1591,7 @@ PlayerObject.prototype.finishCrime = function(cancelled) {
                                                            formatNumber(this.workDexExpGained, 3) + " dex exp, " +
                                                            formatNumber(this.workAgiExpGained, 3) + " agi exp, " +
                                                            formatNumber(this.workChaExpGained, 3) + " cha exp.");
+                }
             } else {
                 dialogBoxCreate("Crime successful! <br><br>" +
                                 "You gained:<br>"+
@@ -1611,13 +1613,15 @@ PlayerObject.prototype.finishCrime = function(cancelled) {
             this.workAgiExpGained   /= 2;
             this.workChaExpGained   /= 2;
             if (this.committingCrimeThruSingFn) {
-                this.singFnCrimeWorkerScript.scriptRef.log("Crime failed! Gained " +
-                                                           formatNumber(this.workHackExpGained, 3) + " hack exp, " +
-                                                           formatNumber(this.workStrExpGained, 3) + " str exp, " +
-                                                           formatNumber(this.workDefExpGained, 3) + " def exp, " +
-                                                           formatNumber(this.workDexExpGained, 3) + " dex exp, " +
-                                                           formatNumber(this.workAgiExpGained, 3) + " agi exp, " +
-                                                           formatNumber(this.workChaExpGained, 3) + " chaexp.");
+                if(this.singFnCrimeWorkerScript.disableLogs.ALL == null && this.singFnCrimeWorkerScript.disableLogs.commitCrime == null) {
+                    this.singFnCrimeWorkerScript.scriptRef.log("Crime failed! Gained " +
+                                                               formatNumber(this.workHackExpGained, 3) + " hack exp, " +
+                                                               formatNumber(this.workStrExpGained, 3) + " str exp, " +
+                                                               formatNumber(this.workDefExpGained, 3) + " def exp, " +
+                                                               formatNumber(this.workDexExpGained, 3) + " dex exp, " +
+                                                               formatNumber(this.workAgiExpGained, 3) + " agi exp, " +
+                                                               formatNumber(this.workChaExpGained, 3) + " cha exp.");
+                }
             } else {
                 dialogBoxCreate("Crime failed! <br><br>" +
                         "You gained:<br>"+

--- a/src/Script.js
+++ b/src/Script.js
@@ -367,7 +367,7 @@ function calculateRamUsage(codeCopy) {
 
     //Search through AST, scanning for any 'Identifier' nodes for functions, or While/For/If nodes
     var queue = [], ramUsage = 1.4;
-    var whileUsed = false, forUsed = false, ifUsed = false;
+    var loopUsed = false, ifUsed = false;
     queue.push(ast);
     while (queue.length != 0) {
         var exp = queue.shift();
@@ -389,15 +389,15 @@ function calculateRamUsage(codeCopy) {
                 }
                 break;
             case "WhileStatement":
-                if (!whileUsed) {
-                    ramUsage += CONSTANTS.ScriptWhileRamCost;
-                    whileUsed = true;
+                if (!loopUsed) {
+                    ramUsage += CONSTANTS.ScriptLoopRamCost;
+                    loopUsed = true;
                 }
                 break;
             case "ForStatement":
-                if (!forUsed) {
-                    ramUsage += CONSTANTS.ScriptForRamCost;
-                    forUsed = true;
+                if (!loopUsed) {
+                    ramUsage += CONSTANTS.ScriptLoopRamCost;
+                    loopUsed = true;
                 }
                 break;
             case "IfStatement":


### PR DESCRIPTION
fix #207 

`commitCrime()` would log "chaexp" on failure, not logs "cha exp"

disableLog/enableLog now throw error when a string that isn't possible is given. eg `disableLog("iugbu");`

`commitCrime(x)` now takes `disableLog("commitCrime")` into consideration.