### PR TITLE
update ls.rst

### DIFF
--- a/doc/source/netscript/basicfunctions/ls.rst
+++ b/doc/source/netscript/basicfunctions/ls.rst
@@ -5,7 +5,7 @@ ls() Netscript Function
 
     :param string hostname/ip: Hostname or IP of the target server
     :param string grep: a substring to search for in the filename
-    :RAM cost: 0 GB
+    :RAM cost: 0.2 GB
 
     Returns an array with the filenames of all files on the specified server (as strings). The returned array
     is sorted in alphabetic order


### PR DESCRIPTION
on platform testing shows ls() runs for 0.2GB, not 0GB