### PR TITLE
Corrupt location title when backdoor is installed

### DIFF
--- a/src/Locations/ui/GenericLocation.tsx
+++ b/src/Locations/ui/GenericLocation.tsx
@@ -23,7 +23,11 @@ import { CityName }                 from "../data/CityNames";
 import { IEngine }                  from "../../IEngine";
 import { IPlayer }                  from "../../PersonObjects/IPlayer";
 
+import { SpecialServerIps }         from "../../Server/SpecialServerIps";
+import { getServer }                from "../../Server/ServerHelpers";
+
 import { StdButton }                from "../../ui/React/StdButton";
+import { CorruptableText }          from "../../ui/React/CorruptableText";
 
 type IProps = {
     engine: IEngine;
@@ -146,11 +150,19 @@ export class GenericLocation extends React.Component<IProps, any> {
 
     render() {
         const locContent: React.ReactNode[] = this.getLocationSpecificContent();
-
+        const ip = SpecialServerIps.getIp(this.props.loc.name);
+        const server = getServer(ip);
+        const backdoorInstalled = server?.hasOwnProperty('backdoorInstalled');
+        
         return (
             <div>
                 <StdButton onClick={this.props.returnToCity} style={this.btnStyle} text={"Return to World"} />
-                <h1>{this.props.loc.name}</h1>
+                <h1>
+                    {backdoorInstalled
+                        ? <CorruptableText content={this.props.loc.name}/>
+                        : this.props.loc.name
+                    }
+                </h1>
                 {locContent}
             </div>
         )

--- a/src/Locations/ui/GenericLocation.tsx
+++ b/src/Locations/ui/GenericLocation.tsx
@@ -159,7 +159,7 @@ export class GenericLocation extends React.Component<IProps, any> {
             <div>
                 <StdButton onClick={this.props.returnToCity} style={this.btnStyle} text={"Return to World"} />
                 <h1>
-                    {backdoorInstalled
+                    {backdoorInstalled && !Settings.DisableTextEffects
                         ? <CorruptableText content={this.props.loc.name}/>
                         : this.props.loc.name
                     }

--- a/src/Locations/ui/GenericLocation.tsx
+++ b/src/Locations/ui/GenericLocation.tsx
@@ -6,28 +6,29 @@
  */
 import * as React from "react";
 
-import { CompanyLocation }          from "./CompanyLocation";
-import { GymLocation }              from "./GymLocation";
-import { HospitalLocation }         from "./HospitalLocation";
-import { SlumsLocation }            from "./SlumsLocation";
-import { SpecialLocation }          from "./SpecialLocation";
-import { TechVendorLocation }       from "./TechVendorLocation";
-import { TravelAgencyLocation }     from "./TravelAgencyLocation";
-import { UniversityLocation }       from "./UniversityLocation";
-import { CasinoLocation }           from "./CasinoLocation";
+import { CompanyLocation }                  from "./CompanyLocation";
+import { GymLocation }                      from "./GymLocation";
+import { HospitalLocation }                 from "./HospitalLocation";
+import { SlumsLocation }                    from "./SlumsLocation";
+import { SpecialLocation }                  from "./SpecialLocation";
+import { TechVendorLocation }               from "./TechVendorLocation";
+import { TravelAgencyLocation }             from "./TravelAgencyLocation";
+import { UniversityLocation }               from "./UniversityLocation";
+import { CasinoLocation }                   from "./CasinoLocation";
 
-import { Location }                 from "../Location";
-import { LocationType }             from "../LocationTypeEnum";
-import { CityName }                 from "../data/CityNames";
+import { Location }                         from "../Location";
+import { LocationType }                     from "../LocationTypeEnum";
+import { CityName }                         from "../data/CityNames";
 
-import { IEngine }                  from "../../IEngine";
-import { IPlayer }                  from "../../PersonObjects/IPlayer";
+import { IEngine }                          from "../../IEngine";
+import { IPlayer }                          from "../../PersonObjects/IPlayer";
+import { Settings }                         from "../../Settings/Settings";
 
-import { SpecialServerIps }         from "../../Server/SpecialServerIps";
-import { getServer, isBackdoorInstalled }                from "../../Server/ServerHelpers";
+import { SpecialServerIps }                 from "../../Server/SpecialServerIps";
+import { getServer, isBackdoorInstalled }   from "../../Server/ServerHelpers";
 
-import { StdButton }                from "../../ui/React/StdButton";
-import { CorruptableText }          from "../../ui/React/CorruptableText";
+import { StdButton }                        from "../../ui/React/StdButton";
+import { CorruptableText }                  from "../../ui/React/CorruptableText";
 
 type IProps = {
     engine: IEngine;

--- a/src/Locations/ui/GenericLocation.tsx
+++ b/src/Locations/ui/GenericLocation.tsx
@@ -24,7 +24,7 @@ import { IEngine }                  from "../../IEngine";
 import { IPlayer }                  from "../../PersonObjects/IPlayer";
 
 import { SpecialServerIps }         from "../../Server/SpecialServerIps";
-import { getServer }                from "../../Server/ServerHelpers";
+import { getServer, isBackdoorInstalled }                from "../../Server/ServerHelpers";
 
 import { StdButton }                from "../../ui/React/StdButton";
 import { CorruptableText }          from "../../ui/React/CorruptableText";
@@ -152,7 +152,7 @@ export class GenericLocation extends React.Component<IProps, any> {
         const locContent: React.ReactNode[] = this.getLocationSpecificContent();
         const ip = SpecialServerIps.getIp(this.props.loc.name);
         const server = getServer(ip);
-        const backdoorInstalled = server?.hasOwnProperty('backdoorInstalled');
+        const backdoorInstalled = server !== null && isBackdoorInstalled(server);
         
         return (
             <div>

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -147,3 +147,10 @@ export function getServerOnNetwork(server: Server, i: number) {
 
     return AllServers[server.serversOnNetwork[i]];
 }
+
+export function isBackdoorInstalled(server: Server | HacknetServer): boolean {
+    if ("backdoorInstalled" in server) {
+      return server.backdoorInstalled;
+    }
+    return false;
+}

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -29,6 +29,11 @@ interface IDefaultSettings {
      * Whether global keyboard shortcuts should be recognized throughout the game.
      */
     DisableHotkeys: boolean;
+    
+    /**
+     * Whether text effects such as corruption should be visible.
+     */
+    DisableTextEffects: boolean;
 
     /**
      * Locale used for display numbers
@@ -108,6 +113,7 @@ const defaultSettings: IDefaultSettings = {
     CodeInstructionRunTime:              50,
     DisableASCIIArt:                     false,
     DisableHotkeys:                      false,
+    DisableTextEffects:                  false,
     Locale:                              "en",
     MaxLogCapacity:                      50,
     MaxPortCapacity:                     50,
@@ -127,6 +133,7 @@ export const Settings: ISettings & ISelfInitializer & ISelfLoading = {
     CodeInstructionRunTime:              25,
     DisableASCIIArt:                     defaultSettings.DisableASCIIArt,
     DisableHotkeys:                      defaultSettings.DisableHotkeys,
+    DisableTextEffects:                  defaultSettings.DisableTextEffects,
     Editor:                              EditorSetting.Ace,
     EditorKeybinding:                    AceKeybindingSetting.Ace,
     EditorTheme:                         "Monokai",

--- a/src/index.html
+++ b/src/index.html
@@ -541,6 +541,16 @@ if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
                     <input class="optionCheckbox" type="checkbox" name="settingsDisableASCIIArt" id="settingsDisableASCIIArt">
                 </fieldset>
 
+                <!-- Disable text effects such as corruption. -->
+                <fieldset>
+                    <label for="settingsDisableTextEffects" class="tooltip">Disable Text Effects:
+                        <span class="tooltiptexthigh">
+                            If this is set, text effects will not be displayed. This can help if text is difficult to read in certain areas.
+                        </span>
+                    </label>
+                    <input class="optionCheckbox" type="checkbox" name="settingsDisableTextEffects" id="settingsDisableTextEffects">
+                </fieldset>
+
                 <!-- Locale for displaying numbers -->
                 <fieldset>
                     <label for="settingsLocale" class="tooltip">Locale:

--- a/src/ui/React/CorruptableText.tsx
+++ b/src/ui/React/CorruptableText.tsx
@@ -4,16 +4,12 @@ function replace(str: string, i: number, char: string): string {
     return str.substring(0, i) + char + str.substring(i + 1);
 }
 
-type IProps = {
+interface IProps {
     content: string;
 }
 
 function randomize(char: string): string {
-
-    function randFrom(str: string): string {
-        return str[Math.floor(Math.random()*str.length)];
-    }
-
+    const randFrom = (str: string): string => str[Math.floor(Math.random()*str.length)];
     const classes = [
         "abcdefghijklmnopqrstuvwxyz",
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -22,6 +18,7 @@ function randomize(char: string): string {
         "()[]{}<>",
     ];
     const other = `!@#$%^&*()_+|\\';"/.,?\`~`;
+
     for(const c of classes) {
         if (c.includes(char)) return randFrom(c);
     }
@@ -32,7 +29,7 @@ function randomize(char: string): string {
 export function CorruptableText(props: IProps) {
     const [content, setContent] = React.useState(props.content);
 
-    const corruptText = () => {
+    useEffect(() => {
         let counter = 5;
         const id = setInterval(() => {
             counter--;
@@ -50,10 +47,6 @@ export function CorruptableText(props: IProps) {
         return () => {
             clearInterval(id);
         };
-    }
-
-    useEffect(() => {
-        return corruptText();
     }, []);
 
     return <span>{content}</span>

--- a/src/ui/React/CorruptableText.tsx
+++ b/src/ui/React/CorruptableText.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 function replace(str: string, i: number, char: string): string {
     return str.substring(0, i) + char + str.substring(i + 1);
@@ -27,7 +27,7 @@ function randomize(char: string): string {
 }
 
 export function CorruptableText(props: IProps) {
-    const [content, setContent] = React.useState(props.content);
+    const [content, setContent] = useState(props.content);
 
     useEffect(() => {
         let counter = 5;

--- a/src/ui/React/CorruptableText.tsx
+++ b/src/ui/React/CorruptableText.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from "react";
+
+function replace(str: string, i: number, char: string): string {
+    return str.substring(0, i) + char + str.substring(i + 1);
+}
+
+type IProps = {
+    content: string;
+}
+
+function randomize(char: string): string {
+
+    function randFrom(str: string): string {
+        return str[Math.floor(Math.random()*str.length)];
+    }
+
+    const classes = [
+        "abcdefghijklmnopqrstuvwxyz",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        "1234567890",
+        " _",
+        "()[]{}<>",
+    ];
+    const other = `!@#$%^&*()_+|\\';"/.,?\`~`;
+    for(const c of classes) {
+        if (c.includes(char)) return randFrom(c);
+    }
+
+    return randFrom(other);
+}
+
+export function CorruptableText(props: IProps) {
+    const [content, setContent] = React.useState(props.content);
+
+    const corruptText = () => {
+        let counter = 5;
+        const id = setInterval(() => {
+            counter--;
+            if (counter > 0)
+                return;
+            counter = Math.random() * 5;
+            const index = Math.random() * content.length;
+            const letter = content.charAt(index);
+            setContent(replace(content, index, randomize(letter)));
+            setTimeout(() => {
+                setContent(content);
+            }, 50);
+        }, 100);
+
+        return () => {
+            clearInterval(id);
+        };
+    }
+
+    useEffect(() => {
+        return corruptText();
+    }, []);
+
+    return <span>{content}</span>
+}

--- a/src/ui/setSettingsLabels.js
+++ b/src/ui/setSettingsLabels.js
@@ -24,6 +24,7 @@ function setSettingsLabels() {
     const autosaveInterval = document.getElementById("settingsAutosaveIntervalValLabel");
     const disableHotkeys = document.getElementById("settingsDisableHotkeys");
     const disableASCIIArt = document.getElementById("settingsDisableASCIIArt");
+    const disableTextEffects = document.getElementById("settingsDisableTextEffects");
     const locale = document.getElementById("settingsLocale");
 
     //Initialize values on labels
@@ -38,6 +39,7 @@ function setSettingsLabels() {
     setAutosaveLabel(autosaveInterval);
     disableHotkeys.checked = Settings.DisableHotkeys;
     disableASCIIArt.checked = Settings.CityListView;
+    disableTextEffects.checked = Settings.DisableTextEffects;
     locale.value = Settings.Locale;
     numeralWrapper.updateLocale(Settings.Locale); //Initialize locale
 
@@ -103,6 +105,10 @@ function setSettingsLabels() {
 
     disableASCIIArt.onclick = function() {
         Settings.DisableASCIIArt = this.checked;
+    }
+
+    disableTextEffects.onclick = function() {
+        Settings.DisableTextEffects = this.checked;
     }
 
     //Locale selector


### PR DESCRIPTION
If a location's server has a backdoor installed, the title will appear corrupted.

![working](https://user-images.githubusercontent.com/17269242/116327556-f02c6c00-a7be-11eb-8453-d12067a7872f.gif)

Option to disable text effects:

![working](https://user-images.githubusercontent.com/17269242/116366489-4076ee80-a7fe-11eb-9ff0-c5fc1de1ae35.gif)

There is an issue with text scaling which will be handled after this is merged.
