### PR TITLE
exec, spawn, and run won't log when disableLog is set

### DIFF
--- a/src/NetscriptEvaluator.js
+++ b/src/NetscriptEvaluator.js
@@ -833,7 +833,9 @@ function runScriptFromScript(server, scriptname, args, workerScript, threads=1) 
                 return Promise.resolve(false);
             } else {
                 //Able to run script
-                workerScript.scriptRef.log("Running script: " + scriptname + " on " + server.hostname + " with " + threads + " threads and args: " + printArray(args) + ". May take a few seconds to start up...");
+                if(workerScript.disableLogs.ALL == null && workerScript.disableLogs.exec == null && workerScript.disableLogs.run == null && workerScript.disableLogs.spawn == null) {
+                    workerScript.scriptRef.log("Running script: " + scriptname + " on " + server.hostname + " with " + threads + " threads and args: " + printArray(args) + ". May take a few seconds to start up...");
+                }
                 var runningScriptObj = new RunningScript(script, args);
                 runningScriptObj.threads = threads;
                 server.runningScripts.push(runningScriptObj);    //Push onto runningScripts


### PR DESCRIPTION
The only weird thing is since all 3 are calling the same function disabling either `exec`, `run`, or `spawn` disables the others. It's not a big deal usually most people who disable log disable everything but it needs to be taken into consideration.


I was thinking the log object should be the one to take care of enable/disable anyway and it could look up the call stack to see in which netscript function was called (later PR)