### PR TITLE
[chore] Fixing import casing to actually match file casing

### DIFF
--- a/src/ui/setSettingsLabels.js
+++ b/src/ui/setSettingsLabels.js
@@ -1,7 +1,7 @@
 import {Engine} from "../engine";
 import {Settings} from "../Settings";
 
-import {numeralWrapper} from "./NumeralFormat";
+import {numeralWrapper} from "./numeralFormat";
 
 
 function setSettingsLabels() {


### PR DESCRIPTION
Fixes the Webpack warning about mismatched casing and OS's that are case-sensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/danielyxie/bitburner/461)
<!-- Reviewable:end -->
