### PR TITLE
Correctly throw error when ns.run() is called with 0 threads

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -930,7 +930,7 @@ function NetscriptFunctions(workerScript) {
             if (scriptname === undefined) {
                 throw makeRuntimeRejectMsg(workerScript, "run() call has incorrect number of arguments. Usage: run(scriptname, [numThreads], [arg1], [arg2]...)");
             }
-            if (isNaN(threads) || threads < 0) {
+            if (isNaN(threads) || threads <= 0) {
                 throw makeRuntimeRejectMsg(workerScript, "Invalid argument for thread count passed into run(). Must be numeric and greater than 0");
             }
             var argsForNewScript = [];


### PR DESCRIPTION
Current behaviour when ns.run() is called with zero threads is some internal error being thrown when bitburner internals doesn't expect the number to be zero. This situation was already supposed to be checked against, the comparison was just off by one.