### PR TITLE
NetscriptJS: Die when sleepy

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -229,7 +229,6 @@ function NetscriptFunctions(workerScript) {
                 workerScript.scriptRef.log("Sleeping for " + time + " milliseconds");
             }
             return netscriptDelay(time, workerScript).then(function() {
-                if (workerScript.env.stopFlag) {return Promise.reject(workerScript);}
                 return Promise.resolve(true);
             });
         },

--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -229,6 +229,7 @@ function NetscriptFunctions(workerScript) {
                 workerScript.scriptRef.log("Sleeping for " + time + " milliseconds");
             }
             return netscriptDelay(time, workerScript).then(function() {
+                if (workerScript.env.stopFlag) {return Promise.reject(workerScript);}
                 return Promise.resolve(true);
             });
         },

--- a/src/NetscriptWorker.js
+++ b/src/NetscriptWorker.js
@@ -73,6 +73,13 @@ function startJsScript(workerScript) {
         // This function unfortunately cannot be an async function, because we don't
         // know if the original one was, and there's no way to tell.
         return function (...args) {
+            // Wrap every netscript function with a check for the stop flag.
+            // This prevents cases where we never stop because we are only calling
+            // netscript functions that don't check this.
+            // This is not a problem for legacy Netscript because it also checks the
+            // stop flag in the evaluator.
+            if (workerScript.env.stopFlag) {return Promise.reject(workerScript);}
+
             const msg = "Concurrent calls to Netscript functions not allowed! " +
                         "Did you forget to await hack(), grow(), or some other " +
                         "promise-returning function? (Currently running: %s tried to run: %s)"

--- a/src/NetscriptWorker.js
+++ b/src/NetscriptWorker.js
@@ -78,7 +78,9 @@ function startJsScript(workerScript) {
             // netscript functions that don't check this.
             // This is not a problem for legacy Netscript because it also checks the
             // stop flag in the evaluator.
-            if (workerScript.env.stopFlag) {return Promise.reject(workerScript);}
+            if (workerScript.env.stopFlag) {throw workerScript;}
+
+            if (propName === "sleep") return f(...args);  // OK for multiple simultaneous calls to sleep.
 
             const msg = "Concurrent calls to Netscript functions not allowed! " +
                         "Did you forget to await hack(), grow(), or some other " +
@@ -99,9 +101,9 @@ function startJsScript(workerScript) {
             }
         }
     };
+
     for (let prop in workerScript.env.vars) {
         if (typeof workerScript.env.vars[prop] !== "function") continue;
-        if (prop === "sleep") continue;  // OK for multiple simultaneous calls to sleep.
         workerScript.env.vars[prop] = wrap(prop, workerScript.env.vars[prop]);
     }
 


### PR DESCRIPTION
It seems like .script scripts pick this up by checking whether the script is dead in the evaluator. We don't have an evaluator under our control in JS mode, so we instead check on every netscript function invocation.