### PR TITLE
Fixed bug with "rm" terminal and ns commands

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -2261,7 +2261,7 @@ function NetscriptFunctions(workerScript) {
                 throw makeRuntimeRejectMsg(workerScript, `Invalid server specified for rm(): ${ip}`);
             }
 
-            if (fn.includes(".exe")) {
+            if (fn.endsWith(".exe")) {
                 for (var i = 0; i < s.programs.length; ++i) {
                     if (s.programs[i] === fn) {
                        s.programs.splice(i, 1);

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -1342,7 +1342,7 @@ let Terminal = {
                 //Check programs
                 let delTarget = commandArray[1];
 
-                if (delTarget.includes(".exe")) {
+                if (delTarget.endsWith(".exe")) {
                     for (let i = 0; i < s.programs.length; ++i) {
                         if (s.programs[i] === delTarget) {
                            s.programs.splice(i, 1);


### PR DESCRIPTION
You could not delete a script or text file if it had ".exe" within its name.

Sample netscript:
```js
write('test.exe.txt', 'test');
rm('test.exe.txt');
```

Sample terminal:
```
nano test.ext.txt
[save file]
rm test.ext.txt
```