### PR TITLE
Update script.module immediately

### DIFF
--- a/src/NetscriptJSEvaluator.js
+++ b/src/NetscriptJSEvaluator.js
@@ -26,9 +26,9 @@ export async function executeJSScript(scripts = [], workerScript) {
         // load fully dynamic content. So we hide the import from webpack
         // by placing it inside an eval call.
         urlStack = _getScriptUrls(script, scripts, []);
-        script.module = await eval('import(urlStack[urlStack.length - 1])');
+        script.module = new Promise(resolve => resolve(eval('import(urlStack[urlStack.length - 1])')));
     }
-    loadedModule = script.module;
+    loadedModule = await script.module;
 
     let ns      = workerScript.env.vars;
 


### PR DESCRIPTION
Fixes the problem where starting multiple copies of a script when that script's module has not been loaded yet leads to every instance of the script having a duplicate module eval'd for it.

Test case:

bug-controller.ns
```js
export async function main(ns) {
    const WORKER_COUNT = ns.args[0];
    
    for (let n = 0; n < WORKER_COUNT; n++) {
        await ns.exec("bug-worker.ns", "home", 1, n);
    }
}
```

bug-worker.ns
```js
export async function main(ns) {
    await ns.sleep(200);
    debugger;
}
```

