### PR TITLE
Update getStamina.rst

### DIFF
--- a/doc/source/netscript/bladeburnerapi/getStamina.rst
+++ b/doc/source/netscript/bladeburnerapi/getStamina.rst
@@ -9,7 +9,7 @@ getStamina() Netscript Function
 
     Example usage::
 
-        function getStaminaPercentage() {
+        function getStamina() {
             let res = bladeburner.getStamina();
             return res[0] / res[1];
         }


### PR DESCRIPTION
The doc for bladeburner getStamina no longer proposes to use `getStaminaPercentage` in the example.