### PR TITLE
Allow ./ in NetscriptJS import paths

### DIFF
--- a/src/NetscriptJSEvaluator.js
+++ b/src/NetscriptJSEvaluator.js
@@ -73,7 +73,7 @@ export function _getScriptUrls(script, scripts, seen) {
         // import {foo} from "blob://<uuid>"
         //
         // Where the blob URL contains the script content.
-        let transformedCode = script.code.replace(/((?:from|import)\s+(?:'|"))([^'"]+)('|";)/g,
+        let transformedCode = script.code.replace(/((?:from|import)\s+(?:'|"))(?:\.\/)?([^'"]+)('|";)/g,
             (unmodified, prefix, filename, suffix) => {
                 const isAllowedImport = scripts.some(s => s.filename == filename);
                 if (!isAllowedImport) return unmodified;


### PR DESCRIPTION
Allows the NetscriptJS evaluator/interpreter to import scripts with path names that start with './'.
This helps when using VSCode (and possibly others) to write scripts, as otherwise it cannot find the correct script file.