### PR TITLE
Server Randomization

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -177,7 +177,7 @@ function initForeignServers() {
 
         AddToAllServers(server);
         if (metadata.networkLayer !== undefined) {
-            networkLayers[metadata.networkLayer - 1].push(server);
+            networkLayers[toNumber(metadata.networkLayer) - 1].push(server);
         }
     }
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -2,10 +2,10 @@ import {BitNodeMultipliers}                         from "./BitNodeMultipliers";
 import {CONSTANTS}                                  from "./Constants";
 import {Programs}                                   from "./CreateProgram";
 import {Player}                                     from "./Player";
-import {RunningScript, Script}                      from "./Script";
-import {SpecialServerNames, SpecialServerIps}       from "./SpecialServerIps";
+import {SpecialServerIps}                           from "./SpecialServerIps";
 import {getRandomInt}                               from "../utils/helpers/getRandomInt";
 import {createRandomIp, ipExists}                   from "../utils/IPAddress";
+import {serverMetadata}                             from "./data/servers";
 import {Reviver, Generic_toJSON,
         Generic_fromJSON}                           from "../utils/JSONReviver";
 import {isValidIPAddress}                           from "../utils/helpers/isValidIPAddress";
@@ -125,652 +125,80 @@ Server.fromJSON = function(value) {
 Reviver.constructors.Server = Server;
 
 function initForeignServers() {
-    //MegaCorporations
-    var ECorpServer = new Server({
-        ip:createRandomIp(), hostname:"ecorp", organizationName:"ECorp",
-        requiredHackingSkill:getRandomInt(1150, 1300), moneyAvailable:getRandomInt(30e9, 70e9),
-        hackDifficulty:99,serverGrowth:99, numOpenPortsRequired: 5,
-    });
-    AddToAllServers(ECorpServer);
-
-    var MegaCorpServer = new Server({
-        ip:createRandomIp(), hostname:"megacorp", organizationName:"MegaCorp",
-        requiredHackingSkill:getRandomInt(1150, 1300), moneyAvailable:getRandomInt(40e9, 60e9),
-        hackDifficulty:99, serverGrowth:99, numOpenPortsRequired:5
-    });
-    AddToAllServers(MegaCorpServer);
-
-    var BachmanAndAssociatesServer = new Server({
-        ip:createRandomIp(), hostname:"b-and-a", organizationName:"Bachman & Associates",
-        requiredHackingSkill:getRandomInt(1000, 1050), moneyAvailable:getRandomInt(20e9, 25e9),
-        hackDifficulty:getRandomInt(75, 85), serverGrowth:getRandomInt(65, 75), numOpenPortsRequired:5
-    });
-    AddToAllServers(BachmanAndAssociatesServer);
-
-    var BladeIndustriesServer = new Server({
-        ip:createRandomIp(), hostname:"blade", organizationName:"Blade Industries", maxRam:128,
-        requiredHackingSkill:getRandomInt(1000, 1100), moneyAvailable:getRandomInt(12e9, 20e9),
-        hackDifficulty:getRandomInt(90, 95), serverGrowth:getRandomInt(60, 75), numOpenPortsRequired:5
-    });
-    BladeIndustriesServer.messages.push("beyond-man.lit");
-    AddToAllServers(BladeIndustriesServer);
-
-    var NWOServer = new Server({
-        ip:createRandomIp(), hostname:"nwo", organizationName:"New World Order",
-        requiredHackingSkill:getRandomInt(1000, 1200), moneyAvailable:getRandomInt(25e9, 35e9),
-        hackDifficulty:99, serverGrowth:getRandomInt(75, 85), numOpenPortsRequired:5
-    });
-    NWOServer.messages.push("the-hidden-world.lit");
-    AddToAllServers(NWOServer);
-
-    var ClarkeIncorporatedServer = new Server({
-        ip:createRandomIp(), hostname:"clarkeinc", organizationName:"Clarke Incorporated",
-        requiredHackingSkill:getRandomInt(1000, 1200), moneyAvailable:getRandomInt(15e9, 25e9),
-        hackDifficulty:getRandomInt(50, 60), serverGrowth:getRandomInt(50, 70), numOpenPortsRequired:5
-    });
-    ClarkeIncorporatedServer.messages.push("beyond-man.lit");
-    ClarkeIncorporatedServer.messages.push("cost-of-immortality.lit");
-    AddToAllServers(ClarkeIncorporatedServer);
-
-    var OmniTekIncorporatedServer = new Server({
-        ip:createRandomIp(), hostname:"omnitek", organizationName:"OmniTek Incorporated", maxRam:256,
-        requiredHackingSkill:getRandomInt(900, 1100), moneyAvailable:getRandomInt(15e9, 20e9),
-        hackDifficulty:getRandomInt(90, 99), serverGrowth:getRandomInt(95, 99), numOpenPortsRequired:5
-    });
-    OmniTekIncorporatedServer.messages.push("coded-intelligence.lit");
-    OmniTekIncorporatedServer.messages.push("history-of-synthoids.lit");
-    AddToAllServers(OmniTekIncorporatedServer);
-
-    var FourSigmaServer = new Server({
-        ip:createRandomIp(), hostname:"4sigma", organizationName:"FourSigma",
-        requiredHackingSkill:getRandomInt(950, 1200), moneyAvailable:getRandomInt(15e9, 25e9),
-        hackDifficulty:getRandomInt(60, 70), serverGrowth:getRandomInt(75, 99), numOpenPortsRequired:5
-    });
-    AddToAllServers(FourSigmaServer);
-
-    var KuaiGongInternationalServer = new Server({
-        ip:createRandomIp(), hostname:"kuai-gong", organizationName:"KuaiGong International",
-        requiredHackingSkill:getRandomInt(1000, 1250), moneyAvailable:getRandomInt(20e9, 30e9),
-        hackDifficulty:getRandomInt(95, 99), serverGrowth:getRandomInt(90, 99), numOpenPortsRequired:5,
-    });
-    AddToAllServers(KuaiGongInternationalServer);
-
-    //Technology and communications companies (large targets)
-    var FulcrumTechnologiesServer = new Server({
-        ip:createRandomIp(), hostname:"fulcrumtech", organizationName:"Fulcrum Technologies", maxRam:512,
-        requiredHackingSkill:getRandomInt(1000, 1200), moneyAvailable:getRandomInt(1.4e9, 1.8e9),
-        hackDifficulty:getRandomInt(85, 95), serverGrowth:getRandomInt(80, 99), numOpenPortsRequired:5
-    });
-    FulcrumTechnologiesServer.messages.push("simulated-reality.lit");
-    AddToAllServers(FulcrumTechnologiesServer);
-
-    var FulcrumSecretTechnologiesServer = new Server({
-        ip:createRandomIp(), hostname:"fulcrumassets", organizationName:"Fulcrum Technologies Assets",
-        requiredHackingSkill:getRandomInt(1200, 1500), moneyAvailable:1e6,
-        hackDifficulty:99, serverGrowth:1, numOpenPortsRequired:5
-    });
-    AddToAllServers(FulcrumSecretTechnologiesServer);
-    SpecialServerIps.addIp(SpecialServerNames.FulcrumSecretTechnologies, FulcrumSecretTechnologiesServer.ip);
-
-    var StormTechnologiesServer = new Server({
-        ip:createRandomIp(), hostname:"stormtech", organizationName:"Storm Technologies",
-        requiredHackingSkill:getRandomInt(900, 1050), moneyAvailable:getRandomInt(1e9, 1.2e9),
-        hackDifficulty:getRandomInt(80, 90), serverGrowth:getRandomInt(70, 90), numOpenPortsRequired:5
-    });
-    AddToAllServers(StormTechnologiesServer);
-
-    var DefCommServer = new Server({
-        ip:createRandomIp(), hostname:"defcomm", organizationName:"DefComm",
-        requiredHackingSkill:getRandomInt(900, 1000), moneyAvailable:getRandomInt(800e6, 950e6),
-        hackDifficulty:getRandomInt(85, 95), serverGrowth:getRandomInt(50, 70), numOpenPortsRequired:5
-    });
-    AddToAllServers(DefCommServer);
-
-    var InfoCommServer = new Server({
-        ip:createRandomIp(), hostname:"infocomm", organizationName:"InfoComm",
-        requiredHackingSkill:getRandomInt(875, 950), moneyAvailable:getRandomInt(600e6, 900e6),
-        hackDifficulty:getRandomInt(70, 90), serverGrowth:getRandomInt(35, 75), numOpenPortsRequired:5
-    });
-    AddToAllServers(InfoCommServer);
-
-    var HeliosLabsServer = new Server({
-        ip:createRandomIp(), hostname:"helios", organizationName:"Helios Labs", maxRam:128,
-        requiredHackingSkill:getRandomInt(800, 900), moneyAvailable:getRandomInt(550e6, 750e6),
-        hackDifficulty:getRandomInt(85, 95), serverGrowth:getRandomInt(70, 80), numOpenPortsRequired:5
-    });
-    HeliosLabsServer.messages.push("beyond-man.lit");
-    AddToAllServers(HeliosLabsServer);
-
-    var VitaLifeServer = new Server({
-        ip:createRandomIp(), hostname:"vitalife", organizationName:"VitaLife", maxRam:64,
-        requiredHackingSkill:getRandomInt(775, 900), moneyAvailable:getRandomInt(700e6, 800e6),
-        hackDifficulty:getRandomInt(80, 90), serverGrowth:getRandomInt(60, 80), numOpenPortsRequired:5
-    });
-    VitaLifeServer.messages.push("A-Green-Tomorrow.lit");
-    AddToAllServers(VitaLifeServer);
-
-    var IcarusMicrosystemsServer = new Server({
-        ip:createRandomIp(), hostname:"icarus", organizationName:"Icarus Microsystems",
-        requiredHackingSkill:getRandomInt(850, 925), moneyAvailable:getRandomInt(900e6, 1000e6),
-        hackDifficulty:getRandomInt(85, 95), serverGrowth:getRandomInt(85, 95), numOpenPortsRequired:5
-    });
-    AddToAllServers(IcarusMicrosystemsServer);
-
-    var UniversalEnergyServer = new Server({
-        ip:createRandomIp(), hostname:"univ-energy", organizationName:"Universal Energy", maxRam:64,
-        requiredHackingSkill:getRandomInt(800, 900), moneyAvailable:getRandomInt(1.1e9, 1.2e9),
-        hackDifficulty:getRandomInt(80, 90), serverGrowth:getRandomInt(80, 90), numOpenPortsRequired:4
-    });
-    AddToAllServers(UniversalEnergyServer);
-
-    var TitanLabsServer = new Server({
-        ip:createRandomIp(), hostname:"titan-labs", organizationName:"Titan Laboratories", maxRam:64,
-        requiredHackingSkill:getRandomInt(800, 875), moneyAvailable:getRandomInt(750e6, 900e6),
-        hackDifficulty:getRandomInt(70, 80), serverGrowth:getRandomInt(60, 80), numOpenPortsRequired:5
-    });
-    TitanLabsServer.messages.push("coded-intelligence.lit");
-    AddToAllServers(TitanLabsServer);
-
-    var MicrodyneTechnologiesServer = new Server({
-        ip:createRandomIp(), hostname:"microdyne", organizationName:"Microdyne Technologies", maxRam:32,
-        requiredHackingSkill:getRandomInt(800, 875), moneyAvailable:getRandomInt(500e6, 700e6),
-        hackDifficulty:getRandomInt(65, 75), serverGrowth:getRandomInt(70, 90), numOpenPortsRequired:5
-    });
-    MicrodyneTechnologiesServer.messages.push("synthetic-muscles.lit");
-    AddToAllServers(MicrodyneTechnologiesServer);
-
-    var TaiYangDigitalServer = new Server({
-        ip:createRandomIp(), hostname:"taiyang-digital", organizationName:"Taiyang Digital",
-        requiredHackingSkill:getRandomInt(850, 950), moneyAvailable:getRandomInt(800e6, 900e6),
-        hackDifficulty:getRandomInt(70, 80), serverGrowth:getRandomInt(70, 80), numOpenPortsRequired:5
-    });
-    TaiYangDigitalServer.messages.push("A-Green-Tomorrow.lit");
-    TaiYangDigitalServer.messages.push("brighter-than-the-sun.lit");
-    AddToAllServers(TaiYangDigitalServer);
-
-    var GalacticCyberSystemsServer = new Server({
-        ip:createRandomIp(), hostname:"galactic-cyber", organizationName:"Galactic Cybersystems",
-        requiredHackingSkill:getRandomInt(825, 875), moneyAvailable:getRandomInt(750e6, 850e6),
-        hackDifficulty:getRandomInt(55, 65), serverGrowth:getRandomInt(70, 90), numOpenPortsRequired:5
-    });
-    AddToAllServers(GalacticCyberSystemsServer);
-
-    //Defense Companies ("Large" Companies)
-    var AeroCorpServer = new Server({
-        ip:createRandomIp(), hostname:"aerocorp", organizationName:"AeroCorp",
-        requiredHackingSkill:getRandomInt(850, 925), moneyAvailable:getRandomInt(1e9, 1.2e9),
-        hackDifficulty:getRandomInt(80, 90), serverGrowth:getRandomInt(55, 65), numOpenPortsRequired:5
-    });
-    AeroCorpServer.messages.push("man-and-machine.lit");
-    AddToAllServers(AeroCorpServer);
-
-    var OmniaCybersystemsServer = new Server({
-        ip:createRandomIp(), hostname:"omnia", organizationName:"Omnia Cybersystems", maxRam:64,
-        requiredHackingSkill:getRandomInt(850, 950), moneyAvailable:getRandomInt(900e6, 1e9),
-        hackDifficulty:getRandomInt(85, 95), serverGrowth:getRandomInt(60, 70), numOpenPortsRequired:5
-    });
-    OmniaCybersystemsServer.messages.push("history-of-synthoids.lit");
-    AddToAllServers(OmniaCybersystemsServer);
-
-    var ZBDefenseServer = new Server({
-        ip:createRandomIp(), hostname:"zb-def", organizationName:"ZB Defense Industries",
-        requiredHackingSkill:getRandomInt(775, 825), moneyAvailable:getRandomInt(900e6, 1.1e9),
-        hackDifficulty:getRandomInt(55, 65), serverGrowth:getRandomInt(65, 75), numOpenPortsRequired:4
-    });
-    ZBDefenseServer.messages.push("synthetic-muscles.lit");
-    AddToAllServers(ZBDefenseServer);
-
-    var AppliedEnergeticsServer = new Server({
-        ip:createRandomIp(), hostname:"applied-energetics", organizationName:"Applied Energetics",
-        requiredHackingSkill:getRandomInt(775, 850), moneyAvailable:getRandomInt(700e6, 1e9),
-        hackDifficulty:getRandomInt(60, 80), serverGrowth:getRandomInt(70, 75), numOpenPortsRequired:4
-    });
-    AddToAllServers(AppliedEnergeticsServer);
-
-    var SolarisSpaceSystemsServer = new Server({
-        ip:createRandomIp(), hostname:"solaris", organizationName:"Solaris Space Systems", maxRam:64,
-        requiredHackingSkill:getRandomInt(750, 850), moneyAvailable:getRandomInt(700e6, 900e6),
-        hackDifficulty:getRandomInt(70, 80), serverGrowth:getRandomInt(70, 80), numOpenPortsRequired:5
-    });
-    SolarisSpaceSystemsServer.messages.push("A-Green-Tomorrow.lit");
-    SolarisSpaceSystemsServer.messages.push("the-failed-frontier.lit");
-    AddToAllServers(SolarisSpaceSystemsServer);
-
-    var DeltaOneServer = new Server({
-        ip:createRandomIp(), hostname:"deltaone", organizationName:"Delta One",
-        requiredHackingSkill:getRandomInt(800, 900), moneyAvailable:getRandomInt(1.3e9, 1.7e9),
-        hackDifficulty:getRandomInt(75, 85), serverGrowth:getRandomInt(50, 70), numOpenPortsRequired:5
-    });
-    AddToAllServers(DeltaOneServer);
-
-    //Health, medicine, pharmaceutical companies ("Large" targets)
-    var GlobalPharmaceuticalsServer = new Server({
-        ip:createRandomIp(), hostname:"global-pharm", organizationName:"Global Pharmaceuticals", maxRam:32,
-        requiredHackingSkill:getRandomInt(750, 850), moneyAvailable:getRandomInt(1.5e9, 1.75e9),
-        hackDifficulty:getRandomInt(75, 85), serverGrowth:getRandomInt(80, 90), numOpenPortsRequired:4
-    });
-    GlobalPharmaceuticalsServer.messages.push("A-Green-Tomorrow.lit");
-    AddToAllServers(GlobalPharmaceuticalsServer);
-
-    var NovaMedicalServer = new Server({
-        ip:createRandomIp(), hostname:"nova-med", organizationName:"Nova Medical",
-        requiredHackingSkill:getRandomInt(775, 850), moneyAvailable:getRandomInt(1.1e9, 1.25e9),
-        hackDifficulty:getRandomInt(60, 80), serverGrowth:getRandomInt(65, 85), numOpenPortsRequired:4
-    });
-    AddToAllServers(NovaMedicalServer);
-
-    var ZeusMedicalServer = new Server({
-        ip:createRandomIp(), hostname:"zeus-med", organizationName:"Zeus Medical",
-        requiredHackingSkill:getRandomInt(800, 850), moneyAvailable:getRandomInt(1.3e9, 1.5e9),
-        hackDifficulty:getRandomInt(70, 90), serverGrowth:getRandomInt(70, 80), numOpenPortsRequired:5
-    });
-    AddToAllServers(ZeusMedicalServer);
-
-    var UnitaLifeGroupServer = new Server({
-        ip:createRandomIp(), hostname:"unitalife", organizationName:"UnitaLife Group", maxRam:32,
-        requiredHackingSkill:getRandomInt(775, 825), moneyAvailable:getRandomInt(1e9, 1.1e9),
-        hackDifficulty:getRandomInt(70, 80), serverGrowth:getRandomInt(70, 80), numOpenPortsRequired:4
-    });
-    AddToAllServers(UnitaLifeGroupServer);
-
-    //"Medium level" targets
-    var LexoCorpServer = new Server({
-        ip:createRandomIp(), hostname:"lexo-corp", organizationName:"Lexo Corporation", maxRam:32,
-        requiredHackingSkill:getRandomInt(650, 750), moneyAvailable:getRandomInt(700e6, 800e6),
-        hackDifficulty:getRandomInt(60, 80), serverGrowth:getRandomInt(55, 65), numOpenPortsRequired:4
-    });
-    AddToAllServers(LexoCorpServer);
-
-    var RhoConstructionServer = new Server({
-        ip:createRandomIp(), hostname:"rho-construction", organizationName:"Rho Construction",
-        requiredHackingSkill:getRandomInt(475, 525), moneyAvailable:getRandomInt(500e6, 700e6),
-        hackDifficulty:getRandomInt(40, 60), serverGrowth:getRandomInt(40, 60), numOpenPortsRequired:3
-    });
-    AddToAllServers(RhoConstructionServer);
-
-    var AlphaEnterprisesServer = new Server({
-        ip:createRandomIp(), hostname:"alpha-ent", organizationName:"Alpha Enterprises", maxRam:32,
-        requiredHackingSkill:getRandomInt(500, 600), moneyAvailable:getRandomInt(600e6, 750e6),
-        hackDifficulty:getRandomInt(50, 70), serverGrowth:getRandomInt(50, 60),numOpenPortsRequired:4
-    });
-    AlphaEnterprisesServer.messages.push("sector-12-crime.lit");
-    AddToAllServers(AlphaEnterprisesServer);
-
-    var AevumPoliceServer = new Server({
-        ip:createRandomIp(), hostname:"aevum-police", organizationName:"Aevum Police Network", maxRam:32,
-        requiredHackingSkill:getRandomInt(400, 450), moneyAvailable:getRandomInt(200e6, 400e6),
-        hackDifficulty:getRandomInt(70, 80), serverGrowth:getRandomInt(30, 50), numOpenPortsRequired:4
-    });
-    AddToAllServers(AevumPoliceServer);
-
-    var RothmanUniversityServer = new Server({
-        ip:createRandomIp(), hostname:"rothman-uni", organizationName:"Rothman University Network", maxRam:64,
-        requiredHackingSkill:getRandomInt(370, 430), moneyAvailable:getRandomInt(175e6, 250e6),
-        hackDifficulty:getRandomInt(45, 55), serverGrowth:getRandomInt(35, 45), numOpenPortsRequired:3
-    });
-    RothmanUniversityServer.messages.push("secret-societies.lit");
-    RothmanUniversityServer.messages.push("the-failed-frontier.lit");
-    RothmanUniversityServer.messages.push("tensions-in-tech-race.lit");
-    AddToAllServers(RothmanUniversityServer);
-
-    var ZBInstituteOfTechnologyServer = new Server({
-        ip:createRandomIp(), hostname:"zb-institute", organizationName:"ZB Institute of Technology Network", maxRam:64,
-        requiredHackingSkill:getRandomInt(725, 775), moneyAvailable:getRandomInt(800e6, 1.1e9),
-        hackDifficulty:getRandomInt(65, 85), serverGrowth:getRandomInt(75, 85), numOpenPortsRequired:5
-    });
-    AddToAllServers(ZBInstituteOfTechnologyServer);
-
-    var SummitUniversityServer = new Server({
-        ip:createRandomIp(), hostname:"summit-uni", organizationName:"Summit University Network", maxRam:32,
-        requiredHackingSkill:getRandomInt(425, 475), moneyAvailable:getRandomInt(200e6, 350e6),
-        hackDifficulty:getRandomInt(45, 65), serverGrowth:getRandomInt(40, 60), numOpenPortsRequired:3
-    });
-    SummitUniversityServer.messages.push("secret-societies.lit");
-    SummitUniversityServer.messages.push("the-failed-frontier.lit");
-    SummitUniversityServer.messages.push("synthetic-muscles.lit");
-    AddToAllServers(SummitUniversityServer);
-
-    var SysCoreSecuritiesServer = new Server({
-        ip:createRandomIp(), hostname:"syscore", organizationName:"SysCore Securities",
-        requiredHackingSkill:getRandomInt(550, 650), moneyAvailable:getRandomInt(400e6, 600e6),
-        hackDifficulty:getRandomInt(60, 80), serverGrowth:getRandomInt(60, 70), numOpenPortsRequired:4
-    });
-    AddToAllServers(SysCoreSecuritiesServer);
-
-    var CatalystVenturesServer = new Server({
-        ip:createRandomIp(), hostname:"catalyst", organizationName:"Catalyst Ventures",
-        requiredHackingSkill:getRandomInt(400, 450), moneyAvailable:getRandomInt(300e6, 550e6),
-        hackDifficulty:getRandomInt(60, 70), serverGrowth:getRandomInt(25, 55), numOpenPortsRequired:3,
-    });
-    CatalystVenturesServer.messages.push("tensions-in-tech-race.lit");
-    AddToAllServers(CatalystVenturesServer);
-
-    var TheHubServer = new Server({
-        ip:createRandomIp(), hostname:"the-hub", organizationName:"The Hub",
-        requiredHackingSkill:getRandomInt(275, 325), moneyAvailable:getRandomInt(150e6, 200e6),
-        hackDifficulty:getRandomInt(35, 45), serverGrowth:getRandomInt(45, 55), numOpenPortsRequired:2
-    });
-    AddToAllServers(TheHubServer);
-
-    var CompuTekServer = new Server({
-        ip:createRandomIp(), hostname:"comptek", organizationName:"CompuTek",
-        requiredHackingSkill:getRandomInt(300, 400), moneyAvailable:getRandomInt(220e6, 250e6),
-        hackDifficulty:getRandomInt(55, 65), serverGrowth:getRandomInt(45, 65), numOpenPortsRequired:3
-    });
-    CompuTekServer.messages.push("man-and-machine.lit");
-    AddToAllServers(CompuTekServer);
-
-    var NetLinkTechnologiesServer = new Server({
-        ip:createRandomIp(), hostname:"netlink", organizationName:"NetLink Technologies", maxRam:64,
-        requiredHackingSkill:getRandomInt(375, 425), moneyAvailable:275e6,
-        hackDifficulty:getRandomInt(60, 80), serverGrowth:getRandomInt(45, 75), numOpenPortsRequired:3
-    });
-    NetLinkTechnologiesServer.messages.push("simulated-reality.lit");
-    AddToAllServers(NetLinkTechnologiesServer);
-
-    var JohnsonOrthopedicsServer = new Server({
-        ip:createRandomIp(), hostname:"johnson-ortho", organizationName:"Johnson Orthopedics",
-        requiredHackingSkill:getRandomInt(250, 300), moneyAvailable:getRandomInt(70e6, 85e6),
-        hackDifficulty:getRandomInt(35, 65), serverGrowth:getRandomInt(35, 65), numOpenPortsRequired:2
-    });
-    AddToAllServers(JohnsonOrthopedicsServer);
-
-    //"Low level" targets
-    var FoodNStuffServer = new Server({
-        ip:createRandomIp(), hostname:"foodnstuff", organizationName:"Food N Stuff Supermarket", maxRam:16,
-        requiredHackingSkill:1, moneyAvailable:2e6,
-        hackDifficulty:10, serverGrowth:5, numOpenPortsRequired:0
-    });
-    FoodNStuffServer.messages.push("sector-12-crime.lit");
-    AddToAllServers(FoodNStuffServer);
-
-    var SigmaCosmeticsServer = new Server({
-        ip:createRandomIp(), hostname:"sigma-cosmetics", organizationName:"Sigma Cosmetics", maxRam:16,
-        requiredHackingSkill:5, moneyAvailable:2.3e6,
-        hackDifficulty:10, serverGrowth:10, numOpenPortsRequired:0
-    });
-    AddToAllServers(SigmaCosmeticsServer);
-
-    var JoesGunsServer = new Server({
-        ip:createRandomIp(), hostname:"joesguns", organizationName:"Joe's Guns", maxRam:16,
-        requiredHackingSkill:10, moneyAvailable:2.5e6,
-        hackDifficulty:15, serverGrowth:20, numOpenPortsRequired:0
-    });
-    AddToAllServers(JoesGunsServer);
-
-    var Zer0NightclubServer = new Server({
-        ip:createRandomIp(), hostname:"zer0", organizationName:"ZER0 Nightclub", maxRam:32,
-        requiredHackingSkill:75, moneyAvailable:7.5e6,
-        hackDifficulty:25, serverGrowth:40, numOpenPortsRequired:1
-    });
-    AddToAllServers(Zer0NightclubServer);
-
-    var NectarNightclubServer = new Server({
-        ip:createRandomIp(), hostname:"nectar-net", organizationName:"Nectar Nightclub Network", maxRam:16,
-        requiredHackingSkill:20, moneyAvailable:2.75e6,
-        hackDifficulty:20, serverGrowth:25, numOpenPortsRequired:0
-    });
-    AddToAllServers(NectarNightclubServer);
-
-    var NeoNightclubServer = new Server({
-        ip:createRandomIp(), hostname:"neo-net", organizationName:"Neo Nightclub Network", maxRam:32,
-        requiredHackingSkill:50, moneyAvailable:5e6,
-        hackDifficulty:25, serverGrowth:25, numOpenPortsRequired:1
-    });
-    NeoNightclubServer.messages.push("the-hidden-world.lit");
-    AddToAllServers(NeoNightclubServer);
-
-    var SilverHelixServer = new Server({
-        ip:createRandomIp(), hostname:"silver-helix", organizationName:"Silver Helix", maxRam:64,
-        requiredHackingSkill:150, moneyAvailable:45e6,
-        hackDifficulty:30, serverGrowth:30, numOpenPortsRequired:2
-    });
-    SilverHelixServer.messages.push("new-triads.lit");
-    AddToAllServers(SilverHelixServer);
-
-    var HongFangTeaHouseServer = new Server({
-        ip:createRandomIp(), hostname:"hong-fang-tea", organizationName:"HongFang Teahouse", maxRam:16,
-        requiredHackingSkill:30, moneyAvailable:3e6,
-        hackDifficulty:15, serverGrowth:20, numOpenPortsRequired:0
-    });
-    HongFangTeaHouseServer.messages.push("brighter-than-the-sun.lit");
-    AddToAllServers(HongFangTeaHouseServer);
-
-    var HaraKiriSushiBarServer = new Server({
-        ip:createRandomIp(), hostname:"harakiri-sushi", organizationName:"HaraKiri Sushi Bar Network",maxRam:16,
-        requiredHackingSkill:40, moneyAvailable:4e6,
-        hackDifficulty:15, serverGrowth:40, numOpenPortsRequired:0
-    });
-    AddToAllServers(HaraKiriSushiBarServer);
-
-    var PhantasyServer = new Server({
-        ip:createRandomIp(), hostname:"phantasy", organizationName:"Phantasy Club", maxRam:32,
-        requiredHackingSkill:100, moneyAvailable:24e6,
-        hackDifficulty:20, serverGrowth:35, numOpenPortsRequired:2
-    });
-    AddToAllServers(PhantasyServer);
-
-    var MaxHardwareServer = new Server({
-        ip:createRandomIp(), hostname:"max-hardware", organizationName:"Max Hardware Store", maxRam:32,
-        requiredHackingSkill:80, moneyAvailable:10e6,
-        hackDifficulty:15, serverGrowth:30, numOpenPortsRequired:1,
-    });
-    AddToAllServers(MaxHardwareServer);
-
-    var OmegaSoftwareServer = new Server({
-        ip:createRandomIp(), hostname:"omega-net", organizationName:"Omega Software", maxRam:32,
-        requiredHackingSkill:getRandomInt(180, 220), moneyAvailable:getRandomInt(60e6, 70e6),
-        hackDifficulty:getRandomInt(25, 35), serverGrowth:getRandomInt(30, 40), numOpenPortsRequired:2
-    });
-    OmegaSoftwareServer.messages.push("the-new-god.lit");
-    AddToAllServers(OmegaSoftwareServer);
-
-    //Gyms
-    var CrushFitnessGymServer = new Server({
-        ip:createRandomIp(), hostname:"crush-fitness", organizationName:"Crush Fitness",
-        requiredHackingSkill:getRandomInt(225, 275), moneyAvailable:getRandomInt(40e6, 60e6),
-        hackDifficulty:getRandomInt(35, 45), serverGrowth:getRandomInt(27, 33), numOpenPortsRequired:2
-    });
-    AddToAllServers(CrushFitnessGymServer);
-
-    var IronGymServer = new Server({
-        ip:createRandomIp(), hostname:"iron-gym", organizationName:"Iron Gym Network", maxRam:32,
-        requiredHackingSkill:100, moneyAvailable:20e6,
-        hackDifficulty:30, serverGrowth:20, numOpenPortsRequired:1
-    });
-    AddToAllServers(IronGymServer);
-
-    var MilleniumFitnessGymServer = new Server({
-        ip:createRandomIp(), hostname:"millenium-fitness", organizationName:"Millenium Fitness Network",
-        requiredHackingSkill:getRandomInt(475, 525), moneyAvailable:250e6,
-        hackDifficulty:getRandomInt(45, 55), serverGrowth:getRandomInt(25, 45), numOpenPortsRequired:3,
-    });
-    AddToAllServers(MilleniumFitnessGymServer);
-
-    var PowerhouseGymServer = new Server({
-        ip:createRandomIp(), hostname:"powerhouse-fitness", organizationName:"Powerhouse Fitness",
-        requiredHackingSkill:getRandomInt(950, 1100), moneyAvailable:900e6,
-        hackDifficulty:getRandomInt(55, 65), serverGrowth:getRandomInt(50, 60), numOpenPortsRequired:5,
-    });
-    AddToAllServers(PowerhouseGymServer);
-
-    var SnapFitnessGymServer = new Server({
-        ip:createRandomIp(), hostname:"snap-fitness", organizationName:"Snap Fitness",
-        requiredHackingSkill:getRandomInt(675, 800), moneyAvailable:450e6,
-        hackDifficulty:getRandomInt(40, 60), serverGrowth:getRandomInt(40, 60), numOpenPortsRequired:4
-    });
-    AddToAllServers(SnapFitnessGymServer);
-
-    //Faction servers, cannot hack money from these
-    var BitRunnersServer = new Server({
-        ip:createRandomIp(), hostname:"run4theh111z", organizationName:"The Runners", maxRam:128,
-        requiredHackingSkill:getRandomInt(505, 550), moneyAvailable:0,
-        hackDifficulty:0, serverGrowth:0, numOpenPortsRequired:4
-    });
-    BitRunnersServer.messages.push("simulated-reality.lit");
-    BitRunnersServer.messages.push("the-new-god.lit");
-    AddToAllServers(BitRunnersServer);
-    SpecialServerIps.addIp(SpecialServerNames.BitRunnersServer, BitRunnersServer.ip);
-
-    var TheBlackHandServer = new Server({
-        ip:createRandomIp(), hostname:"I.I.I.I", organizationName:"I.I.I.I", maxRam:64,
-        requiredHackingSkill:getRandomInt(340, 365), moneyAvailable:0,
-        hackDifficulty:0, serverGrowth:0, numOpenPortsRequired:3,
-    });
-    TheBlackHandServer.messages.push("democracy-is-dead.lit");
-    AddToAllServers(TheBlackHandServer);
-    SpecialServerIps.addIp(SpecialServerNames.TheBlackHandServer, TheBlackHandServer.ip);
-
-    var NiteSecServer = new Server({
-        ip:createRandomIp(), hostname:"avmnite-02h", organizationName:"NiteSec", maxRam:32,
-        requiredHackingSkill:getRandomInt(202, 220), moneyAvailable:0,
-        hackDifficulty:0, serverGrowth:0, numOpenPortsRequired:2
-    });
-    NiteSecServer.messages.push("democracy-is-dead.lit");
-    AddToAllServers(NiteSecServer);
-    SpecialServerIps.addIp(SpecialServerNames.NiteSecServer, NiteSecServer.ip);
-
-    var DarkArmyServer = new Server({
-        ip:createRandomIp(), hostname:".", organizationName:".", maxRam:16,
-        requiredHackingSkill:getRandomInt(505, 550), moneyAvailable:0,
-        hackDifficulty:0, serverGrowth:0, numOpenPortsRequired:4
-    });
-    AddToAllServers(DarkArmyServer);
-    SpecialServerIps.addIp(SpecialServerNames.TheDarkArmyServer, DarkArmyServer.ip);
-
-    var CyberSecServer = new Server({
-        ip:createRandomIp(), hostname:"CSEC", organizationName:"CyberSec", maxRam:8,
-        requiredHackingSkill:getRandomInt(51, 60), moneyAvailable:0,
-        hackDifficulty:0, serverGrowth:0, numOpenPortsRequired:1
-    });
-    CyberSecServer.messages.push("democracy-is-dead.lit");
-    AddToAllServers(CyberSecServer);
-    SpecialServerIps.addIp(SpecialServerNames.CyberSecServer, CyberSecServer.ip);
-
-    var DaedalusServer = new Server({
-        ip:createRandomIp(), hostname:"The-Cave", organizationName:"Helios",
-        requiredHackingSkill:925, moneyAvailable:0,
-        hackDifficulty:0, serverGrowth:0, numOpenPortsRequired:5
-    });
-    DaedalusServer.messages.push("alpha-omega.lit");
-    AddToAllServers(DaedalusServer);
-    SpecialServerIps.addIp(SpecialServerNames.DaedalusServer, DaedalusServer.ip);
-
-    //Super special Servers
-    var WorldDaemon = new Server({
-        ip:createRandomIp(), hostname:SpecialServerNames.WorldDaemon, organizationName:SpecialServerNames.WorldDaemon,
-        requiredHackingSkill:3000, moneyAvailable:0,
-        hackDifficulty:0, serverGrowth:0, numOpenPortsRequired:5
-    });
-    AddToAllServers(WorldDaemon);
-    SpecialServerIps.addIp(SpecialServerNames.WorldDaemon, WorldDaemon.ip);
-
     /* Create a randomized network for all the foreign servers */
     //Groupings for creating a randomized network
-    var NetworkGroup1 =     [IronGymServer, FoodNStuffServer, SigmaCosmeticsServer, JoesGunsServer, HongFangTeaHouseServer, HaraKiriSushiBarServer];
-    var NetworkGroup2 =     [MaxHardwareServer, NectarNightclubServer, Zer0NightclubServer, CyberSecServer];
-    var NetworkGroup3 =     [OmegaSoftwareServer, PhantasyServer, SilverHelixServer, NeoNightclubServer];
-    var NetworkGroup4 =     [CrushFitnessGymServer, NetLinkTechnologiesServer, CompuTekServer, TheHubServer, JohnsonOrthopedicsServer, NiteSecServer];
-    var NetworkGroup5 =     [CatalystVenturesServer, SysCoreSecuritiesServer, SummitUniversityServer, ZBInstituteOfTechnologyServer, RothmanUniversityServer, TheBlackHandServer];
-    var NetworkGroup6 =     [LexoCorpServer, RhoConstructionServer, AlphaEnterprisesServer, AevumPoliceServer, MilleniumFitnessGymServer];
-    var NetworkGroup7 =     [GlobalPharmaceuticalsServer, AeroCorpServer, GalacticCyberSystemsServer, SnapFitnessGymServer];
-    var NetworkGroup8 =     [DeltaOneServer, UnitaLifeGroupServer, OmniaCybersystemsServer];
-    var NetworkGroup9 =     [ZeusMedicalServer, SolarisSpaceSystemsServer, UniversalEnergyServer, IcarusMicrosystemsServer, DefCommServer];
-    var NetworkGroup10 =    [NovaMedicalServer, ZBDefenseServer, TaiYangDigitalServer, InfoCommServer];
-    var NetworkGroup11 =    [AppliedEnergeticsServer, MicrodyneTechnologiesServer, TitanLabsServer, BitRunnersServer];
-    var NetworkGroup12 =    [VitaLifeServer, HeliosLabsServer, StormTechnologiesServer, FulcrumTechnologiesServer];
-    var NetworkGroup13 =    [KuaiGongInternationalServer, FourSigmaServer, OmniTekIncorporatedServer, DarkArmyServer];
-    var NetworkGroup14 =    [PowerhouseGymServer, ClarkeIncorporatedServer, NWOServer, BladeIndustriesServer, BachmanAndAssociatesServer];
-    var NetworkGroup15 =    [FulcrumSecretTechnologiesServer, MegaCorpServer, ECorpServer, DaedalusServer];
-
-    for (var i = 0; i < NetworkGroup2.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup1[Math.floor(Math.random() * NetworkGroup1.length)];
-        NetworkGroup2[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup2[i].ip);
+    const networkLayers = [];
+    for (let i = 0; i < 15; i++) {
+        networkLayers.push([]);
     }
 
-    for (var i = 0; i < NetworkGroup3.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup2[Math.floor(Math.random() * NetworkGroup2.length)];
-        NetworkGroup3[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup3[i].ip);
+    // Essentially any property that is of type 'number | IMinMaxRange'
+    const propertiesToPatternMatch = [
+        "hackDifficulty",
+        "moneyAvailable",
+        "requiredHackingSkill",
+        "serverGrowth"
+    ];
+
+    const toNumber = (value) => {
+        switch (typeof value) {
+            case 'number':
+                return value;
+            case 'object':
+                return getRandomInt(value.min, value.max);
+            default:
+                throw Error(`Do not know how to convert the type '${typeof value}' to a number`);
+        }
     }
 
-    for (var i = 0; i < NetworkGroup4.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup3[Math.floor(Math.random() * NetworkGroup3.length)];
-        NetworkGroup4[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup4[i].ip);
+    for (const metadata of serverMetadata) {
+        const serverParams = {
+            hostname: metadata.hostname,
+            ip: createRandomIp(),
+            maxRam: metadata.maxRam || 0,
+            numOpenPortsRequired: metadata.numOpenPortsRequired,
+            organizationName: metadata.organizationName
+        };
+
+        for (const prop of propertiesToPatternMatch) {
+            if (metadata[prop] !== undefined) {
+                serverParams[prop] = toNumber(metadata[prop]);
+            }
+        }
+
+        const server = new Server(serverParams);
+        for (const filename of (metadata.literature || [])) {
+            server.messages.push(filename);
+        }
+
+        if (metadata.specialName !== undefined) {
+            SpecialServerIps.addIp(metadata.specialName, server.ip);
+        }
+
+        AddToAllServers(server);
+        if (metadata.networkLayer !== undefined) {
+            networkLayers[metadata.networkLayer - 1].push(server);
+        }
     }
 
-    for (var i = 0; i < NetworkGroup5.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup4[Math.floor(Math.random() * NetworkGroup4.length)];
-        NetworkGroup5[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup5[i].ip);
-    }
+    /* Create a randomized network for all the foreign servers */
+    const linkComputers = (server1, server2) => {
+        server1.serversOnNetwork.push(server2.ip);
+        server2.serversOnNetwork.push(server1.ip);
+    };
 
-    for (var i = 0; i < NetworkGroup6.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup5[Math.floor(Math.random() * NetworkGroup5.length)];
-        NetworkGroup6[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup6[i].ip);
-    }
+    const getRandomArrayItem = (arr) => arr[Math.floor(Math.random() * arr.length)];
 
-    for (var i = 0; i < NetworkGroup7.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup6[Math.floor(Math.random() * NetworkGroup6.length)];
-        NetworkGroup7[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup7[i].ip);
-    }
+    const linkNetworkLayers = (network1, selectServer) => {
+        for (const server of network1) {
+            linkComputers(server, selectServer());
+        }
+    };
 
-    for (var i = 0; i < NetworkGroup8.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup7[Math.floor(Math.random() * NetworkGroup7.length)];
-        NetworkGroup8[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup8[i].ip);
-    }
-
-    for (var i = 0; i < NetworkGroup9.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup8[Math.floor(Math.random() * NetworkGroup8.length)];
-        NetworkGroup9[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup9[i].ip);
-    }
-
-    for (var i = 0; i < NetworkGroup10.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup9[Math.floor(Math.random() * NetworkGroup9.length)];
-        NetworkGroup10[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup10[i].ip);
-    }
-
-    for (var i = 0; i < NetworkGroup11.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup10[Math.floor(Math.random() * NetworkGroup10.length)];
-        NetworkGroup11[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup11[i].ip);
-    }
-
-    for (var i = 0; i < NetworkGroup12.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup11[Math.floor(Math.random() * NetworkGroup11.length)];
-        NetworkGroup12[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup12[i].ip);
-    }
-
-    for (var i = 0; i < NetworkGroup13.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup12[Math.floor(Math.random() * NetworkGroup12.length)];
-        NetworkGroup13[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup13[i].ip);
-    }
-
-    for (var i = 0; i < NetworkGroup14.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup13[Math.floor(Math.random() * NetworkGroup13.length)];
-        NetworkGroup14[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup14[i].ip);
-    }
-
-    for (var i = 0; i < NetworkGroup15.length; i++) {
-        var randomServerFromPrevGroup = NetworkGroup14[Math.floor(Math.random() * NetworkGroup14.length)];
-        NetworkGroup15[i].serversOnNetwork.push(randomServerFromPrevGroup.ip);
-        randomServerFromPrevGroup.serversOnNetwork.push(NetworkGroup15[i].ip);
-    }
-
-    //Connect the first tier of servers to the player's home computer
-    for (var i = 0; i < NetworkGroup1.length; i++) {
-        Player.getHomeComputer().serversOnNetwork.push(NetworkGroup1[i].ip);
-        NetworkGroup1[i].serversOnNetwork.push(Player.homeComputer);
+    // Connect the first tier of servers to the player's home computer
+    linkNetworkLayers(networkLayers[0], () => Player.getHomeComputer());
+    for (let i = 1; i < networkLayers.length; i++) {
+        linkNetworkLayers(networkLayers[i], () => getRandomArrayItem(networkLayers[i - 1]));
     }
 }
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -155,10 +155,13 @@ function initForeignServers() {
         const serverParams = {
             hostname: metadata.hostname,
             ip: createRandomIp(),
-            maxRam: metadata.maxRam || 0,
             numOpenPortsRequired: metadata.numOpenPortsRequired,
             organizationName: metadata.organizationName
         };
+
+        if (metadata.maxRamExponent !== undefined) {
+            serverParams.maxRam = Math.pow(2, metadata.maxRamExponent);
+        }
 
         for (const prop of propertiesToPatternMatch) {
             if (metadata[prop] !== undefined) {

--- a/src/Server.js
+++ b/src/Server.js
@@ -160,7 +160,7 @@ function initForeignServers() {
         };
 
         if (metadata.maxRamExponent !== undefined) {
-            serverParams.maxRam = Math.pow(2, metadata.maxRamExponent);
+            serverParams.maxRam = Math.pow(2, toNumber(metadata.maxRamExponent));
         }
 
         for (const prop of propertiesToPatternMatch) {

--- a/src/data/servers.ts
+++ b/src/data/servers.ts
@@ -54,7 +54,7 @@ interface IServerMetadata {
      * This value is between 1 and 15.
      * If this is not populated, @specialName should be.
      */
-    networkLayer?: number;
+    networkLayer?: number | IMinMaxRange;
 
     /**
      * The number of ports that must be opened before the player can execute NUKE.

--- a/src/data/servers.ts
+++ b/src/data/servers.ts
@@ -40,9 +40,9 @@ interface IServerMetadata {
     literature?: string[];
 
     /**
-     * When populated, the amount of RAM the server has.
+     * When populated, the exponent of 2^x amount of RAM the server has.
      */
-    maxRam?: number;
+    maxRamExponent?: number;
 
     /**
      * How much money the server starts out with.
@@ -147,7 +147,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "blade",
     literature: ["beyond-man.lit"],
-    maxRam: 128,
+    maxRamExponent: 7,
     moneyAvailable: {
       max: 20000000000,
       min: 12000000000,
@@ -220,7 +220,7 @@ export const serverMetadata: IServerMetadata[] = [
       "coded-intelligence.lit",
       "history-of-synthoids.lit",
     ],
-    maxRam: 256,
+    maxRamExponent: 8,
     moneyAvailable: {
       max: 20000000000,
       min: 15000000000,
@@ -288,7 +288,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "fulcrumtech",
     literature: ["simulated-reality.lit"],
-    maxRam: 512,
+    maxRamExponent: 9,
     moneyAvailable: {
       max: 1800000000,
       min: 1400000000,
@@ -392,7 +392,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "helios",
     literature: ["beyond-man.lit"],
-    maxRam: 128,
+    maxRamExponent: 7,
     moneyAvailable: {
       max: 750000000,
       min: 550000000,
@@ -416,7 +416,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "vitalife",
     literature: ["A-Green-Tomorrow.lit"],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: {
       max: 800000000,
       min: 700000000,
@@ -461,7 +461,7 @@ export const serverMetadata: IServerMetadata[] = [
       min: 80,
     },
     hostname: "univ-energy",
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: {
       max: 1200000000,
       min: 1100000000,
@@ -485,7 +485,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "titan-labs",
     literature: ["coded-intelligence.lit"],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: {
       max: 900000000,
       min: 750000000,
@@ -509,7 +509,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "microdyne",
     literature: ["synthetic-muscles.lit"],
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 700000000,
       min: 500000000,
@@ -604,7 +604,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "omnia",
     literature: ["history-of-synthoids.lit"],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: {
       max: 1000000000,
       min: 900000000,
@@ -676,7 +676,7 @@ export const serverMetadata: IServerMetadata[] = [
         "A-Green-Tomorrow.lit",
         "the-failed-frontier.lit",
     ],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: {
       max: 900000000,
       min: 700000000,
@@ -722,7 +722,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "global-pharm",
     literature: ["A-Green-Tomorrow.lit"],
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 1750000000,
       min: 1500000000,
@@ -789,7 +789,7 @@ export const serverMetadata: IServerMetadata[] = [
       min: 70,
     },
     hostname: "unitalife",
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 1100000000,
       min: 1000000000,
@@ -812,7 +812,7 @@ export const serverMetadata: IServerMetadata[] = [
       min: 60,
     },
     hostname: "lexo-corp",
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 800000000,
       min: 700000000,
@@ -858,7 +858,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "alpha-ent",
     literature: ["sector-12-crime.lit"],
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 750000000,
       min: 600000000,
@@ -881,7 +881,7 @@ export const serverMetadata: IServerMetadata[] = [
       min: 70,
     },
     hostname: "aevum-police",
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 400000000,
       min: 200000000,
@@ -909,7 +909,7 @@ export const serverMetadata: IServerMetadata[] = [
       "the-failed-frontier.lit",
       "tensions-in-tech-race.lit",
     ],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: {
       max: 250000000,
       min: 175000000,
@@ -932,7 +932,7 @@ export const serverMetadata: IServerMetadata[] = [
       min: 65,
     },
     hostname: "zb-institute",
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: {
       max: 1100000000,
       min: 800000000,
@@ -960,7 +960,7 @@ export const serverMetadata: IServerMetadata[] = [
       "the-failed-frontier.lit",
       "synthetic-muscles.lit",
     ],
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 350000000,
       min: 200000000,
@@ -1074,7 +1074,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "netlink",
     literature: ["simulated-reality.lit"],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: 275000000,
     networkLayer: 4,
     numOpenPortsRequired: 3,
@@ -1114,7 +1114,7 @@ export const serverMetadata: IServerMetadata[] = [
     hackDifficulty: 10,
     hostname: "foodnstuff",
     literature: ["sector-12-crime.lit"],
-    maxRam: 16,
+    maxRamExponent: 4,
     moneyAvailable: 2000000,
     networkLayer: 1,
     numOpenPortsRequired: 0,
@@ -1125,7 +1125,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 10,
     hostname: "sigma-cosmetics",
-    maxRam: 16,
+    maxRamExponent: 4,
     moneyAvailable: 2300000,
     networkLayer: 1,
     numOpenPortsRequired: 0,
@@ -1136,7 +1136,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 15,
     hostname: "joesguns",
-    maxRam: 16,
+    maxRamExponent: 4,
     moneyAvailable: 2500000,
     networkLayer: 1,
     numOpenPortsRequired: 0,
@@ -1147,7 +1147,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 25,
     hostname: "zer0",
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: 7500000,
     networkLayer: 2,
     numOpenPortsRequired: 1,
@@ -1158,7 +1158,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 20,
     hostname: "nectar-net",
-    maxRam: 16,
+    maxRamExponent: 4,
     moneyAvailable: 2750000,
     networkLayer: 2,
     numOpenPortsRequired: 0,
@@ -1170,7 +1170,7 @@ export const serverMetadata: IServerMetadata[] = [
     hackDifficulty: 25,
     hostname: "neo-net",
     literature: ["the-hidden-world.lit"],
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: 5000000,
     networkLayer: 3,
     numOpenPortsRequired: 1,
@@ -1182,7 +1182,7 @@ export const serverMetadata: IServerMetadata[] = [
     hackDifficulty: 30,
     hostname: "silver-helix",
     literature: ["new-triads.lit"],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: 45000000,
     networkLayer: 3,
     numOpenPortsRequired: 2,
@@ -1194,7 +1194,7 @@ export const serverMetadata: IServerMetadata[] = [
     hackDifficulty: 15,
     hostname: "hong-fang-tea",
     literature: ["brighter-than-the-sun.lit"],
-    maxRam: 16,
+    maxRamExponent: 4,
     moneyAvailable: 3000000,
     networkLayer: 1,
     numOpenPortsRequired: 0,
@@ -1205,7 +1205,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 15,
     hostname: "harakiri-sushi",
-    maxRam: 16,
+    maxRamExponent: 4,
     moneyAvailable: 4000000,
     networkLayer: 1,
     numOpenPortsRequired: 0,
@@ -1216,7 +1216,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 20,
     hostname: "phantasy",
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: 24000000,
     networkLayer: 3,
     numOpenPortsRequired: 2,
@@ -1227,7 +1227,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 15,
     hostname: "max-hardware",
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: 10000000,
     networkLayer: 2,
     numOpenPortsRequired: 1,
@@ -1242,7 +1242,7 @@ export const serverMetadata: IServerMetadata[] = [
     },
     hostname: "omega-net",
     literature: ["the-new-god.lit"],
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: {
       max: 70000000,
       min: 60000000,
@@ -1284,7 +1284,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 30,
     hostname: "iron-gym",
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: 20000000,
     networkLayer: 1,
     numOpenPortsRequired: 1,
@@ -1356,7 +1356,7 @@ export const serverMetadata: IServerMetadata[] = [
         "simulated-reality.lit",
         "the-new-god.lit",
     ],
-    maxRam: 128,
+    maxRamExponent: 7,
     moneyAvailable: 0,
     networkLayer: 11,
     numOpenPortsRequired: 4,
@@ -1372,7 +1372,7 @@ export const serverMetadata: IServerMetadata[] = [
     hackDifficulty: 0,
     hostname: "I.I.I.I",
     literature: ["democracy-is-dead.lit"],
-    maxRam: 64,
+    maxRamExponent: 6,
     moneyAvailable: 0,
     networkLayer: 5,
     numOpenPortsRequired: 3,
@@ -1388,7 +1388,7 @@ export const serverMetadata: IServerMetadata[] = [
     hackDifficulty: 0,
     hostname: "avmnite-02h",
     literature: ["democracy-is-dead.lit"],
-    maxRam: 32,
+    maxRamExponent: 5,
     moneyAvailable: 0,
     networkLayer: 4,
     numOpenPortsRequired: 2,
@@ -1403,7 +1403,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 0,
     hostname: ".",
-    maxRam: 16,
+    maxRamExponent: 4,
     moneyAvailable: 0,
     networkLayer: 13,
     numOpenPortsRequired: 4,
@@ -1419,7 +1419,7 @@ export const serverMetadata: IServerMetadata[] = [
     hackDifficulty: 0,
     hostname: "CSEC",
     literature: ["democracy-is-dead.lit"],
-    maxRam: 8,
+    maxRamExponent: 3,
     moneyAvailable: 0,
     networkLayer: 2,
     numOpenPortsRequired: 1,

--- a/src/data/servers.ts
+++ b/src/data/servers.ts
@@ -41,8 +41,9 @@ interface IServerMetadata {
 
     /**
      * When populated, the exponent of 2^x amount of RAM the server has.
+     * This should be in the range of 1-20, to match the Player's max RAM.
      */
-    maxRamExponent?: number;
+    maxRamExponent?: number | IMinMaxRange;
 
     /**
      * How much money the server starts out with.

--- a/src/data/servers.ts
+++ b/src/data/servers.ts
@@ -1,0 +1,1456 @@
+// tslint:disable:max-file-line-count
+
+// This could actually be a JSON file as it should be constant metadata to be imported...
+
+/**
+ * Defines the minimum and maximum values for a range.
+ * It is up to the consumer if these values are inclusive or exclusive.
+ * It is up to the implementor to ensure max > min.
+ */
+interface IMinMaxRange {
+    /**
+     * The maximum bound of the range.
+     */
+    max: number;
+
+    /**
+     * The minimum bound of the range.
+     */
+    min: number;
+}
+
+/**
+ * The metadata describing the base state of servers on the network.
+ * These values will be adjusted based on Bitnode multipliers when the Server objects are built out.
+ */
+interface IServerMetadata {
+    /**
+     * When populated, the base security level of the server.
+     */
+    hackDifficulty?: number | IMinMaxRange;
+
+    /**
+     * The DNS name of the server.
+     */
+    hostname: string;
+
+    /**
+     * When populated, the files will be added to the server when created.
+     */
+    literature?: string[];
+
+    /**
+     * When populated, the amount of RAM the server has.
+     */
+    maxRam?: number;
+
+    /**
+     * How much money the server starts out with.
+     */
+    moneyAvailable: number | IMinMaxRange;
+
+    /**
+     * The number of network layers away from the `home` server.
+     * This value is between 1 and 15.
+     * If this is not populated, @specialName should be.
+     */
+    networkLayer?: number;
+
+    /**
+     * The number of ports that must be opened before the player can execute NUKE.
+     */
+    numOpenPortsRequired: number;
+
+    /**
+     * The organization that the server belongs to.
+     */
+    organizationName: string;
+
+    /**
+     * The minimum hacking level before the player can run NUKE.
+     */
+    requiredHackingSkill: number | IMinMaxRange;
+
+    /**
+     * The growth factor for the server.
+     */
+    serverGrowth?: number | IMinMaxRange;
+
+    /**
+     * A "unique" server that has special implications when the player manually hacks it.
+     */
+    specialName?: string;
+}
+
+/**
+ * The metadata for building up the servers on the network.
+ */
+export const serverMetadata: IServerMetadata[] = [
+  {
+    hackDifficulty: 99,
+    hostname: "ecorp",
+    moneyAvailable: {
+      max: 70000000000,
+      min: 30000000000,
+    },
+    networkLayer: 15,
+    numOpenPortsRequired: 5,
+    organizationName: "ECorp",
+    requiredHackingSkill: {
+      max: 1300,
+      min: 1150,
+    },
+    serverGrowth: 99,
+  },
+  {
+    hackDifficulty: 99,
+    hostname: "megacorp",
+    moneyAvailable: {
+      max: 60000000000,
+      min: 40000000000,
+    },
+    networkLayer: 15,
+    numOpenPortsRequired: 5,
+    organizationName: "MegaCorp",
+    requiredHackingSkill: {
+      max: 1300,
+      min: 1150,
+    },
+    serverGrowth: 99,
+  },
+  {
+    hackDifficulty: {
+      max: 85,
+      min: 75,
+    },
+    hostname: "b-and-a",
+    moneyAvailable: {
+      max: 25000000000,
+      min: 20000000000,
+    },
+    networkLayer: 14,
+    numOpenPortsRequired: 5,
+    organizationName: "Bachman & Associates",
+    requiredHackingSkill: {
+      max: 1050,
+      min: 1000,
+    },
+    serverGrowth: {
+      max: 75,
+      min: 65,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 95,
+      min: 90,
+    },
+    hostname: "blade",
+    literature: ["beyond-man.lit"],
+    maxRam: 128,
+    moneyAvailable: {
+      max: 20000000000,
+      min: 12000000000,
+    },
+    networkLayer: 14,
+    numOpenPortsRequired: 5,
+    organizationName: "Blade Industries",
+    requiredHackingSkill: {
+      max: 1100,
+      min: 1000,
+    },
+    serverGrowth: {
+      max: 75,
+      min: 60,
+    },
+  },
+  {
+    hackDifficulty: 99,
+    hostname: "nwo",
+    literature: ["the-hidden-world.lit"],
+    moneyAvailable: {
+      max: 35000000000,
+      min: 25000000000,
+    },
+    networkLayer: 14,
+    numOpenPortsRequired: 5,
+    organizationName: "New World Order",
+    requiredHackingSkill: {
+      max: 1200,
+      min: 1000,
+    },
+    serverGrowth: {
+      max: 85,
+      min: 75,
+    },
+  },
+  {
+    hackDifficulty: {
+        max: 60,
+        min: 50,
+    },
+    hostname: "clarkinc",
+    literature: [
+        "beyond-man.lit",
+        "cost-of-immortality.lit",
+    ],
+    moneyAvailable: {
+      max: 25000000000,
+      min: 15000000000,
+    },
+    networkLayer: 14,
+    numOpenPortsRequired: 5,
+    organizationName: "Clarke Incorporated",
+    requiredHackingSkill: {
+      max: 1200,
+      min: 1000,
+    },
+    serverGrowth: {
+        max: 70,
+        min: 50,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 99,
+      min: 90,
+    },
+    hostname: "omnitek",
+    literature: [
+      "coded-intelligence.lit",
+      "history-of-synthoids.lit",
+    ],
+    maxRam: 256,
+    moneyAvailable: {
+      max: 20000000000,
+      min: 15000000000,
+    },
+    networkLayer: 13,
+    numOpenPortsRequired: 5,
+    organizationName: "OmniTek Incorporated",
+    requiredHackingSkill: {
+      max: 1100,
+      min: 900,
+    },
+    serverGrowth: {
+      max: 99,
+      min: 95,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 70,
+      min: 60,
+    },
+    hostname: "4sigma",
+    moneyAvailable: {
+      max: 25000000000,
+      min: 15000000000,
+    },
+    networkLayer: 13,
+    numOpenPortsRequired: 5,
+    organizationName: "FourSigma",
+    requiredHackingSkill: {
+      max: 1200,
+      min: 950,
+    },
+    serverGrowth: {
+      max: 99,
+      min: 75,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 99,
+      min: 95,
+    },
+    hostname: "kuai-gong",
+    moneyAvailable: {
+      max: 30000000000,
+      min: 20000000000,
+    },
+    networkLayer: 13,
+    numOpenPortsRequired: 5,
+    organizationName: "KuaiGong International",
+    requiredHackingSkill: {
+      max: 1250,
+      min: 1000,
+    },
+    serverGrowth: {
+      max: 99,
+      min: 90,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 95,
+      min: 85,
+    },
+    hostname: "fulcrumtech",
+    literature: ["simulated-reality.lit"],
+    maxRam: 512,
+    moneyAvailable: {
+      max: 1800000000,
+      min: 1400000000,
+    },
+    networkLayer: 12,
+    numOpenPortsRequired: 5,
+    organizationName: "Fulcrum Technologies",
+    requiredHackingSkill: {
+      max: 1200,
+      min: 1000,
+    },
+    serverGrowth: {
+      max: 99,
+      min: 80,
+    },
+  },
+  {
+    hackDifficulty: 99,
+    hostname: "fulcrumassets",
+    moneyAvailable: 1000000,
+    networkLayer: 15,
+    numOpenPortsRequired: 5,
+    organizationName: "Fulcrum Technologies Assets",
+    requiredHackingSkill: {
+      max: 1500,
+      min: 1200,
+    },
+    serverGrowth: 1,
+    specialName: "Fulcrum Secret Technologies Server",
+  },
+  {
+    hackDifficulty: {
+      max: 90,
+      min: 80,
+    },
+    hostname: "stormtech",
+    moneyAvailable: {
+      max: 1200000000,
+      min: 1000000000,
+    },
+    networkLayer: 12,
+    numOpenPortsRequired: 5,
+    organizationName: "Storm Technologies",
+    requiredHackingSkill: {
+      max: 1050,
+      min: 900,
+    },
+    serverGrowth: {
+      max: 90,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 95,
+      min: 85,
+    },
+    hostname: "defcomm",
+    moneyAvailable: {
+      max: 950000000,
+      min: 800000000,
+    },
+    networkLayer: 9,
+    numOpenPortsRequired: 5,
+    organizationName: "DefComm",
+    requiredHackingSkill: {
+      max: 1000,
+      min: 900,
+    },
+    serverGrowth: {
+      max: 70,
+      min: 50,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 90,
+      min: 70,
+    },
+    hostname: "infocomm",
+    moneyAvailable: {
+      max: 900000000,
+      min: 600000000,
+    },
+    networkLayer: 10,
+    numOpenPortsRequired: 5,
+    organizationName: "InfoComm",
+    requiredHackingSkill: {
+      max: 950,
+      min: 875,
+    },
+    serverGrowth: {
+      max: 75,
+      min: 35,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 95,
+      min: 85,
+    },
+    hostname: "helios",
+    literature: ["beyond-man.lit"],
+    maxRam: 128,
+    moneyAvailable: {
+      max: 750000000,
+      min: 550000000,
+    },
+    networkLayer: 12,
+    numOpenPortsRequired: 5,
+    organizationName: "Helios Labs",
+    requiredHackingSkill: {
+      max: 900,
+      min: 800,
+    },
+    serverGrowth: {
+      max: 80,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 90,
+      min: 80,
+    },
+    hostname: "vitalife",
+    literature: ["A-Green-Tomorrow.lit"],
+    maxRam: 64,
+    moneyAvailable: {
+      max: 800000000,
+      min: 700000000,
+    },
+    networkLayer: 12,
+    numOpenPortsRequired: 5,
+    organizationName: "VitaLife",
+    requiredHackingSkill: {
+      max: 900,
+      min: 775,
+    },
+    serverGrowth: {
+      max: 80,
+      min: 60,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 95,
+      min: 85,
+    },
+    hostname: "icarus",
+    moneyAvailable: {
+      max: 1000000000,
+      min: 900000000,
+    },
+    networkLayer: 9,
+    numOpenPortsRequired: 5,
+    organizationName: "Icarus Microsystems",
+    requiredHackingSkill: {
+      max: 925,
+      min: 850,
+    },
+    serverGrowth: {
+      max: 95,
+      min: 85,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 90,
+      min: 80,
+    },
+    hostname: "univ-energy",
+    maxRam: 64,
+    moneyAvailable: {
+      max: 1200000000,
+      min: 1100000000,
+    },
+    networkLayer: 9,
+    numOpenPortsRequired: 4,
+    organizationName: "Universal Energy",
+    requiredHackingSkill: {
+      max: 900,
+      min: 800,
+    },
+    serverGrowth: {
+      max: 90,
+      min: 80,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 70,
+    },
+    hostname: "titan-labs",
+    literature: ["coded-intelligence.lit"],
+    maxRam: 64,
+    moneyAvailable: {
+      max: 900000000,
+      min: 750000000,
+    },
+    networkLayer: 11,
+    numOpenPortsRequired: 5,
+    organizationName: "Titan Laboratories",
+    requiredHackingSkill: {
+      max: 875,
+      min: 800,
+    },
+    serverGrowth: {
+      max: 80,
+      min: 60,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 75,
+      min: 65,
+    },
+    hostname: "microdyne",
+    literature: ["synthetic-muscles.lit"],
+    maxRam: 32,
+    moneyAvailable: {
+      max: 700000000,
+      min: 500000000,
+    },
+    networkLayer: 11,
+    numOpenPortsRequired: 5,
+    organizationName: "Microdyne Technologies",
+    requiredHackingSkill: {
+      max: 875,
+      min: 800,
+    },
+    serverGrowth: {
+      max: 90,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 70,
+    },
+    hostname: "taiyang-digital",
+    literature: [
+      "A-Green-Tomorrow.lit",
+      "brighter-than-the-sun.lit",
+    ],
+    moneyAvailable: {
+      max: 900000000,
+      min: 800000000,
+    },
+    networkLayer: 10,
+    numOpenPortsRequired: 5,
+    organizationName: "Taiyang Digital",
+    requiredHackingSkill: {
+      max: 950,
+      min: 850,
+    },
+    serverGrowth: {
+      max: 80,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 65,
+      min: 55,
+    },
+    hostname: "galactic-cyber",
+    moneyAvailable: {
+      max: 850000000,
+      min: 750000000,
+    },
+    networkLayer: 7,
+    numOpenPortsRequired: 5,
+    organizationName: "Galactic Cybersystems",
+    requiredHackingSkill: {
+      max: 875,
+      min: 825,
+    },
+    serverGrowth: {
+      max: 90,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 90,
+      min: 80,
+    },
+    hostname: "aerocorp",
+    literature: ["man-and-machine.lit"],
+    moneyAvailable: {
+      max: 1200000000,
+      min: 1000000000,
+    },
+    networkLayer: 7,
+    numOpenPortsRequired: 5,
+    organizationName: "AeroCorp",
+    requiredHackingSkill: {
+      max: 925,
+      min: 850,
+    },
+    serverGrowth: {
+      max: 65,
+      min: 55,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 95,
+      min: 85,
+    },
+    hostname: "omnia",
+    literature: ["history-of-synthoids.lit"],
+    maxRam: 64,
+    moneyAvailable: {
+      max: 1000000000,
+      min: 900000000,
+    },
+    networkLayer: 8,
+    numOpenPortsRequired: 5,
+    organizationName: "Omnia Cybersystems",
+    requiredHackingSkill: {
+      max: 950,
+      min: 850,
+    },
+    serverGrowth: {
+      max: 70,
+      min: 60,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 65,
+      min: 55,
+    },
+    hostname: "zb-def",
+    literature: ["synthetic-muscles.lit"],
+    moneyAvailable: {
+      max: 1100000000,
+      min: 900000000,
+    },
+    networkLayer: 10,
+    numOpenPortsRequired: 4,
+    organizationName: "ZB Defense Industries",
+    requiredHackingSkill: {
+      max: 825,
+      min: 775,
+    },
+    serverGrowth: {
+      max: 75,
+      min: 65,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 60,
+    },
+    hostname: "applied-energetics",
+    moneyAvailable: {
+      max: 1000000000,
+      min: 700000000,
+    },
+    networkLayer: 11,
+    numOpenPortsRequired: 4,
+    organizationName: "Applied Energetics",
+    requiredHackingSkill: {
+      max: 850,
+      min: 775,
+    },
+    serverGrowth: {
+      max: 75,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 70,
+    },
+    hostname: "solaris",
+    literature: [
+        "A-Green-Tomorrow.lit",
+        "the-failed-frontier.lit",
+    ],
+    maxRam: 64,
+    moneyAvailable: {
+      max: 900000000,
+      min: 700000000,
+    },
+    networkLayer: 9,
+    numOpenPortsRequired: 5,
+    organizationName: "Solaris Space Systems",
+    requiredHackingSkill: {
+      max: 850,
+      min: 750,
+    },
+    serverGrowth: {
+      max: 80,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 85,
+      min: 75,
+    },
+    hostname: "deltaone",
+    moneyAvailable: {
+      max: 1700000000,
+      min: 1300000000,
+    },
+    networkLayer: 8,
+    numOpenPortsRequired: 5,
+    organizationName: "Delta One",
+    requiredHackingSkill: {
+      max: 900,
+      min: 800,
+    },
+    serverGrowth: {
+      max: 70,
+      min: 50,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 85,
+      min: 75,
+    },
+    hostname: "global-pharm",
+    literature: ["A-Green-Tomorrow.lit"],
+    maxRam: 32,
+    moneyAvailable: {
+      max: 1750000000,
+      min: 1500000000,
+    },
+    networkLayer: 7,
+    numOpenPortsRequired: 4,
+    organizationName: "Global Pharmaceuticals",
+    requiredHackingSkill: {
+      max: 850,
+      min: 750,
+    },
+    serverGrowth: {
+      max: 90,
+      min: 80,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 60,
+    },
+    hostname: "nova-med",
+    moneyAvailable: {
+      max: 1250000000,
+      min: 1100000000,
+    },
+    networkLayer: 10,
+    numOpenPortsRequired: 4,
+    organizationName: "Nova Medical",
+    requiredHackingSkill: {
+      max: 850,
+      min: 775,
+    },
+    serverGrowth: {
+      max: 85,
+      min: 65,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 90,
+      min: 70,
+    },
+    hostname: "zeus-med",
+    moneyAvailable: {
+      max: 1500000000,
+      min: 1300000000,
+    },
+    networkLayer: 9,
+    numOpenPortsRequired: 5,
+    organizationName: "Zeus Medical",
+    requiredHackingSkill: {
+      max: 850,
+      min: 800,
+    },
+    serverGrowth: {
+      max: 80,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 70,
+    },
+    hostname: "unitalife",
+    maxRam: 32,
+    moneyAvailable: {
+      max: 1100000000,
+      min: 1000000000,
+    },
+    networkLayer: 8,
+    numOpenPortsRequired: 4,
+    organizationName: "UnitaLife Group",
+    requiredHackingSkill: {
+      max: 825,
+      min: 775,
+    },
+    serverGrowth: {
+      max: 80,
+      min: 70,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 60,
+    },
+    hostname: "lexo-corp",
+    maxRam: 32,
+    moneyAvailable: {
+      max: 800000000,
+      min: 700000000,
+    },
+    networkLayer: 6,
+    numOpenPortsRequired: 4,
+    organizationName: "Lexo Corporation",
+    requiredHackingSkill: {
+      max: 750,
+      min: 650,
+    },
+    serverGrowth: {
+      max: 65,
+      min: 55,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 60,
+      min: 40,
+    },
+    hostname: "rho-construction",
+    moneyAvailable: {
+      max: 700000000,
+      min: 500000000,
+    },
+    networkLayer: 6,
+    numOpenPortsRequired: 3,
+    organizationName: "Rho Construction",
+    requiredHackingSkill: {
+      max: 525,
+      min: 475,
+    },
+    serverGrowth: {
+      max: 60,
+      min: 40,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 70,
+      min: 50,
+    },
+    hostname: "alpha-ent",
+    literature: ["sector-12-crime.lit"],
+    maxRam: 32,
+    moneyAvailable: {
+      max: 750000000,
+      min: 600000000,
+    },
+    networkLayer: 6,
+    numOpenPortsRequired: 4,
+    organizationName: "Alpha Enterprises",
+    requiredHackingSkill: {
+      max: 600,
+      min: 500,
+    },
+    serverGrowth: {
+      max: 60,
+      min: 50,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 70,
+    },
+    hostname: "aevum-police",
+    maxRam: 32,
+    moneyAvailable: {
+      max: 400000000,
+      min: 200000000,
+    },
+    networkLayer: 6,
+    numOpenPortsRequired: 4,
+    organizationName: "Aevum Police Network",
+    requiredHackingSkill: {
+      max: 450,
+      min: 400,
+    },
+    serverGrowth: {
+      max: 50,
+      min: 30,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 55,
+      min: 45,
+    },
+    hostname: "rothman-uni",
+    literature: [
+      "secret-societies.lit",
+      "the-failed-frontier.lit",
+      "tensions-in-tech-race.lit",
+    ],
+    maxRam: 64,
+    moneyAvailable: {
+      max: 250000000,
+      min: 175000000,
+    },
+    networkLayer: 5,
+    numOpenPortsRequired: 3,
+    organizationName: "Rothman University Network",
+    requiredHackingSkill: {
+      max: 430,
+      min: 370,
+    },
+    serverGrowth: {
+      max: 45,
+      min: 35,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 85,
+      min: 65,
+    },
+    hostname: "zb-institute",
+    maxRam: 64,
+    moneyAvailable: {
+      max: 1100000000,
+      min: 800000000,
+    },
+    networkLayer: 5,
+    numOpenPortsRequired: 5,
+    organizationName: "ZB Institute of Technology Network",
+    requiredHackingSkill: {
+      max: 775,
+      min: 725,
+    },
+    serverGrowth: {
+      max: 85,
+      min: 75,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 65,
+      min: 45,
+    },
+    hostname: "summit-uni",
+    literature: [
+      "secret-societies.lit",
+      "the-failed-frontier.lit",
+      "synthetic-muscles.lit",
+    ],
+    maxRam: 32,
+    moneyAvailable: {
+      max: 350000000,
+      min: 200000000,
+    },
+    networkLayer: 5,
+    numOpenPortsRequired: 3,
+    organizationName: "Summit University Network",
+    requiredHackingSkill: {
+      max: 475,
+      min: 425,
+    },
+    serverGrowth: {
+      max: 60,
+      min: 40,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 60,
+    },
+    hostname: "syscore",
+    moneyAvailable: {
+      max: 600000000,
+      min: 400000000,
+    },
+    networkLayer: 5,
+    numOpenPortsRequired: 4,
+    organizationName: "SysCore Securities",
+    requiredHackingSkill: {
+      max: 650,
+      min: 550,
+    },
+    serverGrowth: {
+      max: 70,
+      min: 60,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 70,
+      min: 60,
+    },
+    hostname: "catalyst",
+    literature: ["tensions-in-tech-race.lit"],
+    moneyAvailable: {
+      max: 550000000,
+      min: 300000000,
+    },
+    networkLayer: 5,
+    numOpenPortsRequired: 3,
+    organizationName: "Catalyst Ventures",
+    requiredHackingSkill: {
+      max: 450,
+      min: 400,
+    },
+    serverGrowth: {
+      max: 55,
+      min: 25,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 45,
+      min: 35,
+    },
+    hostname: "the-hub",
+    moneyAvailable: {
+      max: 200000000,
+      min: 150000000,
+    },
+    networkLayer: 4,
+    numOpenPortsRequired: 2,
+    organizationName: "The Hub",
+    requiredHackingSkill: {
+      max: 325,
+      min: 275,
+    },
+    serverGrowth: {
+      max: 55,
+      min: 45,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 65,
+      min: 55,
+    },
+    hostname: "comptek",
+    literature: ["man-and-machine.lit"],
+    moneyAvailable: {
+      max: 250000000,
+      min: 220000000,
+    },
+    networkLayer: 4,
+    numOpenPortsRequired: 3,
+    organizationName: "CompuTek",
+    requiredHackingSkill: {
+      max: 400,
+      min: 300,
+    },
+    serverGrowth: {
+      max: 65,
+      min: 45,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 80,
+      min: 60,
+    },
+    hostname: "netlink",
+    literature: ["simulated-reality.lit"],
+    maxRam: 64,
+    moneyAvailable: 275000000,
+    networkLayer: 4,
+    numOpenPortsRequired: 3,
+    organizationName: "Netlink Technologies",
+    requiredHackingSkill: {
+      max: 425,
+      min: 375,
+    },
+    serverGrowth: {
+      max: 75,
+      min: 45,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 65,
+      min: 35,
+    },
+    hostname: "johnson-ortho",
+    moneyAvailable: {
+      max: 85000000,
+      min: 70000000,
+    },
+    networkLayer: 4,
+    numOpenPortsRequired: 2,
+    organizationName: "Johnson Orthopedics",
+    requiredHackingSkill: {
+      max: 300,
+      min: 250,
+    },
+    serverGrowth: {
+      max: 65,
+      min: 35,
+    },
+  },
+  {
+    hackDifficulty: 10,
+    hostname: "foodnstuff",
+    literature: ["sector-12-crime.lit"],
+    maxRam: 16,
+    moneyAvailable: 2000000,
+    networkLayer: 1,
+    numOpenPortsRequired: 0,
+    organizationName: "Food N Stuff Supermarket",
+    requiredHackingSkill: 1,
+    serverGrowth: 5,
+  },
+  {
+    hackDifficulty: 10,
+    hostname: "sigma-cosmetics",
+    maxRam: 16,
+    moneyAvailable: 2300000,
+    networkLayer: 1,
+    numOpenPortsRequired: 0,
+    organizationName: "Sigma Cosmetics",
+    requiredHackingSkill: 5,
+    serverGrowth: 10,
+  },
+  {
+    hackDifficulty: 15,
+    hostname: "joesguns",
+    maxRam: 16,
+    moneyAvailable: 2500000,
+    networkLayer: 1,
+    numOpenPortsRequired: 0,
+    organizationName: "Joe's Guns",
+    requiredHackingSkill: 10,
+    serverGrowth: 20,
+  },
+  {
+    hackDifficulty: 25,
+    hostname: "zer0",
+    maxRam: 32,
+    moneyAvailable: 7500000,
+    networkLayer: 2,
+    numOpenPortsRequired: 1,
+    organizationName: "ZER0 Nightclub",
+    requiredHackingSkill: 75,
+    serverGrowth: 40,
+  },
+  {
+    hackDifficulty: 20,
+    hostname: "nectar-net",
+    maxRam: 16,
+    moneyAvailable: 2750000,
+    networkLayer: 2,
+    numOpenPortsRequired: 0,
+    organizationName: "Nectar Nightclub Network",
+    requiredHackingSkill: 20,
+    serverGrowth: 25,
+  },
+  {
+    hackDifficulty: 25,
+    hostname: "neo-net",
+    literature: ["the-hidden-world.lit"],
+    maxRam: 32,
+    moneyAvailable: 5000000,
+    networkLayer: 3,
+    numOpenPortsRequired: 1,
+    organizationName: "Neo Nightclub Network",
+    requiredHackingSkill: 50,
+    serverGrowth: 25,
+  },
+  {
+    hackDifficulty: 30,
+    hostname: "silver-helix",
+    literature: ["new-triads.lit"],
+    maxRam: 64,
+    moneyAvailable: 45000000,
+    networkLayer: 3,
+    numOpenPortsRequired: 2,
+    organizationName: "Silver Helix",
+    requiredHackingSkill: 150,
+    serverGrowth: 30,
+  },
+  {
+    hackDifficulty: 15,
+    hostname: "hong-fang-tea",
+    literature: ["brighter-than-the-sun.lit"],
+    maxRam: 16,
+    moneyAvailable: 3000000,
+    networkLayer: 1,
+    numOpenPortsRequired: 0,
+    organizationName: "HongFang Teahouse",
+    requiredHackingSkill: 30,
+    serverGrowth: 20,
+  },
+  {
+    hackDifficulty: 15,
+    hostname: "harakiri-sushi",
+    maxRam: 16,
+    moneyAvailable: 4000000,
+    networkLayer: 1,
+    numOpenPortsRequired: 0,
+    organizationName: "HaraKiri Sushi Bar Network",
+    requiredHackingSkill: 40,
+    serverGrowth: 40,
+  },
+  {
+    hackDifficulty: 20,
+    hostname: "phantasy",
+    maxRam: 32,
+    moneyAvailable: 24000000,
+    networkLayer: 3,
+    numOpenPortsRequired: 2,
+    organizationName: "Phantasy Club",
+    requiredHackingSkill: 100,
+    serverGrowth: 35,
+  },
+  {
+    hackDifficulty: 15,
+    hostname: "max-hardware",
+    maxRam: 32,
+    moneyAvailable: 10000000,
+    networkLayer: 2,
+    numOpenPortsRequired: 1,
+    organizationName: "Max Hardware Store",
+    requiredHackingSkill: 80,
+    serverGrowth: 30,
+  },
+  {
+    hackDifficulty: {
+      max: 35,
+      min: 25,
+    },
+    hostname: "omega-net",
+    literature: ["the-new-god.lit"],
+    maxRam: 32,
+    moneyAvailable: {
+      max: 70000000,
+      min: 60000000,
+    },
+    networkLayer: 3,
+    numOpenPortsRequired: 2,
+    organizationName: "Omega Software",
+    requiredHackingSkill: {
+      max: 220,
+      min: 180,
+    },
+    serverGrowth: {
+      max: 40,
+      min: 30,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 45,
+      min: 35,
+    },
+    hostname: "crush-fitness",
+    moneyAvailable: {
+      max: 60000000,
+      min: 40000000,
+    },
+    networkLayer: 4,
+    numOpenPortsRequired: 2,
+    organizationName: "Crush Fitness",
+    requiredHackingSkill: {
+      max: 275,
+      min: 225,
+    },
+    serverGrowth: {
+      max: 33,
+      min: 27,
+    },
+  },
+  {
+    hackDifficulty: 30,
+    hostname: "iron-gym",
+    maxRam: 32,
+    moneyAvailable: 20000000,
+    networkLayer: 1,
+    numOpenPortsRequired: 1,
+    organizationName: "Iron Gym Network",
+    requiredHackingSkill: 100,
+    serverGrowth: 20,
+  },
+  {
+    hackDifficulty: {
+      max: 55,
+      min: 45,
+    },
+    hostname: "millenium-fitness",
+    moneyAvailable: 250000000,
+    networkLayer: 6,
+    numOpenPortsRequired: 3,
+    organizationName: "Millenium Fitness Network",
+    requiredHackingSkill: {
+      max: 525,
+      min: 475,
+    },
+    serverGrowth: {
+      max: 45,
+      min: 25,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 65,
+      min: 55,
+    },
+    hostname: "powerhouse-fitness",
+    moneyAvailable: 900000000,
+    networkLayer: 14,
+    numOpenPortsRequired: 5,
+    organizationName: "Powerhouse Fitness",
+    requiredHackingSkill: {
+      max: 1100,
+      min: 950,
+    },
+    serverGrowth: {
+      max: 60,
+      min: 50,
+    },
+  },
+  {
+    hackDifficulty: {
+      max: 60,
+      min: 40,
+    },
+    hostname: "snap-fitness",
+    moneyAvailable: 450000000,
+    networkLayer: 7,
+    numOpenPortsRequired: 4,
+    organizationName: "Snap Fitness",
+    requiredHackingSkill: {
+      max: 800,
+      min: 675,
+    },
+    serverGrowth: {
+      max: 60,
+      min: 40,
+    },
+  },
+  {
+    hackDifficulty: 0,
+    hostname: "run4theh111z",
+    literature: [
+        "simulated-reality.lit",
+        "the-new-god.lit",
+    ],
+    maxRam: 128,
+    moneyAvailable: 0,
+    networkLayer: 11,
+    numOpenPortsRequired: 4,
+    organizationName: "The Runners",
+    requiredHackingSkill: {
+      max: 550,
+      min: 505,
+    },
+    serverGrowth: 0,
+    specialName: "BitRunners Server",
+  },
+  {
+    hackDifficulty: 0,
+    hostname: "I.I.I.I",
+    literature: ["democracy-is-dead.lit"],
+    maxRam: 64,
+    moneyAvailable: 0,
+    networkLayer: 5,
+    numOpenPortsRequired: 3,
+    organizationName: "I.I.I.I",
+    requiredHackingSkill: {
+      max: 365,
+      min: 340,
+    },
+    serverGrowth: 0,
+    specialName: "The Black Hand Server",
+  },
+  {
+    hackDifficulty: 0,
+    hostname: "avmnite-02h",
+    literature: ["democracy-is-dead.lit"],
+    maxRam: 32,
+    moneyAvailable: 0,
+    networkLayer: 4,
+    numOpenPortsRequired: 2,
+    organizationName: "NiteSec",
+    requiredHackingSkill: {
+      max: 220,
+      min: 202,
+    },
+    serverGrowth: 0,
+    specialName: "NiteSec Server",
+  },
+  {
+    hackDifficulty: 0,
+    hostname: ".",
+    maxRam: 16,
+    moneyAvailable: 0,
+    networkLayer: 13,
+    numOpenPortsRequired: 4,
+    organizationName: ".",
+    requiredHackingSkill: {
+      max: 550,
+      min: 505,
+    },
+    serverGrowth: 0,
+    specialName: "The Dark Army Server",
+  },
+  {
+    hackDifficulty: 0,
+    hostname: "CSEC",
+    literature: ["democracy-is-dead.lit"],
+    maxRam: 8,
+    moneyAvailable: 0,
+    networkLayer: 2,
+    numOpenPortsRequired: 1,
+    organizationName: "CyberSec",
+    requiredHackingSkill: {
+      max: 60,
+      min: 51,
+    },
+    serverGrowth: 0,
+    specialName: "CyberSec Server",
+  },
+  {
+    hackDifficulty: 0,
+    hostname: "The-Cave",
+    literature: ["alpha-omega.lit"],
+    moneyAvailable: 0,
+    networkLayer: 15,
+    numOpenPortsRequired: 5,
+    organizationName: "Helios",
+    requiredHackingSkill: 925,
+    serverGrowth: 0,
+    specialName: "Daedalus Server",
+  },
+  {
+    hackDifficulty: 0,
+    hostname: "w0r1d_d43m0n",
+    moneyAvailable: 0,
+    numOpenPortsRequired: 5,
+    organizationName: "w0r1d_d43m0n",
+    requiredHackingSkill: 3000,
+    serverGrowth: 0,
+    specialName: "w0r1d_d43m0n",
+  },
+];


### PR DESCRIPTION
Based on a conversation in the #noobsgame Discord channel related to the usefulness of running scripts on the non-purchased servers, this change separates the initial server data from how they are created. It also gives some flexibility of randomizing more of the server information, such as a range of RAM, or how many network layers away from `home` it is.

This change doesn't change any of the existing server information, only separates it out. I'll leave changing static values to ranges up to @danielyxie 😄. 