### PR TITLE
Hacknet Node Constants Fix (see omuretsu's message in Discord)

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -4386,7 +4386,7 @@ function NetscriptFunctions(workerScript) {
                 },
                 constants: function() {
                     checkFormulasAccess("hacknetNodes.constants", 5);
-                    return Object.assign({}, HacknetNodeConstants, HacknetServerConstants);
+                    return Object.assign({}, HacknetNodeConstants);
                 },
             },
             hacknetServers: {


### PR DESCRIPTION
omuretsu: At least when the player has SF-9, ns.formulas.hacknetNodes.constants() doesn't just show the HacknetNodeConstants from bitburner/src/Hacknet/data/Constants.ts. For keys which are only in the HacknetNodeConstants, it shows that value, but any others are overwritten by the values from HacknetServerConstants (which should instead be referenced through ns.formulas.hacknetServers.constants())