### PR TITLE
fixed serverExists returning true for non-existent IPs

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -1199,7 +1199,7 @@ function NetscriptFunctions(workerScript) {
                 return updateStaticRam("serverExists", CONSTANTS.ScriptGetServerRamCost);
             }
             updateDynamicRam("serverExists", CONSTANTS.ScriptGetServerRamCost);
-            return (getServer(ip) != null);
+            return (getServer(ip) !== null);
         },
         fileExists : function(filename,ip=workerScript.serverIp) {
             if (workerScript.checkingRam) {

--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -1199,7 +1199,7 @@ function NetscriptFunctions(workerScript) {
                 return updateStaticRam("serverExists", CONSTANTS.ScriptGetServerRamCost);
             }
             updateDynamicRam("serverExists", CONSTANTS.ScriptGetServerRamCost);
-            return (getServer(ip) !== null);
+            return (getServer(ip) != null);
         },
         fileExists : function(filename,ip=workerScript.serverIp) {
             if (workerScript.checkingRam) {

--- a/src/Server.js
+++ b/src/Server.js
@@ -873,9 +873,11 @@ function GetServerByHostname(hostname) {
 function getServer(s) {
     if (!isValidIPAddress(s)) {
         return GetServerByHostname(s);
-    } else {
+    }
+    if(AllServers[s] !== undefined) {
         return AllServers[s];
     }
+    return null;
 }
 
 //Debugging tool


### PR DESCRIPTION
`getServer(ip)` returns `undefined`, which isn't `!==` null, fixed this to return appropriate values.