### PR TITLE
[chore] Fixing sourcemaps so they actually point to the correct sources

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,11 +19,10 @@ module.exports = {
         engine: "./src/engine.js",
         tests: "./tests/index.js",
     },
-    devtool: "nosources-source-map",
+    devtool: "source-map",
     output: {
         path: path.resolve(__dirname, "dist"),
-        filename: "[name].bundle.js",
-        devtoolModuleFilenameTemplate: "[id]"
+        filename: "[name].bundle.js"
     },
     module: {
         rules: [


### PR DESCRIPTION
This has been annoying me far longer than I care to admit. This finally fixes the sourcemap files generated from WebPack to actually point back to the correct locations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/danielyxie/bitburner/276)
<!-- Reviewable:end -->
