### PR TITLE
fix growth not increasing security if server reaches max money

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -768,19 +768,31 @@ function initForeignServers() {
     }
 }
 
+function numCycleForGrowth(server, growth) {
+    let ajdGrowthRate = 1 + (CONSTANTS.ServerBaseGrowthRate - 1) / server.hackDifficulty;
+    if(ajdGrowthRate > CONSTANTS.ServerMaxGrowthRate) {
+        ajdGrowthRate = CONSTANTS.ServerMaxGrowthRate;
+    }
+
+    const serverGrowthPercentage = server.serverGrowth / 100;
+
+    const cycles = Math.log(growth)/(Math.log(ajdGrowthRate)*Player.hacking_grow_mult*serverGrowthPercentage);
+    return cycles;
+}
+
 //Applied server growth for a single server. Returns the percentage growth
 function processSingleServerGrowth(server, numCycles) {
     //Server growth processed once every 450 game cycles
-    var numServerGrowthCycles = Math.max(Math.floor(numCycles / 450), 0);
+    const numServerGrowthCycles = Math.max(Math.floor(numCycles / 450), 0);
 
     //Get adjusted growth rate, which accounts for server security
-    var growthRate = CONSTANTS.ServerBaseGrowthRate;
+    const growthRate = CONSTANTS.ServerBaseGrowthRate;
     var adjGrowthRate = 1 + (growthRate - 1) / server.hackDifficulty;
     if (adjGrowthRate > CONSTANTS.ServerMaxGrowthRate) {adjGrowthRate = CONSTANTS.ServerMaxGrowthRate;}
 
     //Calculate adjusted server growth rate based on parameters
-    var serverGrowthPercentage = server.serverGrowth / 100;
-    var numServerGrowthCyclesAdjusted = numServerGrowthCycles * serverGrowthPercentage * BitNodeMultipliers.ServerGrowthRate;
+    const serverGrowthPercentage = server.serverGrowth / 100;
+    const numServerGrowthCyclesAdjusted = numServerGrowthCycles * serverGrowthPercentage * BitNodeMultipliers.ServerGrowthRate;
 
     //Apply serverGrowth for the calculated number of growth cycles
     var serverGrowth = Math.pow(adjGrowthRate, numServerGrowthCyclesAdjusted * Player.hacking_grow_mult);
@@ -789,19 +801,26 @@ function processSingleServerGrowth(server, numCycles) {
         serverGrowth = 1;
     }
 
-    var oldMoneyAvailable = server.moneyAvailable;
+    const oldMoneyAvailable = server.moneyAvailable;
     server.moneyAvailable *= serverGrowth;
+
+    // in case of data corruption
     if (server.moneyMax && isNaN(server.moneyAvailable)) {
         server.moneyAvailable = server.moneyMax;
     }
+
+    // cap at max
     if (server.moneyMax && server.moneyAvailable > server.moneyMax) {
         server.moneyAvailable = server.moneyMax;
-        return server.moneyAvailable / oldMoneyAvailable;
     }
-
-    //Growing increases server security twice as much as hacking
-    server.fortify(2 * CONSTANTS.ServerFortifyAmount * numServerGrowthCycles);
-    return serverGrowth;
+    
+    // if there was any growth at all, increase security
+    if(oldMoneyAvailable !== server.moneyAvailable) {
+        //Growing increases server security twice as much as hacking
+        const usedCycles = numCycleForGrowth(server, server.moneyAvailable / oldMoneyAvailable);
+        server.fortify(2 * CONSTANTS.ServerFortifyAmount * Math.ceil(usedCycles));
+    }
+    return server.moneyAvailable / oldMoneyAvailable;
 }
 
 function prestigeHomeComputer(homeComp) {


### PR DESCRIPTION
Growth does not increase security if the server finishes with max money. This was a safety measure for players on a hiatus so they wouldn't return with servers with thousands of security. This however meant that player could get away with the security cost as long as they got their server to max money (which is easy/mandatory with the hgw cycle technique). This patch fixes this by increasing difficulty only by the amount of growth thread/cycles actually used to reach 100%, this is done by calculating the amount of threads/cycles needed to reach the actual growth that occurred on the server instead of number of threads/cycles given as argument.
<img width="451" alt="screen shot 2018-06-13 at 5 24 00 pm" src="https://user-images.githubusercontent.com/2773127/41378919-97f9a65e-6f2e-11e8-93a4-dcbe2df159ac.png">
