### PR TITLE
Update AugmentationHelpers.jsx

### DIFF
--- a/src/Augmentation/AugmentationHelpers.jsx
+++ b/src/Augmentation/AugmentationHelpers.jsx
@@ -1681,20 +1681,20 @@ function initAugmentations() {
              "uses advanced mathematical algorithims to rapidly identify and compute statistical " +
              "outcomes of nearly every situation. The use of this implant is outlawed for use in " +
              "Aevum's casino.<br><br>" +
-             "Increases charisma by 7%.<br>" +
-             "Increases charisma experience gain by 7%.<br>" +
-             "Increases money gained from working by 7%.<br>" +
-             "Increases reputation gain from factions and companies by 7%.<br>" +
-             "Increases crime success rate by 7%.<br>" +
-             "Increases money gained from committing crimes by 7%.<br>" +
+             "Increases charisma by 7.77%.<br>" +
+             "Increases charisma experience gain by 7.77%.<br>" +
+             "Increases money gained from working by 77.7%.<br>" +
+             "Increases reputation gain from factions and companies by 7.77%.<br>" +
+             "Increases crime success rate by 7.77%.<br>" +
+             "Increases money gained from committing crimes by 7.77%.<br>" +
              "Provides DeepscanV1.exe and AutoLink.exe after a reset.",
-        charisma_mult: 1.07,
-        charisma_exp_mult: 1.07,
-        work_money_mult: 1.07,
-        faction_rep_mult: 1.07,
-        company_rep_mult: 1.07,
-        crime_success_mult: 1.07,
-        crime_money_mult: 1.07,
+        charisma_mult: 1.0777,
+        charisma_exp_mult: 1.0777,
+        work_money_mult: 1.777,
+        faction_rep_mult: 1.0777,
+        company_rep_mult: 1.0777,
+        crime_success_mult: 1.0777,
+        crime_money_mult: 1.0777,
     });
     PCMatrix.addToFactions(["Aevum"]);
     if (augmentationExists(AugmentationNames.PCMatrix)) {

--- a/src/Augmentation/AugmentationHelpers.jsx
+++ b/src/Augmentation/AugmentationHelpers.jsx
@@ -1675,6 +1675,32 @@ function initAugmentations() {
 	// Aevum
     // TODO Later Something that lets you learn advanced math...this increases int
     // and profits as a trader/from trading
+    const PCMatrix = new Augmentation({
+        name:AugmentationNames.PCMatrix, repCost:1e4, moneyCost:1e7,
+        info:"A 'Probability Computation Matrix' is installed in the frontal cortex. This implant " +
+             "uses advanced mathematical algorithims to rapidly identify and compute statistical " +
+             "outcomes of nearly every situation. The use of this implant is outlawed for use in " +
+             "Aevum's casino.<br><br>" +
+             "Increases charisma by 7%.<br>" +
+             "Increases charisma experience gain by 7%.<br>" +
+             "Increases money gained from working by 7%.<br>" +
+             "Increases reputation gain from factions and companies by 7%.<br>" +
+             "Increases crime success rate by 7%.<br>" +
+             "Increases money gained from committing crimes by 7%.<br>" +
+             "Provides DeepscanV1.exe and AutoLink.exe after a reset.",
+        charisma_mult: 1.07,
+        charisma_exp_mult: 1.07,
+        work_money_mult: 1.07,
+        faction_rep_mult: 1.07,
+        company_rep_mult: 1.07,
+        crime_success_mult: 1.07,
+        crime_money_mult: 1.07,
+    });
+    PCMatrix.addToFactions(["Aevum"]);
+    if (augmentationExists(AugmentationNames.PCMatrix)) {
+        delete Augmentations[AugmentationNames.PCMatrix];
+    }
+    AddToAugmentations(PCMatrix);
 
     // Ishima
     const INFRARet = new Augmentation({


### PR DESCRIPTION
Unique augment proposed for Aevum, since it is the only city that does not have a unique augment. The augment is themed around "luck". All of the modifiers it provides are 7.77% or 77.7% and the flavor text makes use of Aevum's casino. It would also be a neat gimmick to have it provide DeepscanV1.exe and AutoLink.exe upon a reset. 