### PR TITLE
Add "getPurchasedServerCost" NS function

### DIFF
--- a/doc/source/netscriptfunctions.rst
+++ b/doc/source/netscriptfunctions.rst
@@ -670,6 +670,21 @@ purchaseHacknetNode
     end of the Hacknet Node's name (e.g The Hacknet Node named 'hacknet-node-4' will have an index of 4). If the player cannot afford
     to purchase a new Hacknet Node then the function will return false.
 
+getPurchasedServerCost
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. js:function:: getPurchasedServerCost(ram)
+
+    :param number ram: Amount of RAM of a potential purchased server. Must be a power of 2 (2, 4, 8, 16, etc.). Maximum value of 1048576 (2^20)
+
+    Returns the cost to purchase a server with the specified amount of *ram*.
+
+    Examples::
+
+        for (i = 1; i <= 20; i++) {
+            tprint(i + " -- " + getPurchasedServerCost(Math.pow(2, i)));
+        }
+
 purchaseServer
 ^^^^^^^^^^^^^^
 

--- a/netscript.js
+++ b/netscript.js
@@ -72,6 +72,7 @@ let NetscriptFunctions =
     "serverExists|fileExists|isRunning|"                                       +
     "deleteServer|getPurchasedServers|"                                        +
     "getPurchasedServerLimit|getPurchasedServerMaxRam|"                        +
+    "getPurchasedServerCost|"                                                  +
     "purchaseServer|round|write|read|peek|clear|rm|getPortHandle|"             +
     "scriptRunning|scriptKill|getScriptName|getScriptRam|"                     +
     "getHackTime|getGrowTime|getWeakenTime|getScriptIncome|getScriptExpGain|"  +

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -70,6 +70,7 @@ let CONSTANTS = {
     ScriptHNUpgCoreRamCost:         0.8,
     ScriptGetStockRamCost:          2.0,
     ScriptBuySellStockRamCost:      2.5,
+    ScriptGetPurchaseServerRamCost: 0.25,
     ScriptPurchaseServerRamCost:    2.25,
     ScriptGetPurchasedServerLimit:  0.05,
     ScriptGetPurchasedServerMaxRam: 0.05,


### PR DESCRIPTION
Relatively simple function, and users could manually incorporate the logic behind it into their script, but it's nice to have a way to expose the cast to purchase a server before actually attempting to purchase it.

Not very attached to the actual name, so open to suggestions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/danielyxie/bitburner/317)
<!-- Reviewable:end -->
