### PR TITLE
Simpler home ram

### DIFF
--- a/src/Location.js
+++ b/src/Location.js
@@ -1761,16 +1761,8 @@ function initLocationButtons() {
     });
 
     purchaseHomeRam.addEventListener("click", function() {
-        //Calculate how many times ram has been upgraded (doubled)
-        var currentRam = Player.getHomeComputer().maxRam;
-        var newRam = currentRam * 2;
-        var numUpgrades = Math.log2(currentRam);
-
-        //Calculate cost
-        //Have cost increase by some percentage each time RAM has been upgraded
-        var cost = currentRam * CONSTANTS.BaseCostFor1GBOfRamHome;
-        var mult = Math.pow(1.58, numUpgrades);
-        cost = cost * mult;
+        const cost = Player.getUpgradeHomeRamCost();
+        const ram = Player.getHomeComputer().maxRam;
 
         var yesBtn = yesNoBoxGetYesButton(), noBtn = yesNoBoxGetNoButton();
         yesBtn.innerHTML = "Purchase"; noBtn.innerHTML = "Cancel";
@@ -1782,8 +1774,8 @@ function initLocationButtons() {
             yesNoBoxClose();
         });
         yesNoBoxCreate("Would you like to purchase additional RAM for your home computer? <br><br>" +
-                       "This will upgrade your RAM from " + currentRam + "GB to " + newRam + "GB. <br><br>" +
-                       "This will cost $" + formatNumber(cost, 2));
+                       "This will upgrade your RAM from " + ram + "GB to " + ram*2 + "GB. <br><br>" +
+                       "This will cost " + numeral(cost).format('$0.000a'));
     });
 
     purchaseHomeCores.addEventListener("click", function() {

--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -2506,15 +2506,7 @@ function NetscriptFunctions(workerScript) {
                 }
             }
 
-            //Calculate how many times ram has been upgraded (doubled)
-            var currentRam = Player.getHomeComputer().maxRam;
-            var numUpgrades = Math.log2(currentRam);
-
-            //Calculate cost
-            //Have cost increase by some percentage each time RAM has been upgraded
-            var cost = currentRam * CONSTANTS.BaseCostFor1GBOfRamHome;
-            var mult = Math.pow(1.55, numUpgrades);
-            cost = cost * mult;
+            const cost = Player.getUpgradeHomeRamCost();
 
             if (Player.money.lt(cost)) {
                 workerScript.scriptRef.log("ERROR: upgradeHomeRam() failed because you don't have enough money");
@@ -2546,15 +2538,7 @@ function NetscriptFunctions(workerScript) {
                 }
             }
 
-            //Calculate how many times ram has been upgraded (doubled)
-            var currentRam = Player.getHomeComputer().maxRam;
-            var numUpgrades = Math.log2(currentRam);
-
-            //Calculate cost
-            //Have cost increase by some percentage each time RAM has been upgraded
-            var cost = currentRam * CONSTANTS.BaseCostFor1GBOfRamHome;
-            var mult = Math.pow(1.55, numUpgrades);
-            return cost * mult;
+            return Player.getUpgradeHomeRamCost();
         },
         workForCompany : function() {
             var ramCost = CONSTANTS.ScriptSingularityFn2RamCost;

--- a/src/Player.js
+++ b/src/Player.js
@@ -413,8 +413,7 @@ PlayerObject.prototype.getUpgradeHomeRamCost = function() {
     //Calculate cost
     //Have cost increase by some percentage each time RAM has been upgraded
     const mult = Math.pow(1.58, numUpgrades);
-    var cost = currentRam * CONSTANTS.BaseCostFor1GBOfRamHome;
-    cost = cost * mult;
+    var cost = currentRam * CONSTANTS.BaseCostFor1GBOfRamHome * mult;
     cost = cost.toPrecision(5);
     return cost;
 }

--- a/src/Player.js
+++ b/src/Player.js
@@ -405,6 +405,20 @@ PlayerObject.prototype.getHomeComputer = function() {
     return AllServers[this.homeComputer];
 }
 
+PlayerObject.prototype.getUpgradeHomeRamCost = function() {
+    //Calculate how many times ram has been upgraded (doubled)
+    const currentRam = Player.getHomeComputer().maxRam;
+    const numUpgrades = Math.log2(currentRam);
+
+    //Calculate cost
+    //Have cost increase by some percentage each time RAM has been upgraded
+    const mult = Math.pow(1.58, numUpgrades);
+    var cost = currentRam * CONSTANTS.BaseCostFor1GBOfRamHome;
+    cost = cost * mult;
+    cost = cost.toPrecision(5);
+    return cost;
+}
+
 //Calculates skill level based on experience. The same formula will be used for every skill
 PlayerObject.prototype.calculateSkill = function(exp) {
     return Math.max(Math.floor(32 * Math.log(exp + 534.5) - 200), 1);


### PR DESCRIPTION
<img width="953" alt="screen shot 2018-06-07 at 2 55 28 pm" src="https://user-images.githubusercontent.com/2773127/41120212-d86667ca-6a62-11e8-9d57-c09241af6c26.png">

buying ram was cheaper when doing it through singularity because a factor was different, now it's all reused code. Also the cost was changed to only calculate the first 5 digits of precision. This means the prompt can display a cleaner number like `$10.275t`, like upgrading CPU, instead of `$10,275,135,752,145`.

So neither a nerf nor a boost as it's not cheaper via manual clicking but more expensive via singularity
