### PR TITLE
Update ps documentation

### DIFF
--- a/doc/source/netscript/basicfunctions/ps.rst
+++ b/doc/source/netscript/basicfunctions/ps.rst
@@ -24,7 +24,8 @@ ps() Netscript Function
     .. code-block:: javascript
 
         processes = ps("home");
-        for (let i = 0; i < ps.length; ++i) {
-            tprint(ps[i].filename + ' ' + ps[i].threads);
-            tprint(ps[i].args);
+        for (let i = 0; i < processes.length; ++i) {
+            tprint(processes[i].filename + ' ' + processes[i].threads);
+            tprint(processes[i].args);
+            tprint(processes[i].pid);
         }


### PR DESCRIPTION
I dont really like how the example printing works, but adding nicer formatting in NS1 would overcomplicate the example too much.

If ps returned one or two extra parameters, I would recommend to simply have the first print line and the print the raw processes[i]
If NS1 allowed for easier formatting, i would go for:
tprint(`${processes[i].filename} (${processes[i].pid}) ${processes[i].threads`);
tprint(processes[i].args)
But with the limited formating, that gets too long