### PR TITLE
made skill calculation smoother

### DIFF
--- a/src/Gang.js
+++ b/src/Gang.js
@@ -336,17 +336,17 @@ function GangMember(name) {
 }
 
 //Same formula for Player
-GangMember.prototype.calculateSkill = function(exp) {
-    return Math.max(Math.floor(32 * Math.log(exp + 534.5) - 200), 1);
+GangMember.prototype.calculateSkill = function(exp, mult=1) {
+    return Math.max(Math.floor(mult*(32 * Math.log(exp + 534.5) - 200)), 1);
 }
 
 GangMember.prototype.updateSkillLevels = function() {
-    this.hack   = Math.floor(this.calculateSkill(this.hack_exp) * this.hack_mult);
-    this.str    = Math.floor(this.calculateSkill(this.str_exp) * this.str_mult);
-    this.def    = Math.floor(this.calculateSkill(this.def_exp) * this.def_mult);
-    this.dex    = Math.floor(this.calculateSkill(this.dex_exp) * this.dex_mult);
-    this.agi    = Math.floor(this.calculateSkill(this.agi_exp) * this.agi_mult);
-    this.cha    = Math.floor(this.calculateSkill(this.cha_exp) * this.cha_mult);
+    this.hack   = this.calculateSkill(this.hack_exp, this.hack_mult);
+    this.str    = this.calculateSkill(this.str_exp, this.str_mult);
+    this.def    = this.calculateSkill(this.def_exp, this.def_mult);
+    this.dex    = this.calculateSkill(this.dex_exp, this.dex_mult);
+    this.agi    = this.calculateSkill(this.agi_exp, this.agi_mult);
+    this.cha    = this.calculateSkill(this.cha_exp, this.cha_mult);
 }
 
 GangMember.prototype.calculatePower = function() {

--- a/src/Player.js
+++ b/src/Player.js
@@ -422,17 +422,17 @@ PlayerObject.prototype.receiveInvite = function(factionName) {
 }
 
 //Calculates skill level based on experience. The same formula will be used for every skill
-PlayerObject.prototype.calculateSkill = function(exp) {
-    return Math.max(Math.floor(32 * Math.log(exp + 534.5) - 200), 1);
+PlayerObject.prototype.calculateSkill = function(exp, mult=1) {
+    return Math.max(Math.floor(mult*(32 * Math.log(exp + 534.5) - 200)), 1);
 }
 
 PlayerObject.prototype.updateSkillLevels = function() {
-	this.hacking_skill = Math.max(1, Math.floor(this.calculateSkill(this.hacking_exp) * this.hacking_mult * BitNodeMultipliers.HackingLevelMultiplier));
-	this.strength      = Math.floor(this.calculateSkill(this.strength_exp) * this.strength_mult);
-    this.defense       = Math.floor(this.calculateSkill(this.defense_exp) * this.defense_mult);
-    this.dexterity     = Math.floor(this.calculateSkill(this.dexterity_exp) * this.dexterity_mult);
-    this.agility       = Math.floor(this.calculateSkill(this.agility_exp) * this.agility_mult);
-    this.charisma      = Math.floor(this.calculateSkill(this.charisma_exp) * this.charisma_mult);
+	this.hacking_skill = Math.max(1, Math.floor(this.calculateSkill(this.hacking_exp, this.hacking_mult) * BitNodeMultipliers.HackingLevelMultiplier));
+	this.strength      = this.calculateSkill(this.strength_exp, this.strength_mult);
+    this.defense       = this.calculateSkill(this.defense_exp, this.defense_mult);
+    this.dexterity     = this.calculateSkill(this.dexterity_exp, this.dexterity_mult);
+    this.agility       = this.calculateSkill(this.agility_exp, this.agility_mult);
+    this.charisma      = this.calculateSkill(this.charisma_exp, this.charisma_mult);
 
     if (this.intelligence > 0) {
         this.intelligence = Math.floor(this.calculateSkill(this.intelligence_exp));


### PR DESCRIPTION
http://www.wolframalpha.com/input/?i=plot+floor(2*floor(32*ln(x%2B534.5)-200)),+floor(2*(32*ln(x%2B534.5)-200))+for+x+between+0+and+100

Above you can see the new function, it works the same as the old but by moving the multiplier before the floor we will hit every value for the skill level. Currently once you reach a certain skill multiplier there are certain skill level that you can't hit. This is a trivial change but will make the display smoother.

If this is merged to master some players that are near the end of their bitnode might see an increase of their skill levels upon refreshing as the smooth value will kick in.