### PR TITLE
streamline in factions

### DIFF
--- a/src/Faction.js
+++ b/src/Faction.js
@@ -3,7 +3,7 @@ import {Augmentations, AugmentationNames,
 import {BitNodeMultipliers}                     from "./BitNode.js";
 import {CONSTANTS}                              from "./Constants.js";
 import {Engine}                                 from "./engine.js";
-import {FactionInfo}                            from "./FactionInfo.js";
+import {FactionInfos}                           from "./FactionInfo.js";
 import {Locations}                              from "./Location.js";
 import {HackingMission, setInMission}           from "./Missions.js";
 import {Player}                                 from "./Player.js";
@@ -23,48 +23,24 @@ import {yesNoBoxCreate, yesNoBoxGetYesButton,
 function Faction(name="") {
     this.name 				= name;
     this.augmentations 		= [];   //Name of augmentation only
-    this.info 		        = "";	//Introductory/informational text about the faction
 
     //Player-related properties for faction
     this.isMember 			= false; 	//Whether player is member
     this.isBanned           = false;    //Whether or not player is banned from joining this faction
     this.playerReputation 	= 0;  		//"Reputation" within faction
     this.alreadyInvited     = false;
-    this.enemies            = [];
-
-    //Types of work
-    this.offerHackingMission = false;
-    this.offerHackingWork    = false;
-    this.offerFieldWork      = false;
-    this.offerSecurityWork   = false;
-
-    //Multipliers for unlocking and purchasing augmentations
-    this.augmentationPriceMult = 1;
-    this.augmentationRepRequirementMult = 1;
 
     //Faction favor
     this.favor              = 0;
     this.rolloverRep        = 0;
 };
 
-Faction.prototype.setAugmentationMultipliers = function(price, rep) {
-    this.augmentationPriceMult = price;
-    this.augmentationRepRequirementMult = rep;
-}
-
-Faction.prototype.setInfo = function(inf) {
-	this.info = inf;
-}
-
-Faction.prototype.setEnemies = function(enemies){
-    this.enemies = enemies;
-}
-
-Faction.prototype.setAvailableWork = function(hackMission, hackWork, fieldWork, securityWork) {
-    this.offerHackingMission = hackMission;
-    this.offerHackingWork    = hackWork;
-    this.offerFieldWork      = fieldWork;
-    this.offerSecurityWork   = securityWork;
+Faction.prototype.getInfo = function() {
+    const info = FactionInfos[this.name];
+    if(info == null) {
+        throw new Error("Missing faction from FactionInfos: " + this.name+" this probably means the faction got corrupted somehow");
+    }
+    return info;
 }
 
 Faction.prototype.gainFavor = function() {
@@ -137,180 +113,9 @@ function factionExists(name) {
 //TODO Augmentation price and rep requirement mult are 1 for everything right now,
 //      This might change in the future for balance
 function initFactions() {
-	//Endgame
-	var Illuminati = new Faction("Illuminati");
-    Illuminati.setInfo(FactionInfo.IlluminatiInfo);
-    Illuminati.setAvailableWork(true, true, true, false);
-    resetFaction(Illuminati);
-
-	var Daedalus = new Faction("Daedalus");
-    Daedalus.setInfo(FactionInfo.DaedalusInfo);
-    Daedalus.setAvailableWork(true, true, true, false);
-    resetFaction(Daedalus);
-
-	var Covenant = new Faction("The Covenant");
-    Covenant.setInfo(FactionInfo.CovenantInfo);
-    Covenant.setAvailableWork(true, true, true, false);
-    resetFaction(Covenant);
-
-	//Megacorporations, each forms its own faction
-	var ECorp = new Faction("ECorp");
-    ECorp.setInfo(FactionInfo.ECorpInfo);
-    ECorp.setAvailableWork(true, true, true, true);
-    resetFaction(ECorp);
-
-	var MegaCorp = new Faction("MegaCorp");
-    MegaCorp.setAvailableWork(true, true, true, true);
-    MegaCorp.setInfo(FactionInfo.MegaCorpInfo);
-    resetFaction(MegaCorp);
-
-	var BachmanAndAssociates = new Faction("Bachman & Associates");
-    BachmanAndAssociates.setInfo(FactionInfo.BachmanAndAssociatesInfo);
-    BachmanAndAssociates.setAvailableWork(true, true, true, true);
-    resetFaction(BachmanAndAssociates);
-
-	var BladeIndustries = new Faction("Blade Industries");
-    BladeIndustries.setInfo(FactionInfo.BladeIndustriesInfo);
-    BladeIndustries.setAvailableWork(true, true, true, true);
-    resetFaction(BladeIndustries);
-
-	var NWO = new Faction("NWO");
-    NWO.setInfo(FactionInfo.NWOInfo);
-    NWO.setAvailableWork(true, true, true, true);
-    resetFaction(NWO);
-
-	var ClarkeIncorporated = new Faction("Clarke Incorporated");
-    ClarkeIncorporated.setInfo(FactionInfo.ClarkeIncorporatedInfo);
-    ClarkeIncorporated.setAvailableWork(true, true, true, true);
-    resetFaction(ClarkeIncorporated);
-
-	var OmniTekIncorporated = new Faction("OmniTek Incorporated");
-    OmniTekIncorporated.setInfo(FactionInfo.OmniTekIncorporatedInfo);
-    OmniTekIncorporated.setAvailableWork(true, true, true, true);
-    resetFaction(OmniTekIncorporated);
-
-	var FourSigma = new Faction("Four Sigma");
-    FourSigma.setInfo(FactionInfo.FourSigmaInfo);
-    FourSigma.setAvailableWork(true, true, true, true);
-    resetFaction(FourSigma);
-
-	var KuaiGongInternational = new Faction("KuaiGong International");
-    KuaiGongInternational.setInfo(FactionInfo.KuaiGongInternationalInfo);
-    KuaiGongInternational.setAvailableWork(true, true, true, true);
-    resetFaction(KuaiGongInternational);
-
-    //Other corporations
-    var FulcrumTechnologies = new Faction("Fulcrum Secret Technologies");
-    FulcrumTechnologies.setInfo(FactionInfo.FulcrumSecretTechnologiesInfo);
-    FulcrumTechnologies.setAvailableWork(true, true, false, true);
-    resetFaction(FulcrumTechnologies);
-
-	//Hacker groups
-	var BitRunners = new Faction("BitRunners");
-    BitRunners.setInfo(FactionInfo.BitRunnersInfo);
-    BitRunners.setAvailableWork(true, true, false, false);
-    resetFaction(BitRunners);
-
-	var BlackHand = new Faction("The Black Hand");
-    BlackHand.setInfo(FactionInfo.BlackHandInfo);
-    BlackHand.setAvailableWork(true, true, true, false);
-    resetFaction(BlackHand);
-
-	var NiteSec = new Faction("NiteSec");
-    NiteSec.setInfo(FactionInfo.NiteSecInfo);
-    NiteSec.setAvailableWork(true, true, false, false);
-    resetFaction(NiteSec);
-
-	//City factions, essentially governments
-	var Chongqing = new Faction("Chongqing");
-    Chongqing.setInfo(FactionInfo.ChongqingInfo);
-    Chongqing.setAvailableWork(true, true, true, true);
-    Chongqing.setEnemies(["Sector-12", "Aevum", "Volhaven"]);
-    resetFaction(Chongqing);
-
-	var Sector12 = new Faction("Sector-12");
-    Sector12.setInfo(FactionInfo.Sector12Info);
-    Sector12.setAvailableWork(true, true, true, true);
-    Sector12.setEnemies(["Chongqing", "New Tokyo", "Ishima", "Volhaven"]);
-    resetFaction(Sector12);
-
-	var NewTokyo = new Faction("New Tokyo");
-    NewTokyo.setInfo(FactionInfo.NewTokyoInfo);
-    NewTokyo.setAvailableWork(true, true, true, true);
-    NewTokyo.setEnemies(["Sector-12", "Aevum", "Volhaven"]);
-    resetFaction(NewTokyo);
-
-	var Aevum = new Faction("Aevum");
-    Aevum.setInfo(FactionInfo.AevumInfo);
-    Aevum.setAvailableWork(true, true, true, true);
-    Aevum.setEnemies(["Chongqing", "New Tokyo", "Ishima", "Volhaven"]);
-    resetFaction(Aevum);
-
-    var Ishima = new Faction("Ishima");
-    Ishima.setInfo(FactionInfo.Ishima);
-    Ishima.setAvailableWork(true, true, true, true);
-    Ishima.setEnemies(["Sector-12", "Aevum", "Volhaven"]);
-    resetFaction(Ishima);
-
-	var Volhaven = new Faction("Volhaven");
-    Volhaven.setInfo(FactionInfo.VolhavenInfo);
-    Volhaven.setAvailableWork(true, true, true, true);
-    Volhaven.setEnemies(["Chongqing", "Sector-12", "New Tokyo", "Aevum", "Ishima"]);
-    resetFaction(Volhaven);
-
-	//Criminal Organizations/Gangs
-	var SpeakersForTheDead = new Faction("Speakers for the Dead");
-    SpeakersForTheDead.setInfo(FactionInfo.SpeakersForTheDeadInfo);
-    SpeakersForTheDead.setAvailableWork(true, true, true, true);
-    resetFaction(SpeakersForTheDead);
-
-	var DarkArmy = new Faction("The Dark Army");
-    DarkArmy.setInfo(FactionInfo.DarkArmyInfo);
-    DarkArmy.setAvailableWork(true, true, true, false);
-    resetFaction(DarkArmy);
-
-	var TheSyndicate = new Faction("The Syndicate");
-    TheSyndicate.setInfo(FactionInfo.TheSyndicateInfo);
-    TheSyndicate.setAvailableWork(true, true, true, true);
-    resetFaction(TheSyndicate);
-
-    var Silhouette = new Faction("Silhouette");
-    Silhouette.setInfo(FactionInfo.SilhouetteInfo);
-    Silhouette.setAvailableWork(true, true, true, false);
-    resetFaction(Silhouette);
-
-    var Tetrads = new Faction("Tetrads"); //Low-medium level asian crime gang
-    Tetrads.setInfo(FactionInfo.TetradsInfo);
-    Tetrads.setAvailableWork(false, false, true, true);
-    resetFaction(Tetrads);
-
-    var SlumSnakes = new Faction("Slum Snakes"); //Low level crime gang
-    SlumSnakes.setInfo(FactionInfo.SlumSnakesInfo);
-    SlumSnakes.setAvailableWork(false, false, true, true);
-    resetFaction(SlumSnakes);
-
-	//Earlygame factions - factions the player will prestige with early on that don't
-	//belong in other categories
-    var Netburners = new Faction("Netburners");
-    Netburners.setInfo(FactionInfo.NetburnersInfo);
-    Netburners.setAvailableWork(true, true, false, false);
-    resetFaction(Netburners);
-
-	var TianDiHui = new Faction("Tian Di Hui");	//Society of the Heaven and Earth
-    TianDiHui.setInfo(FactionInfo.TianDiHuiInfo);
-    TianDiHui.setAvailableWork(true, true, false, true);
-    resetFaction(TianDiHui);
-
-	var CyberSec = new Faction("CyberSec");
-    CyberSec.setInfo(FactionInfo.CyberSecInfo);
-    CyberSec.setAvailableWork(true, true, false, false);
-    resetFaction(CyberSec);
-
-    //Special Factions
-    var Bladeburners = new Faction("Bladeburners");
-    Bladeburners.setInfo(FactionInfo.BladeburnersInfo);
-    Bladeburners.setAvailableWork(false, false, false, false);
-    resetFaction(Bladeburners);
+    for(const name in FactionInfos) {
+        resetFaction(new Faction(name));    
+    }
 }
 
 //Resets a faction during (re-)initialization. Saves the favor in the new
@@ -343,10 +148,11 @@ function inviteToFaction(faction) {
 function joinFaction(faction) {
 	faction.isMember = true;
     Player.factions.push(faction.name);
+    const factionInfo = faction.getInfo();
 
     //Determine what factions you are banned from now that you have joined this faction
-    for(const i in faction.enemies) {
-        const enemy = faction.enemies[i];
+    for(const i in factionInfo.enemies) {
+        const enemy = factionInfo.enemies[i];
         Factions[enemy].isBanned = true;
     }
 }
@@ -357,6 +163,8 @@ function displayFactionContent(factionName) {
     if (faction == null) {
         throw new Error("Invalid factionName passed into displayFactionContent: " + factionName);
     }
+    var factionInfo = faction.getInfo();
+
     removeChildrenFromElement(Engine.Display.factionContent);
     var elements = [];
 
@@ -365,7 +173,7 @@ function displayFactionContent(factionName) {
         innerText:factionName
     }));
     elements.push(createElement("pre", {
-        innerHTML:"<i>" + faction.info + "</i>"
+        innerHTML:"<i>" + factionInfo.infoText + "</i>"
     }));
     elements.push(createElement("p", {
         innerText:"---------------",
@@ -620,10 +428,10 @@ function displayFactionContent(factionName) {
 
     donateDiv.style.display = faction.favor >= (150 * BitNodeMultipliers.RepToDonateToFaction) ? "inline" : "none";
 
-    hackMissionDiv.style.display  = faction.offerHackingMission ? "inline": "none";
-    hackDiv.style.display         = faction.offerHackingWork ? "inline" : "none";
-    fieldWorkDiv.style.display    = faction.offerFieldWork ? "inline" : "none";
-    securityWorkDiv.style.display = faction.offerSecurityWork ? "inline" : "none";
+    hackMissionDiv.style.display  = factionInfo.offerHackingMission ? "inline": "none";
+    hackDiv.style.display         = factionInfo.offerHackingWork ? "inline" : "none";
+    fieldWorkDiv.style.display    = factionInfo.offerFieldWork ? "inline" : "none";
+    securityWorkDiv.style.display = factionInfo.offerSecurityWork ? "inline" : "none";
 
     //Display all elements
     for (var i = 0; i < elements.length; ++i) {
@@ -749,6 +557,8 @@ function displayFactionAugmentations(factionName) {
 //  @augs Array of Aug names
 //  @faction Faction for which to display Augmentations
 function createFactionAugmentationDisplayElements(augmentationsList, augs, faction) {
+    const factionInfo = faction.getInfo();
+
     for (var i = 0; i < augs.length; ++i) {
         (function () {
             var aug = Augmentations[augs[i]];
@@ -800,10 +610,10 @@ function createFactionAugmentationDisplayElements(augmentationsList, augs, facti
                 pElem.innerHTML = "ALREADY OWNED";
             } else if (faction.playerReputation >= req) {
                 aElem.setAttribute("class", "a-link-button");
-                pElem.innerHTML = "UNLOCKED - " + numeral(aug.baseCost * faction.augmentationPriceMult).format("$0.000a");
+                pElem.innerHTML = "UNLOCKED - " + numeral(aug.baseCost * factionInfo.augmentationPriceMult).format("$0.000a");
             } else {
                 aElem.setAttribute("class", "a-link-button-inactive");
-                pElem.innerHTML = "LOCKED (Requires " + formatNumber(req, 1) + " faction reputation) - " + numeral(aug.baseCost * faction.augmentationPriceMult).format("$0.000a");
+                pElem.innerHTML = "LOCKED (Requires " + formatNumber(req, 1) + " faction reputation) - " + numeral(aug.baseCost * factionInfo.augmentationPriceMult).format("$0.000a");
                 pElem.style.color = "red";
             }
             aDiv.appendChild(aElem);
@@ -816,6 +626,7 @@ function createFactionAugmentationDisplayElements(augmentationsList, augs, facti
 }
 
 function purchaseAugmentationBoxCreate(aug, fac) {
+    const factionInfo = fac.info();
     var yesBtn = yesNoBoxGetYesButton(), noBtn = yesNoBoxGetNoButton();
     yesBtn.innerHTML = "Purchase";
     noBtn.innerHTML = "Cancel";
@@ -829,7 +640,7 @@ function purchaseAugmentationBoxCreate(aug, fac) {
     yesNoBoxCreate("<h2>" + aug.name + "</h2><br>" +
                    aug.info + "<br><br>" +
                    "<br>Would you like to purchase the " + aug.name + " Augmentation for $" +
-                   formatNumber(aug.baseCost * fac.augmentationPriceMult, 2)  + "?");
+                   formatNumber(aug.baseCost * factionInfo.augmentationPriceMult, 2)  + "?");
 }
 
 //Returns a boolean indicating whether the player has the prerequisites for the

--- a/src/Faction.js
+++ b/src/Faction.js
@@ -30,6 +30,13 @@ function Faction(name="") {
     this.isBanned           = false;    //Whether or not player is banned from joining this faction
     this.playerReputation 	= 0;  		//"Reputation" within faction
     this.alreadyInvited     = false;
+    this.enemies            = [];
+
+    //Types of work
+    this.offerHackingMission = false;
+    this.offerHackingWork    = false;
+    this.offerFieldWork      = false;
+    this.offerSecurityWork   = false;
 
     //Multipliers for unlocking and purchasing augmentations
     this.augmentationPriceMult = 1;
@@ -47,6 +54,17 @@ Faction.prototype.setAugmentationMultipliers = function(price, rep) {
 
 Faction.prototype.setInfo = function(inf) {
 	this.info = inf;
+}
+
+Faction.prototype.setEnemies = function(enemies){
+    this.enemies = enemies;
+}
+
+Faction.prototype.setAvailableWork = function(hackMission, hackWork, fieldWork, securityWork) {
+    this.offerHackingMission = hackMission;
+    this.offerHackingWork    = hackWork;
+    this.offerFieldWork      = fieldWork;
+    this.offerSecurityWork   = securityWork;
 }
 
 Faction.prototype.gainFavor = function() {
@@ -122,138 +140,176 @@ function initFactions() {
 	//Endgame
 	var Illuminati = new Faction("Illuminati");
     Illuminati.setInfo(FactionInfo.IlluminatiInfo);
+    Illuminati.setAvailableWork(true, true, true, false);
     resetFaction(Illuminati);
 
 	var Daedalus = new Faction("Daedalus");
     Daedalus.setInfo(FactionInfo.DaedalusInfo);
+    Daedalus.setAvailableWork(true, true, true, false);
     resetFaction(Daedalus);
 
 	var Covenant = new Faction("The Covenant");
     Covenant.setInfo(FactionInfo.CovenantInfo);
+    Covenant.setAvailableWork(true, true, true, false);
     resetFaction(Covenant);
 
 	//Megacorporations, each forms its own faction
 	var ECorp = new Faction("ECorp");
     ECorp.setInfo(FactionInfo.ECorpInfo);
+    ECorp.setAvailableWork(true, true, true, true);
     resetFaction(ECorp);
 
 	var MegaCorp = new Faction("MegaCorp");
+    MegaCorp.setAvailableWork(true, true, true, true);
     MegaCorp.setInfo(FactionInfo.MegaCorpInfo);
     resetFaction(MegaCorp);
 
 	var BachmanAndAssociates = new Faction("Bachman & Associates");
     BachmanAndAssociates.setInfo(FactionInfo.BachmanAndAssociatesInfo);
+    BachmanAndAssociates.setAvailableWork(true, true, true, true);
     resetFaction(BachmanAndAssociates);
 
 	var BladeIndustries = new Faction("Blade Industries");
     BladeIndustries.setInfo(FactionInfo.BladeIndustriesInfo);
+    BladeIndustries.setAvailableWork(true, true, true, true);
     resetFaction(BladeIndustries);
 
 	var NWO = new Faction("NWO");
     NWO.setInfo(FactionInfo.NWOInfo);
+    NWO.setAvailableWork(true, true, true, true);
     resetFaction(NWO);
 
 	var ClarkeIncorporated = new Faction("Clarke Incorporated");
     ClarkeIncorporated.setInfo(FactionInfo.ClarkeIncorporatedInfo);
+    ClarkeIncorporated.setAvailableWork(true, true, true, true);
     resetFaction(ClarkeIncorporated);
 
 	var OmniTekIncorporated = new Faction("OmniTek Incorporated");
     OmniTekIncorporated.setInfo(FactionInfo.OmniTekIncorporatedInfo);
+    OmniTekIncorporated.setAvailableWork(true, true, true, true);
     resetFaction(OmniTekIncorporated);
 
 	var FourSigma = new Faction("Four Sigma");
     FourSigma.setInfo(FactionInfo.FourSigmaInfo);
+    FourSigma.setAvailableWork(true, true, true, true);
     resetFaction(FourSigma);
 
 	var KuaiGongInternational = new Faction("KuaiGong International");
     KuaiGongInternational.setInfo(FactionInfo.KuaiGongInternationalInfo);
+    KuaiGongInternational.setAvailableWork(true, true, true, true);
     resetFaction(KuaiGongInternational);
 
     //Other corporations
     var FulcrumTechnologies = new Faction("Fulcrum Secret Technologies");
     FulcrumTechnologies.setInfo(FactionInfo.FulcrumSecretTechnologiesInfo);
+    FulcrumTechnologies.setAvailableWork(true, true, false, true);
     resetFaction(FulcrumTechnologies);
 
 	//Hacker groups
 	var BitRunners = new Faction("BitRunners");
     BitRunners.setInfo(FactionInfo.BitRunnersInfo);
+    BitRunners.setAvailableWork(true, true, false, false);
     resetFaction(BitRunners);
 
 	var BlackHand = new Faction("The Black Hand");
     BlackHand.setInfo(FactionInfo.BlackHandInfo);
+    BlackHand.setAvailableWork(true, true, true, false);
     resetFaction(BlackHand);
 
 	var NiteSec = new Faction("NiteSec");
     NiteSec.setInfo(FactionInfo.NiteSecInfo);
+    NiteSec.setAvailableWork(true, true, false, false);
     resetFaction(NiteSec);
 
 	//City factions, essentially governments
 	var Chongqing = new Faction("Chongqing");
     Chongqing.setInfo(FactionInfo.ChongqingInfo);
+    Chongqing.setAvailableWork(true, true, true, true);
+    Chongqing.setEnemies(["Sector-12", "Aevum", "Volhaven"]);
     resetFaction(Chongqing);
 
 	var Sector12 = new Faction("Sector-12");
     Sector12.setInfo(FactionInfo.Sector12Info);
+    Sector12.setAvailableWork(true, true, true, true);
+    Sector12.setEnemies(["Chongqing", "New Tokyo", "Ishima", "Volhaven"]);
     resetFaction(Sector12);
 
 	var NewTokyo = new Faction("New Tokyo");
     NewTokyo.setInfo(FactionInfo.NewTokyoInfo);
+    NewTokyo.setAvailableWork(true, true, true, true);
+    NewTokyo.setEnemies(["Sector-12", "Aevum", "Volhaven"]);
     resetFaction(NewTokyo);
 
 	var Aevum = new Faction("Aevum");
     Aevum.setInfo(FactionInfo.AevumInfo);
+    Aevum.setAvailableWork(true, true, true, true);
+    Aevum.setEnemies(["Chongqing", "New Tokyo", "Ishima", "Volhaven"]);
     resetFaction(Aevum);
 
     var Ishima = new Faction("Ishima");
     Ishima.setInfo(FactionInfo.Ishima);
+    Ishima.setAvailableWork(true, true, true, true);
+    Ishima.setEnemies(["Sector-12", "Aevum", "Volhaven"]);
     resetFaction(Ishima);
 
 	var Volhaven = new Faction("Volhaven");
     Volhaven.setInfo(FactionInfo.VolhavenInfo);
+    Volhaven.setAvailableWork(true, true, true, true);
+    Volhaven.setEnemies(["Chongqing", "Sector-12", "New Tokyo", "Aevum", "Ishima"]);
     resetFaction(Volhaven);
 
 	//Criminal Organizations/Gangs
 	var SpeakersForTheDead = new Faction("Speakers for the Dead");
     SpeakersForTheDead.setInfo(FactionInfo.SpeakersForTheDeadInfo);
+    SpeakersForTheDead.setAvailableWork(true, true, true, true);
     resetFaction(SpeakersForTheDead);
 
 	var DarkArmy = new Faction("The Dark Army");
     DarkArmy.setInfo(FactionInfo.DarkArmyInfo);
+    DarkArmy.setAvailableWork(true, true, true, false);
     resetFaction(DarkArmy);
 
 	var TheSyndicate = new Faction("The Syndicate");
     TheSyndicate.setInfo(FactionInfo.TheSyndicateInfo);
+    TheSyndicate.setAvailableWork(true, true, true, true);
     resetFaction(TheSyndicate);
 
     var Silhouette = new Faction("Silhouette");
     Silhouette.setInfo(FactionInfo.SilhouetteInfo);
+    Silhouette.setAvailableWork(true, true, true, false);
     resetFaction(Silhouette);
 
     var Tetrads = new Faction("Tetrads"); //Low-medium level asian crime gang
     Tetrads.setInfo(FactionInfo.TetradsInfo);
+    Tetrads.setAvailableWork(false, false, true, true);
     resetFaction(Tetrads);
 
     var SlumSnakes = new Faction("Slum Snakes"); //Low level crime gang
     SlumSnakes.setInfo(FactionInfo.SlumSnakesInfo);
+    SlumSnakes.setAvailableWork(false, false, true, true);
     resetFaction(SlumSnakes);
 
 	//Earlygame factions - factions the player will prestige with early on that don't
 	//belong in other categories
     var Netburners = new Faction("Netburners");
     Netburners.setInfo(FactionInfo.NetburnersInfo);
+    Netburners.setAvailableWork(true, true, false, false);
     resetFaction(Netburners);
 
 	var TianDiHui = new Faction("Tian Di Hui");	//Society of the Heaven and Earth
     TianDiHui.setInfo(FactionInfo.TianDiHuiInfo);
+    TianDiHui.setAvailableWork(true, true, false, true);
     resetFaction(TianDiHui);
 
 	var CyberSec = new Faction("CyberSec");
     CyberSec.setInfo(FactionInfo.CyberSecInfo);
+    CyberSec.setAvailableWork(true, true, false, false);
     resetFaction(CyberSec);
 
     //Special Factions
     var Bladeburners = new Faction("Bladeburners");
     Bladeburners.setInfo(FactionInfo.BladeburnersInfo);
+    Bladeburners.setAvailableWork(false, false, false, false);
     resetFaction(Bladeburners);
 }
 
@@ -289,34 +345,9 @@ function joinFaction(faction) {
     Player.factions.push(faction.name);
 
     //Determine what factions you are banned from now that you have joined this faction
-    if (faction.name == "Chongqing") {
-        Factions["Sector-12"].isBanned = true;
-        Factions["Aevum"].isBanned = true;
-        Factions["Volhaven"].isBanned = true;
-    } else if (faction.name == "Sector-12") {
-        Factions["Chongqing"].isBanned = true;
-        Factions["New Tokyo"].isBanned = true;
-        Factions["Ishima"].isBanned = true;
-        Factions["Volhaven"].isBanned = true;
-    } else if (faction.name == "New Tokyo") {
-        Factions["Sector-12"].isBanned = true;
-        Factions["Aevum"].isBanned = true;
-        Factions["Volhaven"].isBanned = true;
-    } else if (faction.name == "Aevum") {
-        Factions["Chongqing"].isBanned = true;
-        Factions["New Tokyo"].isBanned = true;
-        Factions["Ishima"].isBanned = true;
-        Factions["Volhaven"].isBanned = true;
-    } else if (faction.name == "Ishima") {
-        Factions["Sector-12"].isBanned = true;
-        Factions["Aevum"].isBanned = true;
-        Factions["Volhaven"].isBanned = true;
-    } else if (faction.name == "Volhaven") {
-        Factions["Chongqing"].isBanned = true;
-        Factions["Sector-12"].isBanned = true;
-        Factions["New Tokyo"].isBanned = true;
-        Factions["Aevum"].isBanned = true;
-        Factions["Ishima"].isBanned = true;
+    for(const i in faction.enemies) {
+        const enemy = faction.enemies[i];
+        Factions[enemy].isBanned = true;
     }
 }
 
@@ -583,213 +614,16 @@ function displayFactionContent(factionName) {
         return;
     }
 
-	if (faction.isMember) {
-        if (faction.favor >= (150 * BitNodeMultipliers.RepToDonateToFaction)) {
-            donateDiv.style.display = "inline";
-        } else {
-            donateDiv.style.display = "none";
-        }
-
-		switch(faction.name) {
-			case "Illuminati":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "none";
-				break;
-			case "Daedalus":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "none";
-				break;
-			case "The Covenant":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "none";
-				break;
-			case "ECorp":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "MegaCorp":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Bachman & Associates":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Blade Industries":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "NWO":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Clarke Incorporated":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "OmniTek Incorporated":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Four Sigma":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "KuaiGong International":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-            case "Fulcrum Secret Technologies":
-                hackMissionDiv.style.display = "inline";
-                hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "none";
-				securityWorkDiv.style.display = "inline";
-                break;
-			case "BitRunners":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "none";
-				securityWorkDiv.style.display = "none";
-				break;
-			case "The Black Hand":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "none";
-				break;
-			case "NiteSec":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "none";
-				securityWorkDiv.style.display = "none";
-				break;
-			case "Chongqing":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Sector-12":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "New Tokyo":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Aevum":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Ishima":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Volhaven":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "Speakers for the Dead":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "The Dark Army":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "none";
-				break;
-			case "The Syndicate":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "inline";
-				securityWorkDiv.style.display = "inline";
-				break;
-            case "Silhouette":
-                hackMissionDiv.style.display = "inline";
-                hackDiv.style.display = "inline";
-                fieldWorkDiv.style.display = "inline";
-                securityWorkDiv.style.display = "none";
-                break;
-            case "Tetrads":
-                hackMissionDiv.style.display = "none";
-                hackDiv.style.display = "none";
-                fieldWorkDiv.style.display = "inline";
-                securityWorkDiv.style.display = "inline";
-                break;
-            case "Slum Snakes":
-                hackMissionDiv.style.display = "none";
-                hackDiv.style.display = "none";
-                fieldWorkDiv.style.display = "inline";
-                securityWorkDiv.style.display = "inline";
-                break;
-            case "Netburners":
-                hackMissionDiv.style.display = "inline";
-                hackDiv.style.display = "inline";
-                fieldWorkDiv.style.display = "none";
-                securityWorkDiv.style.display = "none";
-                break;
-			case "Tian Di Hui":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "none";
-				securityWorkDiv.style.display = "inline";
-				break;
-			case "CyberSec":
-                hackMissionDiv.style.display = "inline";
-				hackDiv.style.display = "inline";
-				fieldWorkDiv.style.display = "none";
-				securityWorkDiv.style.display = "none";
-				break;
-            case "Bladeburners":
-                hackMissionDiv.style.display = "none";
-                hackDiv.style.display = "none";
-                fieldWorkDiv.style.display = "none";
-                securityWorkDiv.style.display = "none";
-                break;
-			default:
-				console.log("Faction does not exist");
-				break;
-		}
-	} else {
+	if (!faction.isMember) {
 		throw new Error("Not a member of this faction, cannot display faction information");
 	}
+
+    donateDiv.style.display = faction.favor >= (150 * BitNodeMultipliers.RepToDonateToFaction) ? "inline" : "none";
+
+    hackMissionDiv.style.display  = faction.offerHackingMission ? "inline": "none";
+    hackDiv.style.display         = faction.offerHackingWork ? "inline" : "none";
+    fieldWorkDiv.style.display    = faction.offerFieldWork ? "inline" : "none";
+    securityWorkDiv.style.display = faction.offerSecurityWork ? "inline" : "none";
 
     //Display all elements
     for (var i = 0; i < elements.length; ++i) {

--- a/src/FactionInfo.js
+++ b/src/FactionInfo.js
@@ -1,68 +1,81 @@
 //Contains the "information" property for all the Factions, which is just a description
 //of each faction
-const FactionInfo = {
+function FactionInfo(infoText, enemies, offerHackingMission, offerHackingWork, offerFieldWork, offerSecurityWork) {
+  this.infoText = infoText;
+  this.enemies = enemies;
+  this.offerHackingMission = offerHackingMission;
+  this.offerHackingWork = offerHackingWork;
+  this.offerFieldWork = offerFieldWork;
+  this.offerSecurityWork = offerSecurityWork;
+
+  // these are always all 1 for now.
+  this.augmentationPriceMult = 1;
+  this.augmentationRepRequirementMult = 1;
+}
+
+const FactionInfos = {
     //Endgame
-    IlluminatiInfo: "Humanity never changes. No matter how civilized society becomes, it will eventually fall back " +
-                    "into chaos. And from this chaos, we are the Invisible hand that guides them to order. ",
+    "Illuminati": new FactionInfo("Humanity never changes. No matter how civilized society becomes, it will eventually fall back " +
+                    "into chaos. And from this chaos, we are the Invisible hand that guides them to order. ", [], true, true, true, false),
 
-    DaedalusInfo: "Yesterday we obeyed kings and bent our necks to emperors. Today we kneel only to truth.",
+    "Daedalus": new FactionInfo("Yesterday we obeyed kings and bent our necks to emperors. Today we kneel only to truth.", [], true, true, true, false),
 
-    CovenantInfo: "Surrender yourself. Give up your empty individuality to become part of something great, something eternal. " +
+    "The Covenant": new FactionInfo("Surrender yourself. Give up your empty individuality to become part of something great, something eternal. " +
                   "Become a slave. Submit your mind, body, and soul. Only then can you set yourself free.<br><br> " +
-                  "Only then can you discover immortality.",
+                  "Only then can you discover immortality.", [], true, true, true, false),
 
     //Megacorporations, each forms its own faction
-    ECorpInfo: "ECorp's mission is simple: to connect the world of today with the technology of tomorrow. " +
+    "ECorp": new FactionInfo("ECorp's mission is simple: to connect the world of today with the technology of tomorrow. " +
                "With our wide range of Internet-related software and commercial hardware, ECorp makes the world's " +
-               "information universally accessible.",
+               "information universally accessible.", [], true, true, true, true),
 
-    MegaCorpInfo: "MegaCorp does things that others don't. We imagine. We create. We invent. We build things that " +
+    "MegaCorp": new FactionInfo("MegaCorp does things that others don't. We imagine. We create. We invent. We build things that " +
                   "others have never even dreamed of. Our work fills the world's needs for food, water, power, and " +
                   "transporation on an unprecendented scale, in ways that no other company can.<br><br>" +
-                  "In our labs and factories and on the ground with customers, MegaCorp is ushering in a new era for the world.",
+                  "In our labs and factories and on the ground with customers, MegaCorp is ushering in a new era for the world.", [], true, true, true, true),
 
-    BachmanAndAssociatesInfo: "Where Law and Business meet - thats where we are. <br><br>" +
-                              "Legal Insight - Business Instinct - Experience Innovation",
+    "Bachman & Associates": new FactionInfo("Where Law and Business meet - thats where we are. <br><br>" +
+                              "Legal Insight - Business Instinct - Experience Innovation", [], true, true, true, true),
 
-    BladeIndustriesInfo: "Augmentation is salvation",
+    "Blade Industries": new FactionInfo("Augmentation is salvation", [], true, true, true, true),
 
-    NWOInfo: "The human being does not truly desire freedom. It wants " +
+    "NWO": new FactionInfo("The human being does not truly desire freedom. It wants " +
              "to be observed, understood, and judged. It wants to be given purpose and " +
              "direction in its life. That is why humans created God. " +
              "And that is why humans created civilization - " +
              "not because of willingness, " +
-             "but because of a need to be incorporated into higher orders of structure and meaning.",
+             "but because of a need to be incorporated into higher orders of structure and meaning.", [], true, true, true, true),
 
-    ClarkeIncorporatedInfo: "Unlocking the power of the genome",
+    "Clarke Incorporated": new FactionInfo("Unlocking the power of the genome", [], true, true, true, true),
 
-    OmniTekIncorporatedInfo: "Simply put, our mission is to design and build robots that make a difference",
+    "OmniTek Incorporated": new FactionInfo("Simply put, our mission is to design and build robots that make a difference", [], true, true, true, true),
 
-    FourSigmaInfo: "The scientific method is the best way to approach investing. Big strategies backed up with big data. Driven by " +
-                   "deep learning and innovative ideas. And improved by iteration. That's Four Sigma.",
+    "Four Sigma": new FactionInfo("The scientific method is the best way to approach investing. Big strategies backed up with big data. Driven by " +
+                   "deep learning and innovative ideas. And improved by iteration. That's Four Sigma.", [], true, true, true, true),
 
-    KuaiGongInternationalInfo: "Dream big. Work hard. Make history.",
+    "KuaiGong International": new FactionInfo("Dream big. Work hard. Make history.", [], true, true, true, true),
 
     //Other Corporations
-    FulcrumSecretTechnologiesInfo: "The human organism has an innate desire to worship. " +
+    "Fulcrum Secret Technologies": new FactionInfo("The human organism has an innate desire to worship. " +
                                    "That is why they created gods. If there were no gods, " +
-                                   "it would be necessary to create them. And now we can.",
+                                   "it would be necessary to create them. And now we can.", [], true, true, false, true),
 
     //Hacker groups
-    BitRunnersInfo: "Our entire lives are controlled by bits. All of our actions, our thoughts, our personal information.  "+
+    "BitRunners": new FactionInfo("Our entire lives are controlled by bits. All of our actions, our thoughts, our personal information.  "+
                     "It's all transformed into bits, stored in bits, communicated through bits. It’s impossible for any person " +
                     "to move, to live, to operate at any level without the use of bits.  " +
                     "And when a person moves, lives, and operates, they leave behind their bits, mere traces of seemingly " +
                     "meaningless fragments of information. But these bits can be reconstructed. Transformed. Used.<br><br>" +
-                    "Those who run the bits, run the world",
+                    "Those who run the bits, run the world", [], true, true, false, false),
 
 
-    BlackHandInfo: "The world, so afraid of strong government, now has no government. Only power - Digital power. Financial power. " +
+    "The Black Hand": new FactionInfo("The world, so afraid of strong government, now has no government. Only power - Digital power. Financial power. " +
                    "Technological power. " +
                    "And those at the top rule with an invisible hand. They built a society where the rich get richer, " +
                    "and everyone else suffers.<br><br>" +
-                   "So much pain. So many lives. Their darkness must end.",
+                   "So much pain. So many lives. Their darkness must end.", [], true, true, true, false),
 
-    NiteSecInfo:
+    "NiteSec": new FactionInfo(
 "                          __..__               <br>" +
 "                      _.nITESECNIt.            <br>" +
 "                   .-'NITESECNITESEc.          <br>" +
@@ -97,47 +110,47 @@ const FactionInfo = {
 "               /       .d$$$$;          ,   ;  <br>" +
 "              d      .dNITESEC          $   |  <br>" +
 "             :bp.__.gNITESEC$$         :$   ;  <br>" +
-"             NITESECNITESECNIT         $$b :   <br>",
+"             NITESECNITESECNIT         $$b :   <br>", [], true, true, false, false),
 
     //City factions, essentially governments
-    ChongqingInfo: "Serve the people",
-    Sector12Info: "The City of the Future",
-    HongKongInfo: "Asia's World City",
-    AevumInfo: "The Silicon City",
-    IshimaInfo: "The East Asian Order of the Future",
-    VolhavenInfo: "Benefit, Honour, and Glory",
+    "Chongqing": new FactionInfo("Serve the people", ["Sector-12", "Aevum", "Volhaven"], true, true, true, true),
+    "Sector-12": new FactionInfo("The City of the Future", ["Chongqing", "New Tokyo", "Ishima", "Volhaven"], true, true, true, true),
+    "New Tokyo": new FactionInfo("Asia's World City", ["Sector-12", "Aevum", "Volhaven"], true, true, true, true),
+    "Aevum": new FactionInfo("The Silicon City", ["Chongqing", "New Tokyo", "Ishima", "Volhaven"], true, true, true, true),
+    "Ishima": new FactionInfo("The East Asian Order of the Future", ["Sector-12", "Aevum", "Volhaven"], true, true, true, true),
+    "Volhaven": new FactionInfo("Benefit, Honour, and Glory", ["Chongqing", "Sector-12", "New Tokyo", "Aevum", "Ishima"], true, true, true, true),
 
     //Criminal Organizations/Gangs
-    SpeakersForTheDeadInfo:    "It is better to reign in hell than to serve in heaven.",
+    "Speakers for the Dead": new FactionInfo("It is better to reign in hell than to serve in heaven.", [], true, true, true, true),
 
-    DarkArmyInfo: "The World doesn't care about right or wrong. It's all about power.",
+    "The Dark Army": new FactionInfo("The World doesn't care about right or wrong. It's all about power.", [], true, true, true, false),
 
-    TheSyndicateInfo: "Honor holds you back",
+    "The Syndicate": new FactionInfo("Honor holds you back", [], true, true, true, true),
 
-    SilhouetteInfo: "Corporations have filled the void of power left behind by the collapse of Western government. The issue is they've become so big " +
+    "Silhouette": new FactionInfo("Corporations have filled the void of power left behind by the collapse of Western government. The issue is they've become so big " +
                     "that you don't know who they're working for. And if you're employed at one of these corporations, you don't even know who you're working " +
                     "for.\n\n" +
-                    "That's terror. Terror, fear, and corruption. All born into the system, all propagated by the system.",
+                    "That's terror. Terror, fear, and corruption. All born into the system, all propagated by the system.", [], true, true, true, false),
 
-    TetradsInfo: "Following the Mandate of Heaven and Carrying out the Way",
+    "Tetrads": new FactionInfo("Following the Mandate of Heaven and Carrying out the Way", [], false, false, true, true),
 
-    SlumSnakesInfo: "Slum Snakes rule!",
+    "Slum Snakes": new FactionInfo("Slum Snakes rule!", [], false, false, true, true),
 
     //Earlygame factions - factions the player will prestige with early on that don't
     //belong in other categories
-    NetburnersInfo: "~~//*>H4CK|\|3T 8URN3R5**>?>\\~~",
+    "Netburners": new FactionInfo("~~//*>H4CK|\|3T 8URN3R5**>?>\\~~", [], true, true, false, false),
 
-    TianDiHuiInfo: "Obey Heaven and Work Righteousness",
+    "Tian Di Hui": new FactionInfo("Obey Heaven and Work Righteousness", [], true, true, false, true),
 
-    CyberSecInfo: "The Internet is the first thing that humanity has built that humanity doesn’t understand, " +
+    "CyberSec": new FactionInfo("The Internet is the first thing that humanity has built that humanity doesn’t understand, " +
                   "the largest experiment in anarchy that we have ever had. And as the world becomes increasingly " +
                   "dominated by the internet, society approaches the brink of total chaos. " +
-                  "We serve only to protect society, to protect humanity, to protect the world from its imminent collapse.",
+                  "We serve only to protect society, to protect humanity, to protect the world from its imminent collapse.", [], true, true, false, false),
 
     //Special Factions
-    BladeburnersInfo: "It's too bad they won't live. But then again, who does?<br><br>" +
+    "Bladeburners": new FactionInfo("It's too bad they won't live. But then again, who does?<br><br>" +
                       "Note that for this faction, reputation can only be gained through Bladeburner actions. Completing " +
-                      "Bladeburner contracts/operations will increase your reputation.",
+                      "Bladeburner contracts/operations will increase your reputation.", [], false, false, false, false),
 }
 
-export {FactionInfo};
+export {FactionInfos};

--- a/src/FactionInfo.js
+++ b/src/FactionInfo.js
@@ -1,6 +1,6 @@
 //Contains the "information" property for all the Factions, which is just a description
 //of each faction
-let FactionInfo = {
+const FactionInfo = {
     //Endgame
     IlluminatiInfo: "Humanity never changes. No matter how civilized society becomes, it will eventually fall back " +
                     "into chaos. And from this chaos, we are the Invisible hand that guides them to order. ",


### PR DESCRIPTION
move all static data related to faction to FactionInfo, which is now more than a string

aggregated faction enemies, simplifying the faction banning code
aggregated the type of work available for each faction, simplifying the display code

now build the factions from the faction infos, greatly streamlining that code.

