### PR TITLE
Update purchaseServer docs for BitNode 10

### DIFF
--- a/doc/source/netscript/basicfunctions/purchaseServer.rst
+++ b/doc/source/netscript/basicfunctions/purchaseServer.rst
@@ -4,7 +4,7 @@ purchaseServer() Netscript Function
 .. js:function:: purchaseServer(hostname, ram)
 
     :param string hostname: Hostname of the purchased server
-    :param number ram: Amount of RAM of the purchased server. Must be a power of 2 (2, 4, 8, 16, etc.). Maximum value of 1048576 (2^20)
+    :param number ram: Amount of RAM of the purchased server. Must be a power of 2 (2, 4, 8, 16, etc.). Maximum value of getPurchasedServerMaxRam()
     :RAM cost: 2.25 GB
 
     Purchased a server with the specified hostname and amount of RAM.


### PR DESCRIPTION
BitNode 10 reduces the maximum RAM a purchased server can have so encouraging the use of getPurchasedServerMaxRam() instead of a hardcoded value of 2 ^ 20