### PR TITLE
Fixed O(n) runtime of "Find Largest Prime Factor" for high primes to …

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -65,16 +65,15 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         solver: (data: number, ans: string) => {
             let fac: number = 2;
             let n: number = data;
-            while (n > fac) {
-                if (n % fac === 0) {
+            while (Math.sqrt(n) > fac-1) {
+                while (n % fac === 0) {
                     n = Math.round(n / fac);
-                    fac = 2;
                 } else {
                     ++fac;
                 }
             }
 
-            return fac === parseInt(ans, 10);
+            return (n===1?(fac-1):n) === parseInt(ans, 10);
         },
     },
     {

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -68,9 +68,8 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
             while (Math.sqrt(n) > fac-1) {
                 while (n % fac === 0) {
                     n = Math.round(n / fac);
-                } else {
-                    ++fac;
                 }
+                ++fac;
             }
 
             return (n===1?(fac-1):n) === parseInt(ans, 10);


### PR DESCRIPTION
…O(sqrt(n)). Also improved the general runtime for most/all cases. High primes could lock the game for up to 10 seconds before, now the worst case runtime is about 20 ms.