### PR TITLE
correct typo in hacknet nodes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
         <div id="hacknet-nodes-money-multipliers-div">
             <p id="hacknet-nodes-money">
                 <span>Money:</span><span id="hacknet-nodes-player-money"></span><br/>
-                <span>Total Hacknet Node Prodution:</span><span id="hacknet-nodes-total-production"></span>
+                <span>Total Hacknet Node Production:</span><span id="hacknet-nodes-total-production"></span>
             </p>
             <span id="hacknet-nodes-multipliers">
                 <a id="hacknet-nodes-1x-multiplier" class="a-link-button-inactive"> x1 </a>


### PR DESCRIPTION
I found a typo in the hacknet nodes section of the index.html file, and corrected it.

Was:
`Total Hacknet Node Prodution:`
Is now:
`Total Hacknet Node Production:`