### PR TITLE
Move 'Changelog' url to the new, up-to-date location.

### DIFF
--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@
                 </form>
             </div>
             <div id="game-options-right-panel">
-                <a class="a-link-button" style="display:block;" href="https://bitburner.wikia.com/wiki/Changelog" target="_blank"> Changelog </a>
+                <a class="a-link-button" style="display:block;" href="https://bitburner.readthedocs.io/en/latest/changelog.html" target="_blank"> Changelog </a>
                 <a class="a-link-button" style="display:block;" href="https://bitburner.wikia.com" target="_blank">Wiki</a>
                 <a class="a-link-button" style="display:block;", href="https://www.reddit.com/r/bitburner" target="_blank">Subreddit</a>
                 <a id="save-game-link" class="a-link-button" style="display:inline-block;width:46%;"> Save Game </a>


### PR DESCRIPTION
As of the time of this writing, the wikia changelog is *still* not updated, whereas the readthedocs changelog is fully up to date. Considering the wikia is being deprecated, I took the liberty to fix this.