### PR TITLE
Fix bladeburner.getActionTime returning null

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -3424,12 +3424,7 @@ function NetscriptFunctions(workerScript) {
                 }
                 updateDynamicRam("getCurrentAction", CONSTANTS.ScriptBladeburnerApiBaseRamCost / 4);
                 if (Player.bladeburner instanceof Bladeburner && (Player.bitNodeN === 7 || hasBladeburner2079SF)) {
-                    let res = Player.bladeburner.getTypeAndNameFromActionId(Player.bladeburner.action);
-                    if (res.type === "Idle" && res.name === "Idle") {
-                        return null;
-                    } else {
-                        return res;
-                    }
+                    return Player.bladeburner.getTypeAndNameFromActionId(Player.bladeburner.action);
                 }
                 throw makeRuntimeRejectMsg(workerScript, "getCurrentAction() failed because you do not currently have access to the Bladeburner API. This is either because you are not currently employed " +
                                                          "at the Bladeburner division or because you do not have Source-File 7");


### PR DESCRIPTION
[Bladeburner.prototype.getTypeAndNameFromAction](https://github.com/danielyxie/bitburner/blob/b00d2acc00ce61912ffd69610fade7ec32875f0f/src/Bladeburner.js#L3285) already sets type and value to Idle when null, so having the ns function return null is a deviation from the documented behavior.

> If the player is not performing an action, the function will return an object with the ‘type’ property set to “Idle”.