### PR TITLE
moved the suppress buy aug confirmation to settings, will now persist

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,6 +886,17 @@
                     <input type="checkbox" name="settingsSuppressTravelConfirmation" id="settingsSuppressTravelConfirmation">
                 </fieldset>
 
+
+                <!-- Suppress buy aug confirmation -->
+                <fieldset>
+                    <label for="settingsSuppressBuyAugmentationConfirmation" class="tooltip">Suppress buy augmentation confirmation:
+                        <span class="tooltiptext">
+                            If this is set, the confirmation message before buying augmentation will not show up.
+                        </span>
+                    </label>
+                    <input type="checkbox" name="settingsSuppressBuyAugmentationConfirmation" id="settingsSuppressBuyAugmentationConfirmation">
+                </fieldset>
+
                 <!-- Disable Terminal and Navigation Shortcuts -->
                 <fieldset>
                     <label for="settingsDisableHotkeys" class="tooltip">Disable Hotkeys:

--- a/src/Faction.js
+++ b/src/Faction.js
@@ -439,7 +439,6 @@ function displayFactionContent(factionName) {
     }
 }
 
-var confirmingPurchases = true;
 var sortOption = null;
 function displayFactionAugmentations(factionName) {
     var faction = Factions[factionName];
@@ -468,19 +467,6 @@ function displayFactionAugmentations(factionName) {
                   "Augmentations are powerful upgrades that will enhance your abilities."
     }));
 
-    //Confirming not confirming button
-    elements.push(createElement("label", {
-        for:"faction-augmentations-confirming-checkbox",innerText:"Confirm Purchases",
-        color:"white", margin:"4px", padding:"4px",
-    }));
-    var confirmingPurchasesCheckbox = createElement("input", {
-        type:"checkbox", id:"faction-augmentations-confirming-checkbox", checked:confirmingPurchases,
-        margin:"4px", padding:"4px",
-        clickListener:()=>{
-            confirmingPurchases = confirmingPurchasesCheckbox.checked;
-        }
-    });
-    elements.push(confirmingPurchasesCheckbox);
     elements.push(createElement("br"));
     elements.push(createElement("br"));
 
@@ -585,7 +571,8 @@ function createFactionAugmentationDisplayElements(augmentationsList, augs, facti
             var aElem = createElement("a", {
                 innerText:aug.name, display:"inline",
                 clickListener:()=>{
-                    if (confirmingPurchases) {
+                    console.log('sup buy in fac: '+Settings.SuppressBuyAugmentationConfirmation);
+                    if (!Settings.SuppressBuyAugmentationConfirmation) {
                         purchaseAugmentationBoxCreate(aug, faction);
                     } else {
                         purchaseAugmentation(aug, faction);
@@ -723,10 +710,12 @@ function purchaseAugmentation(aug, fac, sing=false) {
         if (sing) {
             return "You purchased " + aug.name;
         } else {
-            dialogBoxCreate("You purchased "  + aug.name + ". It's enhancements will not take " +
-                            "effect until they are installed. To install your augmentations, go to the " +
-                            "'Augmentations' tab on the left-hand navigation menu. Purchasing additional " +
-                            "augmentations will now be more expensive.");
+            if(!Settings.SuppressBuyAugmentationConfirmation){
+                dialogBoxCreate("You purchased "  + aug.name + ". It's enhancements will not take " +
+                                "effect until they are installed. To install your augmentations, go to the " +
+                                "'Augmentations' tab on the left-hand navigation menu. Purchasing additional " +
+                                "augmentations will now be more expensive.");
+            }
         }
 
         displayFactionAugmentations(fac.name);

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -2,19 +2,20 @@ import {Engine} from "./engine.js";
 
 /* Settings.js */
 let Settings = {
-    CodeInstructionRunTime:         50,
-    MaxLogCapacity:                 50,
-    MaxPortCapacity:                50,
-    SuppressMessages:               false,
-    SuppressFactionInvites:         false,
-    SuppressTravelConfirmation:     false,
-    AutosaveInterval:               60,
-    DisableHotkeys:                 false,
-    ThemeHighlightColor:            "#ffffff",
-    ThemeFontColor:                 "#66ff33",
-    ThemeBackgroundColor:           "#000000",
-    EditorTheme:                    "Monokai",
-    EditorKeybinding:               "ace",
+    CodeInstructionRunTime:              50,
+    MaxLogCapacity:                      50,
+    MaxPortCapacity:                     50,
+    SuppressMessages:                    false,
+    SuppressFactionInvites:              false,
+    SuppressTravelConfirmation:          false,
+    SuppressBuyAugmentationConfirmation: false,
+    AutosaveInterval:                    60,
+    DisableHotkeys:                      false,
+    ThemeHighlightColor:                 "#ffffff",
+    ThemeFontColor:                      "#66ff33",
+    ThemeBackgroundColor:                "#000000",
+    EditorTheme:                         "Monokai",
+    EditorKeybinding:                    "ace",
 }
 
 function loadSettings(saveString) {
@@ -28,6 +29,7 @@ function initSettings()  {
     Settings.SuppressMessages = false;
     Settings.SuppressFactionInvites = false;
     Settings.SuppressTravelConfirmation = false,
+    Settings.SuppressBuyAugmentationConfirmation = false,
     Settings.AutosaveInterval = 60;
     Settings.DisableHotkeys = false;
 }
@@ -39,6 +41,7 @@ function setSettingsLabels() {
     var suppressMsgs = document.getElementById("settingsSuppressMessages");
     var suppressFactionInv = document.getElementById("settingsSuppressFactionInvites")
     var suppressTravelConfirmation = document.getElementById("settingsSuppressTravelConfirmation");
+    var suppressBuyAugmentationConfirmation = document.getElementById("settingsSuppressBuyAugmentationConfirmation");
     var autosaveInterval = document.getElementById("settingsAutosaveIntervalValLabel");
     var disableHotkeys = document.getElementById("settingsDisableHotkeys");
 
@@ -49,6 +52,7 @@ function setSettingsLabels() {
     suppressMsgs.checked = Settings.SuppressMessages;
     suppressFactionInv.checked = Settings.SuppressFactionInvites;
     suppressTravelConfirmation.checked = Settings.SuppressTravelConfirmation;
+    suppressBuyAugmentationConfirmation.checked = Settings.SuppressBuyAugmentationConfirmation;
     autosaveInterval.innerHTML = Settings.AutosaveInterval;
     disableHotkeys.checked = Settings.DisableHotkeys;
 
@@ -97,6 +101,11 @@ function setSettingsLabels() {
 
     suppressTravelConfirmation.onclick = function() {
         Settings.SuppressTravelConfirmation = this.checked;
+    };
+
+    suppressBuyAugmentationConfirmation.onclick = function() {
+        Settings.SuppressBuyAugmentationConfirmation = this.checked;
+        console.log('sup buy: '+Settings.SuppressBuyAugmentationConfirmation);
     };
 
     disableHotkeys.onclick = function() {


### PR DESCRIPTION
The current confirm aug purchase setting doesn't persist through augments/bns, I moved it with the other suppress also prevent the "You purchase the xyz augment it will not take effect until you install it" message