### PR TITLE
add getAugmentationEffects(augName) Singularity 3 function, returns a…

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -202,6 +202,7 @@ export const RamCosts: IMap<any> = {
     getAugmentationsFromFaction: () => RamCostConstants.ScriptSingularityFn3RamCost,
     getAugmentationPrereq: () => RamCostConstants.ScriptSingularityFn3RamCost,
     getAugmentationCost: () => RamCostConstants.ScriptSingularityFn3RamCost,
+    getAugmentationEffects: () => RamCostConstants.ScriptSingularityFn3RamCost,
     purchaseAugmentation: () => RamCostConstants.ScriptSingularityFn3RamCost,
     installAugmentations: () => RamCostConstants.ScriptSingularityFn3RamCost,
 

--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -3103,6 +3103,26 @@ function NetscriptFunctions(workerScript) {
             var aug = Augmentations[name];
             return aug.prereqs.slice();
         },
+        getAugmentationEffects: function(name) {
+            updateDynamicRam("getAugmentationEffects", getRamCost("getAugmentationEffects"));
+            if (Player.bitNodeN !== 4) {
+                if (SourceFileFlags[4] <= 2) {
+                    err( "Cannot run getAugmentationEffects(). It is a Singularity Function and requires SourceFile-4 (level 3) to run.");
+                    return false;
+                }
+            }
+
+            if (!augmentationExists(name)) {
+                workerScript.scriptRef.log("ERROR: getAugmentationEffects() failed. Invalid Augmentation name passed in (note: this is case-sensitive): " + name);
+                return [];
+            }
+
+            var aug = Augmentations[name];
+            var results = {}
+            Object.keys(aug.mults).forEach((key)=>{if (aug.mults[key] != 0.) results[key]= aug.mults[key];});
+
+            return results;
+        },
         getAugmentationCost: function(name) {
             updateDynamicRam("getAugmentationCost", getRamCost("getAugmentationCost"));
             if (Player.bitNodeN !== 4) {


### PR DESCRIPTION
… dict of non-null effects by the augment augName.

This allows automated augmentation filtering and differentiation, letting the player much more control in it's augment purchase decision. (i.e. buy every augment of each known faction if it's hacking related, but only if it's effect is greater than 1.05 [5%])