### PR TITLE
Corporation styling

### DIFF
--- a/css/companymanagement.css
+++ b/css/companymanagement.css
@@ -22,12 +22,6 @@
     background-color: #777;
 }
 
-/* Select industry type when creating a new division */
-.cmpy-mgmt-industry-select {
-    color:white;
-    background-color:black;
-}
-
 /* Switch between Cities */
 .cmpy-mgmt-city-tab {
     display:inline-block;

--- a/css/menupages.css
+++ b/css/menupages.css
@@ -501,18 +501,6 @@
     width: 50%;
 }
 
-.dev-text-input {
-    color: var(--my-font-color);
-    border: 1px solid white;
-    background-color:black;
-}
-
-.dev-dropdown-input {
-    color: var(--my-font-color);
-    border: 1px solid white;
-    background-color:black;
-}
-
 /* Location */
 #location-container {
 	position: fixed;

--- a/css/styles.css
+++ b/css/styles.css
@@ -197,6 +197,16 @@ a:link, a:visited {
     pointer-events: none;
 }
 
+.dropdown {
+    color:white;
+    background-color:black;
+}
+
+.text-input {
+    color:white;
+    background-color:black;
+}
+
 /* Notification icon (for create program right now only) */
 #create-program-tab {
     position:relative;

--- a/index.html
+++ b/index.html
@@ -488,20 +488,20 @@
 
         <p id='dev-menu-text'>Augmentation related: </p>
         <!-- gets populated with the list of all augments -->
-        <select id="dev-menu-aug-dropdown" class="dev-dropdown-input"></select>
+        <select id="dev-menu-aug-dropdown" class="dropdown"></select>
         <a id="dev-add-aug" class="a-link-button tooltip">Queue Augmentation<span class="tooltiptext">May require save + reload</span></a>
 
-        <input id="dev-sf-n" type="number" class="dev-text-input" placeholder="SourceFile-N"><input id="dev-sf-lvl" type="number" class="dev-text-input" placeholder="SourceFile-Lvl"><a id="dev-add-source-file" class="a-link-button tooltip"> Add/Remove source file <span class="tooltiptext">If Lvl == 0 the sf will be removed, calling it with another level will replace your current source file. You CAN set a source file higher than it's maximum level.</span></a>
+        <input id="dev-sf-n" type="number" class="text-input" placeholder="SourceFile-N"><input id="dev-sf-lvl" type="number" class="text-input" placeholder="SourceFile-Lvl"><a id="dev-add-source-file" class="a-link-button tooltip"> Add/Remove source file <span class="tooltiptext">If Lvl == 0 the sf will be removed, calling it with another level will replace your current source file. You CAN set a source file higher than it's maximum level.</span></a>
 
         <p id='dev-menu-text'>Faction related: </p>
-        <select id="dev-menu-faction-dropdown" class="dev-dropdown-input"></select>
+        <select id="dev-menu-faction-dropdown" class="dropdown"></select>
         <a id="dev-add-faction" class="a-link-button tooltip">Receive invite<span class="tooltiptext">May require save + reload</span></a>
 
         <p id='dev-menu-text'>Program related: </p>
-        <select id="dev-menu-connect-dropdown" class="dev-dropdown-input"></select>
+        <select id="dev-menu-connect-dropdown" class="dropdown"></select>
         <a id="dev-connect" class="a-link-button tooltip">Connect<span class="tooltiptext">Connect to the target server.</span></a>
 
-        <select id="dev-menu-add-program-dropdown" class="dev-dropdown-input"></select>
+        <select id="dev-menu-add-program-dropdown" class="dropdown"></select>
         <a id="dev-add-program" class="a-link-button tooltip">Add Program<span class="tooltiptext">Add this program to the player home server, won't add the same program twice.</span></a>
 
         <a id="dev-bit-flume" class="a-link-button tooltip">Trigger BitFlume<span class="tooltiptext">Quick escape to change BN, does not give SFs</span></a>
@@ -512,19 +512,19 @@
         <a id="dev-max-money" class="a-link-button tooltip">maximize all servers money<span class="tooltiptext">Set all servers available money to maximum for that server</span></a>
 
         <p id='dev-menu-text'>Exp/stats related: </p>
-        <input id="dev-hacking-exp" type="number" class="dev-text-input" placeholder="+exp/-exp (int)">
+        <input id="dev-hacking-exp" type="number" class="text-input" placeholder="+exp/-exp (int)">
         <a id="dev-add-hacking" class="a-link-button tooltip">add hacking exp<span class="tooltiptext">Add that many hacking experience point, use negative numbers to remove, don't worry about going under 0 exp</span></a>
-        <input id="dev-strength-exp" type="number" class="dev-text-input" placeholder="+exp/-exp (int)">
+        <input id="dev-strength-exp" type="number" class="text-input" placeholder="+exp/-exp (int)">
         <a id="dev-add-strength" class="a-link-button tooltip">add strength exp<span class="tooltiptext">Add that many strength experience point, use negative numbers to remove, don't worry about going under 0 exp</span></a>
-        <input id="dev-defense-exp" type="number" class="dev-text-input" placeholder="+exp/-exp (int)">
+        <input id="dev-defense-exp" type="number" class="text-input" placeholder="+exp/-exp (int)">
         <a id="dev-add-defense" class="a-link-button tooltip">add defense exp<span class="tooltiptext">Add that many defense experience point, use negative numbers to remove, don't worry about going under 0 exp</span></a>
-        <input id="dev-dexterity-exp" type="number" class="dev-text-input" placeholder="+exp/-exp (int)">
+        <input id="dev-dexterity-exp" type="number" class="text-input" placeholder="+exp/-exp (int)">
         <a id="dev-add-dexterity" class="a-link-button tooltip">add dexterity exp<span class="tooltiptext">Add that many dexterity experience point, use negative numbers to remove, don't worry about going under 0 exp</span></a>
-        <input id="dev-agility-exp" type="number" class="dev-text-input" placeholder="+exp/-exp (int)">
+        <input id="dev-agility-exp" type="number" class="text-input" placeholder="+exp/-exp (int)">
         <a id="dev-add-agility" class="a-link-button tooltip">add agility exp<span class="tooltiptext">Add that many agility experience point, use negative numbers to remove, don't worry about going under 0 exp</span></a>
-        <input id="dev-charisma-exp" type="number" class="dev-text-input" placeholder="+exp/-exp (int)">
+        <input id="dev-charisma-exp" type="number" class="text-input" placeholder="+exp/-exp (int)">
         <a id="dev-add-charisma" class="a-link-button tooltip">add charisma exp<span class="tooltiptext">Add that many charisma experience point, use negative numbers to remove, don't worry about going under 0 exp</span></a>
-        <input id="dev-intelligence-exp" type="number" class="dev-text-input" placeholder="+exp/-exp (int)">
+        <input id="dev-intelligence-exp" type="number" class="text-input" placeholder="+exp/-exp (int)">
         <a id="dev-add-intelligence" class="a-link-button tooltip">add intelligence exp<span class="tooltiptext">Add that many intelligence experience point, use negative numbers to remove, don't worry about going under 0 exp</span></a>
         <a id="dev-enable-intelligence" class="a-link-button tooltip"> enable intelligence<span class="tooltiptext">Enables the intelligence stat</span></a>
         <a id="dev-disable-intelligence" class="a-link-button tooltip"> disable intelligence<span class="tooltiptext">Disables the intelligence stat</span></a>

--- a/src/CompanyManagement.js
+++ b/src/CompanyManagement.js
@@ -2431,8 +2431,9 @@ Warehouse.prototype.createMaterialUI = function(mat, matName, parentRefs) {
             });
 
             //Select industry and city to export to
-            var citySelector = createElement("select");
+            var citySelector = createElement("select", {class: "dropdown"});
             var industrySelector = createElement("select", {
+                class: "dropdown",
                 changeListener:()=>{
                     var industryName = industrySelector.options[industrySelector.selectedIndex].value;
                     for (var foo = 0; foo < company.divisions.length; ++foo) {
@@ -2475,6 +2476,7 @@ Warehouse.prototype.createMaterialUI = function(mat, matName, parentRefs) {
 
             //Select amount to export
             var exportAmount = createElement("input", {
+                class: "text-input",
                 placeholder:"Export amount / s"
             });
 
@@ -3422,15 +3424,14 @@ Corporation.prototype.updateUIHeaderTabs = function() {
                 innerHTML: "Create a new division to expand into a new industry:",
             });
             var selector = createElement("select", {
-                class:"cmpy-mgmt-industry-select"
+                class:"dropdown"
             });
             var industryDescription = createElement("p", {});
             var yesBtn;
             var nameInput = createElement("input", {
                 type:"text",
                 id:"cmpy-mgmt-expand-industry-name-input",
-                color:"white",
-                backgroundColor:"black",
+                class: "text-input",
                 display:"block",
                 maxLength: 30,
                 pattern:"[a-zA-Z0-9-_]",
@@ -4068,7 +4069,7 @@ Corporation.prototype.displayDivisionContent = function(division, city) {
                 innerText: "Would you like to expand into a new city by opening an office? " +
                            "This would cost " + numeral(OfficeInitialCost).format('$0.000a'),
             });
-            var citySelector = createElement("select", {margin:"5px"});
+            var citySelector = createElement("select", {class: "dropdown", margin:"5px"});
             for (var cityName in division.offices) {
                 if (division.offices.hasOwnProperty(cityName)) {
                     if (!(division.offices[cityName] instanceof OfficeSpace)) {


### PR DESCRIPTION
<img width="682" alt="screen shot 2018-06-13 at 4 11 51 pm" src="https://user-images.githubusercontent.com/2773127/41376036-ec1aed1e-6f25-11e8-9b0e-b5c0aad21091.png">

was all white before. now both dev-menu and corporation use the more generic `dropdown` and `text-input` class. Unified everywhere I could find.