### PR TITLE
Add setting to suppress Bladeburner prompts

### DIFF
--- a/src/Bladeburner.jsx
+++ b/src/Bladeburner.jsx
@@ -24,6 +24,7 @@ import {
     convertTimeMsToTimeElapsedString,
 } from "../utils/StringHelperFunctions";
 
+import { Settings } from "./Settings/Settings";
 import { ConsoleHelpText } from "./Bladeburner/data/Help";
 import { City } from "./Bladeburner/City";
 import { BladeburnerConstants } from "./Bladeburner/data/Constants";
@@ -358,7 +359,9 @@ Bladeburner.prototype.process = function() {
                 msg += `<br><br>Your automation was disabled as well. You will have to re-enable it through the Bladeburner console`
                 this.automateEnabled = false;
             }
-            dialogBoxCreate(msg);
+            if (!Settings.SuppressBladeburnerPopup) {
+                dialogBoxCreate(msg);
+            }
         }
         this.resetAction();
     }

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -74,6 +74,11 @@ interface IDefaultSettings {
      * Whether the user should be asked to confirm travelling between cities.
      */
     SuppressTravelConfirmation: boolean;
+
+    /**
+     * Whether the user should be displayed a popup message when his Bladeburner actions are cancelled.
+     */
+    SuppressBladeburnerPopup: boolean;
 }
 
 /**
@@ -122,6 +127,7 @@ const defaultSettings: IDefaultSettings = {
     SuppressHospitalizationPopup:        false,
     SuppressMessages:                    false,
     SuppressTravelConfirmation:          false,
+    SuppressBladeburnerPopup:            false,
 };
 
 /**
@@ -147,6 +153,7 @@ export const Settings: ISettings & ISelfInitializer & ISelfLoading = {
     SuppressHospitalizationPopup:        defaultSettings.SuppressHospitalizationPopup,
     SuppressMessages:                    defaultSettings.SuppressMessages,
     SuppressTravelConfirmation:          defaultSettings.SuppressTravelConfirmation,
+    SuppressBladeburnerPopup:            defaultSettings.SuppressBladeburnerPopup,
     init() {
         Object.assign(Settings, defaultSettings);
     },

--- a/src/index.html
+++ b/src/index.html
@@ -519,6 +519,16 @@ if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
                     <input class="optionCheckbox" type="checkbox" name="settingsSuppressHospitalizationPopup" id="settingsSuppressHospitalizationPopup">
                 </fieldset>
 
+                <!-- Suppress Bladeburner popups -->
+                <fieldset>
+                    <label for="settingsSuppressBladeburnerPopup" class="tooltip">Suppress Bladeburner Popup:
+                        <span class="tooltiptext">
+                            If this is set, then having your Bladeburner actions interrupted by being busy with something else will not display a popup message.
+                        </span>
+                    </label>
+                    <input class="optionCheckbox" type="checkbox" name="settingsSuppressBladeburnerPopup" id="settingsSuppressBladeburnerPopup">
+                </fieldset>
+
                 <!-- Disable Terminal and Navigation Shortcuts -->
                 <fieldset>
                     <label for="settingsDisableHotkeys" class="tooltip">Disable Hotkeys:

--- a/src/ui/setSettingsLabels.js
+++ b/src/ui/setSettingsLabels.js
@@ -1,6 +1,6 @@
 import {Engine} from "../engine";
 import {Settings} from "../Settings/Settings";
-
+import {Player} from "../Player";
 import {numeralWrapper} from "./numeralFormat";
 
 
@@ -21,6 +21,7 @@ function setSettingsLabels() {
     const suppressTravelConfirmation = document.getElementById("settingsSuppressTravelConfirmation");
     const suppressBuyAugmentationConfirmation = document.getElementById("settingsSuppressBuyAugmentationConfirmation");
     const suppressHospitalizationPopup = document.getElementById("settingsSuppressHospitalizationPopup");
+    const suppressBladeburnerPopup = document.getElementById("settingsSuppressBladeburnerPopup");
     const autosaveInterval = document.getElementById("settingsAutosaveIntervalValLabel");
     const disableHotkeys = document.getElementById("settingsDisableHotkeys");
     const disableASCIIArt = document.getElementById("settingsDisableASCIIArt");
@@ -36,6 +37,9 @@ function setSettingsLabels() {
     suppressTravelConfirmation.checked = Settings.SuppressTravelConfirmation;
     suppressBuyAugmentationConfirmation.checked = Settings.SuppressBuyAugmentationConfirmation;
     suppressHospitalizationPopup.checked = Settings.SuppressHospitalizationPopup;
+    suppressBladeburnerPopup.checked = Settings.SuppressBladeburnerPopup;
+    suppressBladeburnerPopup.closest('fieldset').style.display =
+        Player.canAccessBladeburner() ? 'block' : 'none';
     setAutosaveLabel(autosaveInterval);
     disableHotkeys.checked = Settings.DisableHotkeys;
     disableASCIIArt.checked = Settings.CityListView;
@@ -97,6 +101,10 @@ function setSettingsLabels() {
 
     suppressHospitalizationPopup.onclick = function() {
         Settings.SuppressHospitalizationPopup = this.checked;
+    }
+
+    suppressBladeburnerPopup.onclick = function() {
+        Settings.SuppressBladeburnerPopup = this.checked;
     }
 
     disableHotkeys.onclick = function() {


### PR DESCRIPTION
Used to suppress the message that is shown when your Bladeburner action
is cancelled when busy with something else. Useful once you have BN-7 and have a watcher script restarting the action as needed.

![firefox_XHH79zAnkg](https://user-images.githubusercontent.com/1521080/118124188-3ee32400-b3c3-11eb-9c1b-e9f9299085e3.png)

Let me know if there's something else that needs to be added to make save files compatible.

