### PR TITLE
fix faction join exploit

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -738,9 +738,9 @@ let Engine = {
                     clickListener:()=>{
                         joinFaction(Factions[factionName]);
                         for (var i = 0; i < Player.factionInvitations.length; ++i) {
-                            if (Player.factionInvitations[i] == factionName) {
+                            if (Player.factionInvitations[i] == factionName || Factions[Player.factionInvitations[i]].isBanned) {
                                 Player.factionInvitations.splice(i, 1);
-                                break;
+                                i--;
                             }
                         }
                         Engine.displayFactionsInfo();


### PR DESCRIPTION
You could join all factions in game as long as you get invited to them before joining them.

With this fix it's no longer possible to join all city factions as they get removed when you join a pending invite.


before join
<img width="743" alt="screen shot 2018-05-27 at 2 07 13 am" src="https://user-images.githubusercontent.com/2773127/40583010-38a4bd1c-6153-11e8-9b7b-19e5b33d0a02.png">


after joining sector-12 (who pretty much every other city hates apparently)
<img width="735" alt="screen shot 2018-05-27 at 2 10 53 am" src="https://user-images.githubusercontent.com/2773127/40583035-b9dc6696-6153-11e8-83aa-e2e8c09aeaee.png">
