### PR TITLE
add getJoinedFactions() as Singularity2 function

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -190,6 +190,7 @@ export const RamCosts: IMap<any> = {
     checkFactionInvitations: () => RamCostConstants.ScriptSingularityFn2RamCost,
     joinFaction: () => RamCostConstants.ScriptSingularityFn2RamCost,
     workForFaction: () => RamCostConstants.ScriptSingularityFn2RamCost,
+    getJoinedFactions : () => RamCostConstants.ScriptSingularityFn2RamCost / 3,
     getFactionRep: () => RamCostConstants.ScriptSingularityFn2RamCost / 3,
     getFactionFavor: () => RamCostConstants.ScriptSingularityFn2RamCost / 3,
     getFactionFavorGain: () => RamCostConstants.ScriptSingularityFn2RamCost / 4,

--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -2861,6 +2861,24 @@ function NetscriptFunctions(workerScript) {
 
             return Factions[name].playerReputation;
         },
+        getJoinedFactions: function() {
+            updateDynamicRam("getJoinedFactions", getRamCost("getJoinedFactions"));
+            if (Player.bitNodeN !== 4) {
+                if (SourceFileFlags[4] <= 1) {
+                    err( "Cannot run getJoinedFactions(). It is a Singularity Function and requires SourceFile-4 (level 2) to run.");
+                    return -1;
+                }
+            }
+            let result = [];
+            for(let factionName of Object.keys(Factions)){
+                let faction = Factions[factionName];
+                if(faction.isMember){
+                    result.push(faction.name);
+                }
+            }
+            result = result.sort()
+            return result;
+        },
         getFactionFavor: function(name) {
             updateDynamicRam("getFactionFavor", getRamCost("getFactionFavor"));
             if (Player.bitNodeN !== 4) {


### PR DESCRIPTION
Adds a Singularity level 2 function
getJoinedFactions() takes no argument and returns a list of the current factions the player is member of.
This allows further singularity automation without the need of manually codemining the game to get a list of the most common factions, while leaving some mystery about other undiscovered factions.