### PR TITLE
[chore] Disable "no-inferrable-types" lint rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -44,7 +44,7 @@
         ],
         "no-any": false,
         "no-inferrable-types": [
-            true,
+            false,
             "ignore-params",
             "ignore-properties"
         ],


### PR DESCRIPTION
After discussing the conflicting 'typedef' vs. 'no-inferrable-types'
TSLint rules (https://github.com/palantir/tslint/issues/711) in the
Discord #development channel, the conclusion was to disable this rule in
order to be uniform and explicit in what all declarations are. Although
it's more verbose, it will help us out in the long run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/danielyxie/bitburner/332)
<!-- Reviewable:end -->
