### PR TITLE
Make command `cd` without arguments an alias for `cd /`

### DIFF
--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -938,10 +938,10 @@ let Terminal = {
                 break;
             }
             case "cd": {
-                if (commandArray.length !== 2) {
+                if (commandArray.length > 2) {
                     postError("Incorrect number of arguments. Usage: cd [dir]");
                 } else {
-                    let dir = commandArray[1];
+                    let dir = commandArray.length === 2 ? commandArray[1] : "/";
 
                     let evaledDir;
                     if (dir === "/") {


### PR DESCRIPTION
In most shells `cd` without arguments takes you to the home directory
of the current user. I keep trying to do this due to muscle memory
from working in terminals, so I figured I'd make it do something useful.

There is no home directory in the game, but going to / is the closest
thing we have, since that is the starting point for the user in the
game.