### PR TITLE
Augmentation Modifier Description Rework

### DIFF
--- a/src/Augmentation/AugmentationHelpers.jsx
+++ b/src/Augmentation/AugmentationHelpers.jsx
@@ -82,7 +82,7 @@ function getRandomBonus() {
                 hacknet_node_level_cost_mult: 0.85,
             },
             description: "Increases money produced from Hacknet Nodes by 20%.<br>" +
-                         "Decreases all costs related to Hacknet Nodes by 15%.",
+                         "Decreases all upgrade costs of Hacknet Nodes by 15%.",
         },
         {
             bonuses: {
@@ -1005,9 +1005,8 @@ function initAugmentations() {
         info:"Uploads the architecture and design details of a Hacknet Node's CPU into " +
              "the brain. This allows the user to engineer custom hardware and software  " +
              "for the Hacknet Node that provides better performance.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the amount of money produced by Hacknet Nodes by 15%.<br>" +
-             "Decreases the cost of purchasing a Hacknet Node by 15%.",
+             "Increases money produced from Hacknet Nodes by 15%.<br>" +
+             "Decreases the purchase cost of Hacknet Nodes by 15%.",
          hacknet_node_money_mult: 1.15,
          hacknet_node_purchase_cost_mult: 0.85,
     });
@@ -1022,9 +1021,8 @@ function initAugmentations() {
         info:"Uploads the architecture and design details of a Hacknet Node's main-memory cache " +
              "into the brain. This allows the user to engineer custom cache hardware for the  " +
              "Hacknet Node that offers better performance.<br><br>" +
-             "This augmentation:<br> " +
-             "Increases the amount of money produced by Hacknet Nodes by 10%.<br>" +
-             "Decreases the cost of leveling up a Hacknet Node by 15%.",
+             "Increases money produced from Hacknet Nodes by 10%.<br>" +
+             "Decreases the purchase cost of Hacknet Nodes by 15%.",
         hacknet_node_money_mult: 1.10,
         hacknet_node_level_cost_mult: 0.85,
     });
@@ -1039,9 +1037,8 @@ function initAugmentations() {
         info:"Uploads the architecture and design details of a Hacknet Node's Network Interface Card (NIC) " +
              "into the brain. This allows the user to engineer a custom NIC for the Hacknet Node that " +
              "offers better performance.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the amount of money produced by Hacknet Nodes by 10%.<br>" +
-             "Decreases the cost of purchasing a Hacknet Node by 10%.",
+             "Increases money produced from Hacknet Nodes by 10%.<br>" +
+             "Decreases the purchase cost of Hacknet Nodes by 10%.",
         hacknet_node_money_mult: 1.1,
         hacknet_node_purchase_cost_mult: 0.9,
     });
@@ -1056,7 +1053,7 @@ function initAugmentations() {
         info:"Installs a Direct-Neural Interface jack into the arm that is capable of connecting to a " +
              "Hacknet Node. This lets the user access and manipulate the Node's kernel using " +
              "electrochemical signals.<br><br>" +
-             "This augmentation increases the amount of money produced by Hacknet Nodes by 25%.",
+             "Increases money produced from Hacknet Nodes by 25%.",
         hacknet_node_money_mult: 1.25,
     });
     HacknetNodeKernelDNI.addToFactions(["Netburners"]);
@@ -1070,7 +1067,7 @@ function initAugmentations() {
         info:"Installs a Direct-Neural Interface jack into the arm that is capable of connecting " +
              "to a Hacknet Node. This lets the user access and manipulate the Node's processing logic using " +
              "electrochemical signals.<br><br>" +
-             "This augmentation increases the amount of money produced by Hacknet Nodes by 45%.",
+             "Increases money produced from Hacknet Nodes by 45%.",
         hacknet_node_money_mult: 1.45,
     });
     HacknetNodeCoreDNI.addToFactions(["Netburners"]);
@@ -1086,8 +1083,7 @@ function initAugmentations() {
              "monitors and regulates nervous impulses coming to and from the spinal column, " +
              "essentially 'governing' the body. By doing so, it improves the functionality of the " +
              "body's nervous system.<br><br>" +
-             "This is a special augmentation because it can be leveled up infinitely. Each level of this augmentation " +
-             "increases ALL of the player's multipliers by 1%.",
+             "Each level increases all multipliers by 1%.",
         hacking_chance_mult: 1.01,
         hacking_speed_mult: 1.01,
         hacking_money_mult: 1.01,
@@ -1148,7 +1144,7 @@ function initAugmentations() {
              "installed by releasing millions of nanobots into the human brain, each of which " +
              "attaches to a different neural pathway to enhance the brain's ability to retain " +
              "and retrieve information.<br><br>" +
-             "This augmentation increases the player's experience gain rate for all stats by 10%.",
+             "Increases experience gain for all stats by 10%.",
         hacking_exp_mult: 1.1,
         strength_exp_mult: 1.1,
         defense_exp_mult: 1.1,
@@ -1167,7 +1163,7 @@ function initAugmentations() {
         info:"A decentralized cranial implant that improves the brain's ability to learn. This " +
              "is a more powerful version of the Neurotrainer I augmentation, but it does not " +
              "require Neurotrainer I to be installed as a prerequisite.<br><br>" +
-             "This augmentation increases the player's experience gain rate for all stats by 15%.",
+             "Increases experience gain for all stats by 15%.",
         hacking_exp_mult: 1.15,
         strength_exp_mult: 1.15,
         defense_exp_mult: 1.15,
@@ -1186,7 +1182,7 @@ function initAugmentations() {
         info:"A decentralized cranial implant that improves the brain's ability to learn. This " +
              "is a more powerful version of the Neurotrainer I and Neurotrainer II augmentation, " +
              "but it does not require either of them to be installed as a prerequisite.<br><br>" +
-             "This augmentation increases the player's experience gain rate for all stats by 20%.",
+             "Increases experience gain for all stats by 20%.",
         hacking_exp_mult: 1.2,
         strength_exp_mult: 1.2,
         defense_exp_mult: 1.2,
@@ -1205,10 +1201,9 @@ function initAugmentations() {
         info:"A bionic eye implant that grants sight capabilities far beyond those of a natural human. " +
              "Embedded circuitry within the implant provides the ability to detect heat and movement " +
              "through solid objects such as walls, thus providing 'x-ray vision'-like capabilities.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's dexterity by 40%.<br>" +
-             "Increases the player's hacking speed by 3%.<br>" +
-             "Increases the amount of money the player gains from hacking by 10%.",
+             "Increases Dexterity by 40%.<br>" +
+             "Increases Hacking speed by 3%.<br>" +
+             "Increases money gained from Hacking by 10%.",
         dexterity_mult: 1.4,
         hacking_speed_mult: 1.03,
         hacking_money_mult: 1.1,
@@ -1224,9 +1219,8 @@ function initAugmentations() {
         info:"A skin implant that reinforces the skin with highly-advanced synthetic cells. These " +
              "cells, when powered, have a negative refractive index. As a result, they bend light " +
              "around the skin, making the user much harder to see to the naked eye.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's agility by 5%.<br>" +
-             "Increases the amount of money the player gains from crimes by 10%.",
+             "Increases Agility by 5%.<br>" +
+             "Increases money gained from committing crimes by 10%.",
         agility_mult: 1.05,
         crime_money_mult: 1.1,
     });
@@ -1241,11 +1235,10 @@ function initAugmentations() {
         info:"This is a more advanced version of the LuminCloaking-V2 augmentation. This skin implant " +
              "reinforces the skin with highly-advanced synthetic cells. These " +
              "cells, when powered, are capable of not only bending light but also of bending heat, " +
-             "making the user more resilient as well as stealthy.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's agility by 10%.<br>" +
-             "Increases the player's defense by 10%.<br>" +
-             "Increases the amount of money the player gains from crimes by 25%.",
+             "making the user more resilient as well as stealthy.<br><br>" ++
+             "Increases Agility by 10%.<br>" +
+             "Increases Defense by 10%.<br>" +
+             "Increases money gained from committing crimes by 25%.",
 	    prereqs:[AugmentationNames.LuminCloaking1],
         agility_mult: 1.1,
         defense_mult: 1.1,
@@ -1261,10 +1254,9 @@ function initAugmentations() {
         name:AugmentationNames.SmartSonar, repCost:2.25e4, moneyCost:7.5e7,
         info:"A cochlear implant that helps the player detect and locate enemies " +
              "using sound propagation.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's dexterity by 10%.<br>" +
-             "Increases the player's dexterity experience gain rate by 15%.<br>" +
-             "Increases the amount of money the player gains from crimes by 25%.",
+             "Increases Dexterity by 10%.<br>" +
+             "Increases Dexterity experience gain by 15%.<br>" +
+             "Increases money gained from committing crimes by 25%.",
         dexterity_mult: 1.1,
         dexterity_exp_mult: 1.15,
         crime_money_mult: 1.25,
@@ -1280,9 +1272,8 @@ function initAugmentations() {
         info:"The body's nerves are attached with polypyrrole nanocircuits that " +
              "are capable of capturing wasted energy, in the form of heat, " +
              "and converting it back into usable power.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases all of the player's stats by 5%.<br>" +
-             "Increases the player's experience gain rate for all stats by 10%.",
+             "Increases all stats by 5%.<br>" +
+             "Increases experience gain for all stats by 10%.",
         hacking_mult: 1.05,
         strength_mult: 1.05,
         defense_mult: 1.05,
@@ -1313,11 +1304,10 @@ function initAugmentations() {
         info:"A brain implant that wirelessly connects you to the Illuminati's " +
              "quantum supercomputer, allowing you to access and use its incredible " +
              "computing power.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking skill by 75%.<br>" +
-             "Increases the player's hacking speed by 100%.<br>" +
-             "Increases the player's chance of successfully performing a hack by 150%.<br>" +
-             "Increases the amount of money the player gains from hacking by 300%.",
+             "Increases Hacking by 75%.<br>" +
+             "Increases Hacking speed by 100%.<br>" +
+             "Increases Hacking success chance by 150%.<br>" +
+             "Increases money gained from Hacking by 300%.",
         hacking_mult: 1.75,
         hacking_speed_mult: 2,
         hacking_chance_mult: 2.5,
@@ -1347,9 +1337,8 @@ function initAugmentations() {
              "artificially-synthesized gene that was developed by DARPA to create " +
              "super-soldiers through genetic modification. The gene was outlawed in " +
              "2056.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases all of the player's combat stats by 75%.<br>" +
-             "Increases the player's hacking skill by 15%.",
+             "Increases all combat stats by 75%.<br>" +
+             "Increases Hacking by 15%.",
         strength_mult: 1.75,
         defense_mult: 1.75,
         dexterity_mult: 1.75,
@@ -1383,9 +1372,8 @@ function initAugmentations() {
              "to hold and sustain hydrogen plasma. The plasma is used to generate " +
              "fusion power through nuclear fusion, providing limitless amounts of clean " +
              "energy for the body.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases all of the player's combat stats by 35%.<br>" +
-             "Increases all of the player's combat stat experience gain rate by 35%.",
+             "Increases all combat stats by 35%.<br>" +
+             "Increases experience gain for all combat stats by 35%.",
         strength_mult: 1.35,
         defense_mult: 1.35,
         dexterity_mult: 1.35,
@@ -1407,11 +1395,9 @@ function initAugmentations() {
         info:"A bionic jaw that contains advanced hardware and software " +
              "capable of psychoanalyzing and profiling the personality of " +
              "others using optical imaging software.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's charisma by 50%.<br>" +
-             "Increases the player's charisma experience gain rate by 50%.<br>" +
-             "Increases the amount of reputation the player gains for a company by 25%.<br>" +
-             "Increases the amount of reputation the player gains for a faction by 25%.",
+             "Increases Charisma by 50%.<br>" +
+             "Increases Charisma experience gain by 50%.<br>" +
+             "Increases reputation gain from factions and companies by 25%.",
         charisma_mult: 1.5,
         charisma_exp_mult: 1.5,
         company_rep_mult: 1.25,
@@ -1430,7 +1416,8 @@ function initAugmentations() {
              "and integumentary system. The drug permanently modifies the DNA of the " +
              "body's skin and bone cells, granting them the ability to repair " +
              "and restructure themselves.<br><br>" +
-             "This augmentation increases the player's strength and defense by 55%.",
+             "Increases Strength by 55%.<br>" +
+             "Increases Defense by 55%.",
         strength_mult: 1.55,
         defense_mult: 1.55,
     });
@@ -1446,9 +1433,8 @@ function initAugmentations() {
         info:"A concoction of advanced nanobots that is orally ingested into the " +
              "body. These nanobots induce physiological changes and significantly " +
              "improve the body's functioning in all aspects.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases all of the player's stats by 20%.<br>" +
-             "Increases the player's experience gain rate for all stats by 15%.",
+             "Increases all stats by 20%.<br>" +
+             "Increases experience gain for all stats by 15%.",
         hacking_mult: 1.2,
         strength_mult: 1.2,
         defense_mult: 1.2,
@@ -1475,7 +1461,7 @@ function initAugmentations() {
              "Even though it contains no weapons, the advanced tungsten titanium " +
              "alloy increases the users strength to unbelievable levels. The augmentation " +
              "gets more powerful over time for seemingly no reason.<br><br>" +
-             "This augmentation increases the player's strength by 270%.",
+             "Increases Strength by 270%.",
         strength_mult: 2.70,
     });
     HydroflameLeftArm.addToFactions(["NWO"]);
@@ -1492,7 +1478,7 @@ function initAugmentations() {
         info:"The body is genetically re-engineered to maintain a state " +
              "of negligible senescence, preventing the body from " +
              "deteriorating with age.<br><br>" +
-             "This augmentation increases all of the player's stats by 20%.",
+             "Increases all stats by 20%.",
         hacking_mult: 1.2,
         strength_mult: 1.2,
         defense_mult: 1.2,
@@ -1512,9 +1498,8 @@ function initAugmentations() {
         info:"OmniTek's data and information repository is uploaded " +
              "into your brain, enhancing your programming and " +
              "hacking abilities.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking skill by 20%.<br>" +
-             "Increases the player's hacking experience gain rate by 25%.",
+             "Increases Hacking by 20%.<br>" +
+             "Increases Hacking experience gain by 25%.",
         hacking_mult: 1.2,
         hacking_exp_mult: 1.25,
     });
@@ -1534,7 +1519,9 @@ function initAugmentations() {
              "to the body using a skin graft. The result is photosynthetic " +
              "skin cells, allowing users to generate their own energy " +
              "and nutrition using solar power.<br><br>" +
-             "This augmentation increases the player's strength, defense, and agility by 40%.",
+             "Increases Strength by 40%.<br>" +
+             "Increases Defense by 40%.<br>" +
+             "Increases Agility by 40%.",
             strength_mult: 1.4,
             defense_mult: 1.4,
             agility_mult: 1.4,
@@ -1551,12 +1538,11 @@ function initAugmentations() {
         info:"A brain implant that provides a high-bandwidth, direct neural link between your " +
              "mind and the BitRunners' data servers, which reportedly contain " +
              "the largest database of hacking tools and information in the world.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking skill by 15%.<br>" +
-             "Increases the player's hacking experience gain rate by 20%.<br>" +
-             "Increases the player's chance of successfully performing a hack by 10%.<br>" +
-             "Increases the player's hacking speed by 5%.<br>" +
-             "Lets the player start with the FTPCrack.exe and relaySMTP.exe programs after a reset.",
+             "Increases Hacking by 15%.<br>" +
+             "Increases Hacking experience gain by 20%.<br>" +
+             "Increases Hacking success chance by 10%.<br>" +
+             "Increases Hacking speed by 5%.<br>" +
+             "Provides FTPCrack.exe and relaySMTP.exe after a reset.",
         hacking_mult: 1.15,
         hacking_exp_mult: 1.2,
         hacking_chance_mult: 1.1,
@@ -1575,11 +1561,11 @@ function initAugmentations() {
              "enhances strength and dexterity but it is also embedded " +
              "with hardware and firmware that lets the user connect to, access, and hack " +
              "devices and machines by just touching them.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's strength and dexterity by 15%.<br>" +
-             "Increases the player's hacking skill by 10%.<br>" +
-             "Increases the player's hacking speed by 2%.<br>" +
-             "Increases the amount of money the player gains from hacking by 10%.",
+             "Increases Strength by 15%.<br>" +
+             "Increases Dexterity by 15%.<br>" +
+             "Increases Hacking by 10%.<br>" +
+             "Increases Hacking speed by 2%.<br>" +
+             "Increases money gained from Hacking by 10%.",
         strength_mult: 1.15,
         dexterity_mult: 1.15,
         hacking_mult: 1.1,
@@ -1598,9 +1584,8 @@ function initAugmentations() {
         info:"The CRTX42-AA gene is injected into the genome. " +
              "The CRTX42-AA is an artificially-synthesized gene that targets the visual and prefrontal " +
              "cortex and improves cognitive abilities.<br><br>" +
-             "This augmentation:<br>" +
-             "Improves the player's hacking skill by 8%.<br>" +
-             "Improves the player's hacking experience gain rate by 15%.",
+             "Increases Hacking by 8%.<br>" +
+             "Increases Hacking experience gain by 15%.",
         hacking_mult: 1.08,
         hacking_exp_mult: 1.15,
     });
@@ -1616,7 +1601,7 @@ function initAugmentations() {
         info:"A drug that genetically modifies the neurons in the brain " +
              "resulting in neurons never die, continuously " +
              "regenerate, and strengthen themselves.<br><br>" +
-             "This augmentation increases the player's hacking experience gain rate by 40%.",
+             "Increases Hacking experience gain by 40%.",
         hacking_exp_mult: 1.4,
     });
     Neuregen.addToFactions(["Chongqing"]);
@@ -1631,9 +1616,8 @@ function initAugmentations() {
         info:<>A collection of digital assets saved on a small chip. The chip is implanted 
              into your wrist. A small jack in the chip allows you to connect it to a computer 
              and upload the assets.<br /><br />
-             This augmentation:<br />
-             Lets the player start with {Money(1e6)} after a reset.<br />
-             Lets the player start with the BruteSSH.exe program after a reset.</>,
+             Provides {Money(1e6)} after a reset.<br />
+             Provides BruteSSH.exe after a reset.</>,
     });
     CashRoot.addToFactions(["Sector-12"]);
     if (augmentationExists(AugmentationNames.CashRoot)) {
@@ -1648,7 +1632,7 @@ function initAugmentations() {
              "synthesizes glucose, amino acids, and vitamins and redistributes them " +
              "across the body. The device is powered by the body's naturally wasted " +
              "energy in the form of heat.<br><br>" +
-             "This augmentation increases the player's experience gain rate for all combat stats by 20%.",
+             "Increases experience gain for all combat stats by 20%.",
         strength_exp_mult: 1.2,
         defense_exp_mult: 1.2,
         dexterity_exp_mult: 1.2,
@@ -1669,10 +1653,9 @@ function initAugmentations() {
         name:AugmentationNames.INFRARet, repCost:7.5e3, moneyCost:3e7,
         info:"A tiny chip that sits behind the retinae. This implant lets the" +
              "user visually detect infrared radiation.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's crime success rate by 25%.<br>" +
-             "Increases the amount of money the player gains from crimes by 10%.<br>" +
-             "Increases the player's dexterity by 10%.",
+             "Increases crime success rate by 25%.<br>" +
+             "Increases money gained from committing crimes by 10%.<br>" +
+             "Increases Dexterity by 10%.",
         crime_success_mult: 1.25,
         crime_money_mult: 1.1,
         dexterity_mult: 1.1,

--- a/src/Augmentation/AugmentationHelpers.jsx
+++ b/src/Augmentation/AugmentationHelpers.jsx
@@ -38,9 +38,9 @@ function getRandomBonus() {
                 hacking_money_mult: 1.25,
                 hacking_grow_mult: 1.1,
             },
-            description: "Increases the player's hacking chance by 25%.<br>" +
-                         "Increases the player's hacking speed by 10%.<br>" +
-                         "Increases the amount of money the player's gains from hacking by 25%.<br>" +
+            description: "Increases Hacking success chance by 25%.<br>" +
+                         "Increases Hacking speed by 10%.<br>" +
+                         "Increases money gained from Hacking by 25%.<br>" +
                          "Improves grow() by 10%.",
         },
         {
@@ -48,8 +48,8 @@ function getRandomBonus() {
                 hacking_mult: 1.15,
                 hacking_exp_mult: 2,
             },
-            description: "Increases the player's hacking skill by 15%.<br>" +
-                         "Increases the player's hacking experience gain rate by 100%.",
+            description: "Increases Hacking by 15%.<br>" +
+                         "Increases Hacking experience gain by 100%.",
         },
         {
             bonuses: {
@@ -62,16 +62,16 @@ function getRandomBonus() {
                 agility_mult: 1.25,
                 agility_exp_mult: 2,
             },
-            description: "Increases all of the player's combat stats by 25%.<br>" +
-                         "Increases all of the player's combat stat experience gain rate by 100%.",
+            description: "Increases all combat stats by 25%.<br>" +
+                         "Increases experience gain for all combat stats by 100%.",
         },
         {
             bonuses: {
                 charisma_mult: 1.5,
                 charisma_exp_mult: 2,
             },
-            description: "This augmentation increases the player's charisma by 50%.<br>" +
-                         "Increases the player's charisma experience gain rate by 100%.",
+            description: "Increases Charisma by 50%.<br>" +
+                         "Increases Charisma experience gain by 100%.",
         },
         {
             bonuses: {
@@ -81,8 +81,8 @@ function getRandomBonus() {
                 hacknet_node_core_cost_mult: 0.85,
                 hacknet_node_level_cost_mult: 0.85,
             },
-            description: "Increases the amount of money produced by Hacknet Nodes by 20%.<br>" +
-                         "Decreases all costs related to Hacknet Node by 15%.",
+            description: "Increases money produced from Hacknet Nodes by 20%.<br>" +
+                         "Decreases all costs related to Hacknet Nodes by 15%.",
         },
         {
             bonuses: {
@@ -90,17 +90,17 @@ function getRandomBonus() {
                 faction_rep_mult: 1.15,
                 work_money_mult: 1.7,
             },
-            description: "Increases the amount of money the player gains from working by 70%.<br>" +
-                         "Increases the amount of reputation the player gains when working for a company by 25%.<br>" +
-                         "Increases the amount of reputation the player gains for a faction by 15%.",
+            description: "Increases money gained from working by 70%.<br>" +
+                         "Increases reputation gain from companies by 25%.<br>" +
+                         "Increases reputation gain from factions by 15%.",
         },
         {
             bonuses: {
                 crime_success_mult: 2,
                 crime_money_mult: 2,
             },
-            description: "Increases the player's crime success rate by 100%.<br>" +
-                         "Increases the amount of money the player gains from crimes by 100%.",
+            description: "Increases crime success rate by 100%.<br>" +
+                         "Increases money gained from committing crimes by 100%.",
         },
     ]
     
@@ -139,12 +139,12 @@ function initAugmentations() {
     }
     AddToAugmentations(UnstableCircadianModulator);
 
-    //Combat stat augmentations
+    //Combat Augmentations
     const HemoRecirculator = new Augmentation({
         name:AugmentationNames.HemoRecirculator, moneyCost:4.5e7, repCost:1e4,
         info:"A heart implant that greatly increases the body's ability to effectively use and pump " +
              "blood.<br><br>" +
-             "This augmentation increases all of the player's combat stats by 8%.",
+             "Increases all combat stats by 8%.",
         strength_mult: 1.08,
         defense_mult: 1.08,
         agility_mult: 1.08,
@@ -160,7 +160,7 @@ function initAugmentations() {
         name:AugmentationNames.Targeting1, moneyCost:1.5e7, repCost:5e3,
         info:"A cranial implant that is embedded within the inner ear structures and optic nerves. It regulates " +
              "and enhances balance and hand-eye coordination.<br><br>" +
-             "This augmentation increases the player's dexterity by 10%.",
+             "Increases Dexterity by 10%.",
         dexterity_mult: 1.1,
     });
     Targeting1.addToFactions(["Slum Snakes", "The Dark Army", "The Syndicate", "Sector-12", "Ishima",
@@ -174,7 +174,7 @@ function initAugmentations() {
         name:AugmentationNames.Targeting2, moneyCost:4.25e7, repCost:8.75e3,
         info:"This upgraded version of the 'Augmented Targeting' implant is capable of augmenting " +
              "reality by digitally displaying weaknesses and vital signs of threats.<br><br>" +
-             "This augmentation increases the player's dexterity by 20%.",
+             "Increases Dexterity by 20%.",
         prereqs:[AugmentationNames.Targeting1],
         dexterity_mult: 1.2,
     });
@@ -189,7 +189,7 @@ function initAugmentations() {
         name:AugmentationNames.Targeting3, moneyCost:1.15e8, repCost:2.75e4,
         info:"The latest version of the 'Augmented Targeting' implant adds the ability to " +
              "lock-on and track threats.<br><br>" +
-             "This augmentation increases the player's dexterity by 30%.",
+             "Increases Dexterity by 30%.",
         prereqs:[AugmentationNames.Targeting2],
         dexterity_mult: 1.3,
     });
@@ -204,7 +204,8 @@ function initAugmentations() {
         name:AugmentationNames.SyntheticHeart, moneyCost:2.875e9, repCost:7.5e5,
         info:"This advanced artificial heart, created from plasteel and graphene, is capable of pumping blood " +
              "more efficiently than an organic heart.<br><br>" +
-             "This augmentation increases the player's agility and strength by 50%.",
+             "Increases Strength by 50%.<br>" +
+             "Increases Agility by 50%.",
         agility_mult: 1.5,
         strength_mult: 1.5,
     });
@@ -220,7 +221,8 @@ function initAugmentations() {
         info:"The myofibrils in human muscles are injected with special chemicals that react with the proteins inside " +
              "the myofibrils, altering their underlying structure. The end result is muscles that are stronger and more elastic. " +
              "Scientists have named these artificially enhanced units 'synfibrils'.<br><br>" +
-             "This augmentation increases the player's strength and defense by 30%.",
+             "Increases Strength by 30%.<br>" +
+             "Increases Agility by 30%.",
         strength_mult: 1.3,
         defense_mult: 1.3,
     });
@@ -235,7 +237,8 @@ function initAugmentations() {
         name:AugmentationNames.CombatRib1, repCost:7.5e3, moneyCost:2.375e7,
         info:"The rib cage is augmented to continuously release boosters into the bloodstream " +
              "which increase the oxygen-carrying capacity of blood.<br><br>" +
-             "This augmentation increases the player's strength and defense by 10%.",
+             "Increases Strength by 10%.<br>" +
+             "Increases Defense by 10%.",
         strength_mult: 1.1,
         defense_mult: 1.1,
     });
@@ -250,7 +253,8 @@ function initAugmentations() {
         name:AugmentationNames.CombatRib2, repCost:1.875e4, moneyCost:6.5e7,
         info:"An upgraded version of the 'Combat Rib' augmentation that adds potent stimulants which " +
              "improve focus and endurance while decreasing reaction time and fatigue.<br><br>" +
-             "This augmentation increases the player's strength and defense by 14%.",
+             "Increases Strength by 14%.<br>" +
+             "Increases Defense by 14%.",
         prereqs:[AugmentationNames.CombatRib1],
         strength_mult: 1.14,
         defense_mult: 1.14,
@@ -266,7 +270,8 @@ function initAugmentations() {
         name:AugmentationNames.CombatRib3, repCost:3.5e4, moneyCost:1.2e8,
         info:"The latest version of the 'Combat Rib' augmentation releases advanced anabolic steroids that " +
              "improve muscle mass and physical performance while being safe and free of side effects.<br><br>" +
-             "This augmentation increases the player's strength and defense by 18%.",
+             "Increases Strength by 18%.<br>" +
+             "Increases Defense by 18%.",
         prereqs:[AugmentationNames.CombatRib2],
         strength_mult: 1.18,
         defense_mult: 1.18,
@@ -282,7 +287,8 @@ function initAugmentations() {
         name:AugmentationNames.NanofiberWeave, repCost:3.75e4, moneyCost:1.25e8,
         info:"Synthetic nanofibers are woven into the skin's extracellular matrix using electrospinning. " +
              "This improves the skin's ability to regenerate itself and protect the body from external stresses and forces.<br><br>" +
-             "This augmentation increases the player's strength and defense by 20%.",
+             "Increases Strength by 20%.<br>" +
+             "Increases Defense by 20%.",
         strength_mult: 1.2,
         defense_mult: 1.2,
     });
@@ -300,7 +306,7 @@ function initAugmentations() {
              "that has ever been created. The dilatant fluid, despite being thin and light, is extremely effective " +
              "at stopping piercing blows and reducing blunt trauma. The properties of graphene allow the plating to " +
              "mitigate damage from any fire or electrical traumas.<br><br>" +
-             "This augmentation increases the player's defense by 120%.",
+             "Increases Defense by 120%.",
         defense_mult: 2.2,
     });
     SubdermalArmor.addToFactions(["The Syndicate", "Fulcrum Secret Technologies", "Illuminati", "Daedalus",
@@ -314,7 +320,8 @@ function initAugmentations() {
         name:AugmentationNames.WiredReflexes, repCost:1.25e3, moneyCost:2.5e6,
         info:"Synthetic nerve-enhancements are injected into all major parts of the somatic nervous system, " +
              "supercharging the body's ability to send signals through neurons. This results in increased reflex speed.<br><br>" +
-             "This augmentation increases the player's agility and dexterity by 5%.",
+             "Increases Dexterity by 5%.<br>" +
+             "Increases Agility by 5%.",
         agility_mult: 1.05,
         dexterity_mult: 1.05,
     });
@@ -329,7 +336,8 @@ function initAugmentations() {
         name:AugmentationNames.GrapheneBoneLacings, repCost:1.125e6, moneyCost:4.25e9,
         info:"A graphene-based material is grafted and fused into the user's bones, significantly increasing " +
              "their density and tensile strength.<br><br>" +
-             "This augmentation increases the player's strength and defense by 70%.",
+             "Increases Strength by 70%.<br>" +
+             "Increases Defense by 70%.",
         strength_mult: 1.7,
         defense_mult: 1.7,
     });
@@ -345,7 +353,7 @@ function initAugmentations() {
              "Not only is the Bionic Spine physically stronger than a human spine, but it is also capable of digitally " +
              "stimulating and regulating the neural signals that are sent and received by the spinal cord. This results in " +
              "greatly improved senses and reaction speeds.<br><br>" +
-             "This augmentation increases all of the player's combat stats by 15%.",
+             "Increases all combat stats by 15%.",
         strength_mult: 1.15,
         defense_mult: 1.15,
         agility_mult: 1.15,
@@ -362,7 +370,7 @@ function initAugmentations() {
         name:AugmentationNames.GrapheneBionicSpine, repCost:1.625e6, moneyCost:6e9,
         info:"An upgrade to the Bionic Spine augmentation. It fuses the implant with an advanced graphene " +
              "material to make it much stronger and lighter.<br><br>" +
-             "This augmentation increases all of the player's combat stats by 60%.",
+             "Increases all combat stats by 60%.",
         prereqs:[AugmentationNames.BionicSpine],
         strength_mult: 1.6,
         defense_mult: 1.6,
@@ -378,7 +386,7 @@ function initAugmentations() {
     const BionicLegs = new Augmentation({
         name:AugmentationNames.BionicLegs, repCost:1.5e5, moneyCost:3.75e8,
         info:"Cybernetic legs created from plasteel and carbon fibers that completely replace the user's organic legs.<br><br>" +
-             "This augmentation increases the player's agility by 60%.",
+             "Increases Agility by 60%.",
         agility_mult: 1.6,
     });
     BionicLegs.addToFactions(["Speakers for the Dead", "The Syndicate", "KuaiGong International",
@@ -392,7 +400,7 @@ function initAugmentations() {
         name:AugmentationNames.GrapheneBionicLegs, repCost:7.5e5, moneyCost:4.5e9,
         info:"An upgrade to the Bionic Legs augmentation. It fuses the implant with an advanced graphene " +
              "material to make it much stronger and lighter.<br><br>" +
-             "This augmentation increases the player's agility by 150%.",
+             "Increases Agility by 150%.",
         prereqs: [AugmentationNames.BionicLegs],
         agility_mult: 2.5,
     });
@@ -402,13 +410,13 @@ function initAugmentations() {
     }
     AddToAugmentations(GrapheneBionicLegs);
 
-    // Work stat augmentations
+    //Charisma Augmentations
     const SpeechProcessor = new Augmentation({
         name:AugmentationNames.SpeechProcessor, repCost:7.5e3, moneyCost:5e7,
         info:"A cochlear implant with an embedded computer that analyzes incoming speech. " +
              "The embedded computer processes characteristics of incoming speech, such as tone " +
              "and inflection, to pick up on subtle cues and aid in social interactions.<br><br>" +
-             "This augmentation increases the player's charisma by 20%.",
+             "Increases Charisma by 20%.",
         charisma_mult: 1.2,
     });
     SpeechProcessor.addToFactions(["Tian Di Hui", "Chongqing", "Sector-12", "New Tokyo", "Aevum",
@@ -423,7 +431,8 @@ function initAugmentations() {
         info:"TITN is a series of viruses that targets and alters the sequences of human DNA in genes that " +
              "control personality. The TITN-41 strain alters these genes so that the subject becomes more " +
              "outgoing and socialable.<br><br>" +
-             "This augmentation increases the player's charisma and charisma experience gain rate by 15%.",
+             "Increases Charisma by 15%.<br>" +
+             "Increases Charisma experience gain by 15%.",
         charisma_mult: 1.15,
         charisma_exp_mult: 1.15,
     });
@@ -440,7 +449,8 @@ function initAugmentations() {
              "language, and the voice tone, and inflection to determine the best course of action during social" +
              "situations. The implant also uses deep learning software to continuously learn new behavior" +
              "patterns and how to best respond.<br><br>" +
-             "This augmentation increases the player's charisma and charisma experience gain rate by 60%.",
+             "Increases Charisma by 60%.<br>" +
+             "Increases Charisma experience gain by 60%.",
         charisma_mult: 1.6,
         charisma_exp_mult: 1.6,
     });
@@ -451,7 +461,7 @@ function initAugmentations() {
     }
     AddToAugmentations(EnhancedSocialInteractionImplant);
 
-    // Hacking augmentations
+    //Hacking Augmentations
     const BitWire = new Augmentation({
         name:AugmentationNames.BitWire, repCost:3.75e3, moneyCost:1e7,
         info: "A small brain implant embedded in the cerebrum. This regulates and improves the brain's computing " +

--- a/src/Augmentation/AugmentationHelpers.jsx
+++ b/src/Augmentation/AugmentationHelpers.jsx
@@ -1672,7 +1672,7 @@ function initAugmentations() {
         info:"Synthetic skin that is grafted onto the body. This skin consists of " +
              "millions of nanobots capable of projecting high-density muon beams, " +
              "creating an energy barrier around the user.<br><br>" +
-             "This augmentation increases the player's defense by 40%.",
+             "Increases Defense by 40%.",
         defense_mult: 1.4,
     });
     DermaForce.addToFactions(["Volhaven"]);
@@ -1687,10 +1687,10 @@ function initAugmentations() {
         info:"An upgrade to the BrachiBlades augmentation. It infuses " +
              "the retractable blades with an advanced graphene material " +
              "making them stronger and lighter.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's strength and defense by 40%.<br>" +
-             "Increases the player's crime success rate by 10%.<br>" +
-             "Increases the amount of money the player gains from crimes by 30%.",
+             "Increases Strength by 40%.<br>" +
+             "Increases Defense by 40%.<br>" +
+             "Increases crime success rate by 10%.<br>" +
+             "Increases money gained from committing crimes by 30%.",
         prereqs:[AugmentationNames.BrachiBlades],
         strength_mult: 1.4,
         defense_mult: 1.4,
@@ -1709,7 +1709,8 @@ function initAugmentations() {
         info:"An upgrade to the Bionic Arms augmentation. It infuses the " +
              "prosthetic arms with an advanced graphene material " +
              "to make them stronger and lighter.<br><br>" +
-             "This augmentation increases the player's strength and dexterity by 85%.",
+             "Increases Strength by 85%.<br>" +
+             "Increases Dexterity by 85%.",
         prereqs:[AugmentationNames.BionicArms],
         strength_mult: 1.85,
         dexterity_mult: 1.85,
@@ -1724,10 +1725,10 @@ function initAugmentations() {
     const BrachiBlades = new Augmentation({
         name:AugmentationNames.BrachiBlades, repCost:1.25e4, moneyCost:9e7,
         info:"A set of retractable plasteel blades that are implanted in the arm, underneath the skin.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's strength and defense by 15%.<br>" +
-             "Increases the player's crime success rate by 10%.<br>" +
-             "Increases the amount of money the player gains from crimes by 15%.",
+             "Increases Strength by 15%.<br>" +
+             "Increases Defense by 15%.<br>" +
+             "Increases crime success rate by 10%.<br>" +
+             "Increases money gained from committing crimes by 15%.",
         strength_mult: 1.15,
         defense_mult: 1.15,
         crime_success_mult: 1.1,
@@ -1744,7 +1745,8 @@ function initAugmentations() {
         name:AugmentationNames.BionicArms, repCost:6.25e4, moneyCost:2.75e8,
         info:"Cybernetic arms created from plasteel and carbon fibers that completely replace " +
              "the user's organic arms.<br><br>" +
-             "This augmentation increases the user's strength and dexterity by 30%.",
+             "Increases Strength by 30%.<br>" +
+             "Increases Dexterity by 30%.",
         strength_mult: 1.3,
         dexterity_mult: 1.3,
     });
@@ -1759,10 +1761,8 @@ function initAugmentations() {
         name:AugmentationNames.SNA, repCost:6.25e3, moneyCost:3e7,
         info:"A cranial implant that affects the user's personality, making them better " +
              "at negotiation in social situations.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the amount of money the player earns at a company by 10%.<br>" +
-             "Increases the amount of reputation the player gains when working for a " +
-             "company or faction by 15%.",
+             "Increases money gained from working by 10%.<br>" +
+             "Increases reputation gain from factions and companies by 15%.",
         work_money_mult: 1.1,
         company_rep_mult: 1.15,
         faction_rep_mult: 1.15,
@@ -1786,9 +1786,8 @@ function initAugmentations() {
                  "against debris, shrapnel, lasers, blinding flashes, and gas. It is also " +
                  "embedded with a data processing chip that can be programmed to display an " +
                  "AR HUD to assist the user in field missions.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 3%.<br>" +
-                 "Increases the player's dexterity by 5%.",
+                 "Increases Dexterity by 5%.<br>" +
+                 "Increases success chance in Bladeburner Contracts and Operations by 3%.",
             bladeburner_success_chance_mult: 1.03,
             dexterity_mult: 1.05,
             isSpecial: true,
@@ -1802,10 +1801,9 @@ function initAugmentations() {
                  "technique was originally used on Bladeburners during the Synthoid uprising " +
                  "to induce wakefulness and concentration, suppress fear, reduce empathy, " +
                  "improve reflexes, and improve memory among other things.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 3%.<br>" +
-                 "Increases the player's effectiveness in Bladeburner Field Analysis by 5%.<br>" +
-                 "Increases the player's Bladeburner stamina gain rate by 2%.",
+                 "Increases success chance in Bladeburner Contracts and Operations by 3%.<br>" +
+                 "Increases Bladeburner Field Analysis effectiveness by 5%.<br>" +
+                 "Increases Bladeburner Stamina gain by 2%.",
             bladeburner_success_chance_mult: 1.03,
             bladeburner_analysis_mult: 1.05,
             bladeburner_stamina_gain_mult: 1.02,
@@ -1820,10 +1818,10 @@ function initAugmentations() {
                  "the ORION-MKIV shoulder enhances the strength and dexterity " +
                  "of the user's right arm. It also provides protection due to its " +
                  "crystallized graphene plating.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's defense by 5%.<br>" +
-                 "Increases the player's strength and dexterity by 5%.<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 4%.",
+                 "Increases Strength by 5%.<br>" +
+                 "Increases Defense by 5%.<br>" +
+                 "Increases Dexterity by 5%.<br>" +
+                 "Increases success chance in Bladeburner Contracts and Operations by 4%.",
             defense_mult: 1.05,
             strength_mult: 1.05,
             dexterity_mult: 1.05,
@@ -1841,7 +1839,7 @@ function initAugmentations() {
                  "nature of the plasma disrupts the electrical systems of Augmentations. However, " +
                  "it can also be effective against non-augmented enemies due to its high temperature " +
                  "and concussive force.<br><br>" +
-                 "This augmentation increases the player's success chance in Bladeburner contracts/operations by 6%.",
+                 "Increases success chance in Bladeburner Contracts and Operations by 6%.",
             bladeburner_success_chance_mult: 1.06,
             isSpecial: true,
         });
@@ -1854,7 +1852,7 @@ function initAugmentations() {
                  "is more advanced and powerful than the original V1 model. This V2 model is " +
                  "more power-efficient, more accurate, and can fire plasma bolts at a much " +
                  "higher velocity than the V1 model.<br><br>" +
-                 "This augmentation increases the player's success chance in Bladeburner contracts/operations by 8%.",
+                 "Increases success chance in Bladeburner Contracts and Operations by 8%.",
             prereqs:[AugmentationNames.HyperionV1],
             bladeburner_success_chance_mult: 1.08,
             isSpecial: true,
@@ -1868,9 +1866,8 @@ function initAugmentations() {
                  "including strength, speed, immune system enhancements, and mitochondrial efficiency. The " +
                  "serum was originally developed by the Chinese military in an attempt to " +
                  "create super soldiers.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases all of the player's combat stats by 7%.<br>" +
-                 "Increases the player's Bladeburner stamina gain rate by 5%.<br>",
+                 "Increases all combat stats by 7%.<br>" +
+                 "Increases Bladeburner Stamina gain by 5%.<br>",
             strength_mult: 1.07,
             defense_mult: 1.07,
             dexterity_mult: 1.07,
@@ -1885,10 +1882,9 @@ function initAugmentations() {
             name:AugmentationNames.VangelisVirus, repCost:1.875e4, moneyCost:2.75e9,
             info:"A synthetic symbiotic virus that is injected into human brain tissue. The Vangelis virus " +
                  "heightens the senses and focus of its host, and also enhances its intuition.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's effectiveness in Bladeburner Field Analysis by 10%.<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 4%.<br>" +
-                 "Increases the player's dexterity experience gain rate by 10%.",
+                 "Increases Dexterity experience gain by 10%.<br>" +
+                 "Increases Bladeburner Field Analysis effectiveness by 10%.<br>" +
+                 "Increases success chance in Bladeburner Contracts and Operations by 4%.",
             dexterity_exp_mult: 1.1,
             bladeburner_analysis_mult: 1.1,
             bladeburner_success_chance_mult: 1.04,
@@ -1903,10 +1899,10 @@ function initAugmentations() {
                  "injected into human brain tissue. On top of the benefits of the original " +
                  "virus, this also grants an accelerated healing factor and enhanced " +
                  "reflexes.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's effectiveness in Bladeburner Field Analysis by 15%.<br>" +
-                 "Increases the player's defense and dexterity experience gain rate by 10%.<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 5%.",
+                 "Increases Defense experience gain by 10%.<br>" +
+                 "Increases Dexterity experience gain by 10%.<br>" +
+                 "Increases Bladeburner Field Analysis effectiveness by 15%.<br>" +
+                 "Increases success chance in Bladeburner Contracts and Operations by 5%.",
             prereqs:[AugmentationNames.VangelisVirus],
             defense_exp_mult: 1.1,
             dexterity_exp_mult: 1.1,
@@ -1923,9 +1919,8 @@ function initAugmentations() {
                  "extracellular matrix (ECM). This improves the ECM's ability to " +
                  "structurally support the body and grants heightened strength and " +
                  "durability.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's experience gain rate for all combat stats by 5%.<br>" +
-                 "Increases the player's Bladeburner max stamina by 10%.",
+                 "Increases experience gain for all combat stats by 5%.<br>" +
+                 "Increases Bladeburner Stamina by 10%.",
             strength_exp_mult: 1.05,
             defense_exp_mult: 1.05,
             dexterity_exp_mult: 1.05,
@@ -1942,10 +1937,9 @@ function initAugmentations() {
                  "during the Synthoid Uprising. The organic musculature of the human foot " +
                  "is enhanced with flexible carbon nanotube matrices that are controlled by " +
                  "intelligent servo-motors.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's agility by 5%.<br>" +
-                 "Increases the player's Bladeburner max stamina by 5%.<br>" +
-                 "Increases the player's Bladeburner stamina gain rate by 5%.<br>",
+                 "Increases Agility by 5%.<br>" +
+                 "Increases Bladeburner Stamina by 5%.<br>" +
+                 "Increases Bladeburner Stamina gain by 5%.<br>",
             agility_mult: 1.05,
             bladeburner_max_stamina_mult: 1.05,
             bladeburner_stamina_gain_mult: 1.05,
@@ -1960,10 +1954,9 @@ function initAugmentations() {
                  "exoskeleton is incredibly adaptable and can protect the wearer from blunt, piercing, " +
                  "concussive, thermal, chemical, and electric trauma. It also enhances the user's " +
                  "physical abilities.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases all of the player's combat stats by 4%.<br>" +
-                 "Increases the player's Bladeburner stamina gain rate by 2%.<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 3%.",
+                 "Increases all combat stats by 4%.<br>" +
+                 "Increases Bladeburner Stamina gain by 2%.<br>" +
+                 "Increases success chance in Bladeburner Contracts and Operations by 3%.",
             strength_mult: 1.04,
             defense_mult: 1.04,
             dexterity_mult: 1.04,
@@ -1979,10 +1972,9 @@ function initAugmentations() {
             name:AugmentationNames.BladeArmorPowerCells, repCost:1.875e4, moneyCost:2.75e9,
             info:"Upgrades the BLADE-51b Tesla Armor with Ion Power Cells, which are capable of " +
                  "more efficiently storing and using power.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 5%.<br>" +
-                 "Increases the player's Bladeburner stamina gain rate by 2%.<br>" +
-                 "Increases the player's Bladeburner max stamina by 5%.",
+                 "Increases success chance in Bladeburner Contracts and Operations by 5%.<br>" +
+                 "Increases Bladeburner Stamina by 5%.<br>" +
+                 "Increases Bladeburner Stamina gain by 2%.",
             prereqs:[AugmentationNames.BladeArmor],
             bladeburner_success_chance_mult: 1.05,
             bladeburner_stamina_gain_mult: 1.02,
@@ -1996,9 +1988,8 @@ function initAugmentations() {
             name:AugmentationNames.BladeArmorEnergyShielding, repCost:2.125e4, moneyCost:5.5e9,
             info:"Upgrades the BLADE-51b Tesla Armor with a plasma energy propulsion system " +
                  "that is capable of projecting an energy shielding force field.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's defense by 5%.<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 6%.",
+                 "Increases Defense by 5%.<br>" +
+                 "Increases success chance in Bladeburner Contracts and Operations by 6%.",
             prereqs:[AugmentationNames.BladeArmor],
             defense_mult: 1.05,
             bladeburner_success_chance_mult: 1.06,
@@ -2012,7 +2003,7 @@ function initAugmentations() {
             info:"Upgrades the BLADE-51b Tesla Armor with a concentrated deuterium-fluoride laser " +
                  "weapon. It's precision and accuracy makes it useful for quickly neutralizing " +
                  "threats while keeping casualties to a minimum.<br><br>" +
-                 "This augmentation increases the player's success chance in Bladeburner contracts/operations by 8%.",
+                 "Increases success chance in Bladeburner Contracts and Operations by 8%.",
             prereqs:[AugmentationNames.BladeArmor],
             bladeburner_success_chance_mult: 1.08,
             isSpecial: true,
@@ -2026,7 +2017,7 @@ function initAugmentations() {
                  "multiple-fiber system. This upgraded weapon uses multiple fiber laser " +
                  "modules that combine together to form a single, more powerful beam of up to " +
                  "2000MW.<br><br>" +
-                 "This augmentation increases the player's success chance in Bladeburner contracts/operations by 10%.",
+                 "Increases success chance in Bladeburner Contracts and Operations by 10%.",
             prereqs:[AugmentationNames.BladeArmorUnibeam],
             bladeburner_success_chance_mult: 1.1,
             isSpecial: true,
@@ -2039,9 +2030,8 @@ function initAugmentations() {
             info:"Upgrades the BLADE-51b Tesla Armor with an AI Information Processing " +
                  "Unit that was specially designed to analyze Synthoid related data and " +
                  "information.<br><br>" +
-                 "This augmentation:<br>" +
-                 "Increases the player's effectiveness in Bladeburner Field Analysis by 15%.<br>" +
-                 "Increases the player's success chance in Bladeburner contracts/operations by 2%.",
+                 "Increases Bladeburner Field Analysis effectiveness by 15%.<br>" +
+                 "Increases success chance in Bladeburner Contracts and Operations by 2%.",
             prereqs:[AugmentationNames.BladeArmor],
             bladeburner_analysis_mult: 1.15,
             bladeburner_success_chance_mult: 1.02,
@@ -2057,8 +2047,7 @@ function initAugmentations() {
                  "the user to project and control a holographic simulacrum within an " +
                  "extremely large radius. These specially-modified holograms were specifically " +
                  "weaponized by Bladeburner units to be used against Synthoids.<br><br>"  +
-                 "This augmentation allows you to perform Bladeburner actions and other " +
-                 "actions (such as working, commiting crimes, etc.) at the same time.",
+                 "Allows the simultaneous performance of Bladeburner actions and other actions.",
             isSpecial: true,
         });
         BladesSimulacrum.addToFactions([BladeburnersFactionName]);

--- a/src/Augmentation/AugmentationHelpers.jsx
+++ b/src/Augmentation/AugmentationHelpers.jsx
@@ -466,7 +466,7 @@ function initAugmentations() {
         name:AugmentationNames.BitWire, repCost:3.75e3, moneyCost:1e7,
         info: "A small brain implant embedded in the cerebrum. This regulates and improves the brain's computing " +
               "capabilities.<br><br>" +
-              "This augmentation increases the player's hacking skill by 5%.",
+              "Increases Hacking by 5%.",
         hacking_mult: 1.05,
     });
     BitWire.addToFactions(["CyberSec", "NiteSec"]);
@@ -482,10 +482,9 @@ function initAugmentations() {
              "nanoprocessor acting similar to the way a neuron would in a neural network. However, these " +
              "nanoprocessors are programmed to perform computations much faster than organic neurons, " +
              "allowing the user to solve much more complex problems at a much faster rate.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 3%.<br>" +
-             "Increases the amount of money the player's gains from hacking by 15%.<br>" +
-             "Increases the player's hacking skill by 12%.",
+             "Increases Hacking speed by 3%.<br>" +
+             "Increases money gained from Hacking by 15%.<br>" +
+             "Increases Hacking by 12%.",
         hacking_speed_mult: 1.03,
         hacking_money_mult: 1.15,
         hacking_mult: 1.12,
@@ -500,10 +499,9 @@ function initAugmentations() {
         name:AugmentationNames.ArtificialSynapticPotentiation, repCost:6.25e3, moneyCost:8e7,
         info:"The body is injected with a chemical that artificially induces synaptic potentiation, " +
              "otherwise known as the strengthening of synapses. This results in enhanced cognitive abilities.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 2%.<br>" +
-             "Increases the player's hacking chance by 5%.<br>" +
-             "Increases the player's hacking experience gain rate by 5%.",
+             "Increases Hacking speed by 2%.<br>" +
+             "Increases Hacking success chance by 5%.<br>" +
+             "Increases Hacking experience gain by 5%.",
         hacking_speed_mult: 1.02,
         hacking_chance_mult: 1.05,
         hacking_exp_mult: 1.05,
@@ -520,10 +518,9 @@ function initAugmentations() {
              "This process results in the proliferation of new, synthetic myelin sheaths in the nervous " +
              "system. These myelin sheaths can propogate neuro-signals much faster than their organic " +
              "counterparts, leading to greater processing speeds and better brain function.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 3%.<br>" +
-             "Increases the player's hacking skill by 8%.<br>" +
-             "Increases the player's hacking experience gain rate by 10%.",
+             "Increases Hacking speed by 3%.<br>" +
+             "Increases Hacking by 8%.<br>" +
+             "Increases Hacking experience gain by 10%.",
         hacking_speed_mult: 1.03,
         hacking_exp_mult: 1.1,
         hacking_mult: 1.08,
@@ -538,7 +535,7 @@ function initAugmentations() {
         name:AugmentationNames.SynapticEnhancement, repCost:2e3, moneyCost:7.5e6,
         info:"A small cranial implant that continuously uses weak electrical signals to stimulate the brain and " +
              "induce stronger synaptic activity. This improves the user's cognitive abilities.<br><br>" +
-             "This augmentation increases the player's hacking speed by 3%.",
+             "Increases Hacking speed by 3%.",
         hacking_speed_mult: 1.03,
     });
     SynapticEnhancement.addToFactions(["CyberSec", "Aevum"]);
@@ -551,7 +548,7 @@ function initAugmentations() {
         name:AugmentationNames.NeuralRetentionEnhancement, repCost:2e4, moneyCost:2.5e8,
         info:"Chemical injections are used to permanently alter and strengthen the brain's neuronal " +
              "circuits, strengthening the ability to retain information.<br><br>" +
-             "This augmentation increases the player's hacking experience gain rate by 25%.",
+             "Increases Hacking experience gain by 25%.",
         hacking_exp_mult: 1.25,
     });
     NeuralRetentionEnhancement.addToFactions(["NiteSec"]);
@@ -565,7 +562,7 @@ function initAugmentations() {
         info:"A brain implant that provides an interface for direct, wireless communication between a computer's main " +
              "memory and the mind. This implant allows the user to not only access a computer's memory, but also alter " +
              "and delete it.<br><br>" +
-             "This augmentation increases the amount of money the player gains from hacking by 25%.",
+             "Increases money gained from Hacking by 25%.",
         hacking_money_mult: 1.25,
     });
     DataJack.addToFactions(["BitRunners", "The Black Hand", "NiteSec", "Chongqing", "New Tokyo"]);
@@ -581,7 +578,7 @@ function initAugmentations() {
              "processing all of the traffic on that network. By itself, the Embedded Netburner Module does " +
              "not do much, but a variety of very powerful upgrades can be installed that allow you to fully " +
              "control the traffic on a network.<br><br>" +
-             "This augmentation increases the player's hacking skill by 8%.",
+             "Increases Hacking by 8%.",
         hacking_mult: 1.08,
     });
     ENM.addToFactions(["BitRunners", "The Black Hand", "NiteSec", "ECorp", "MegaCorp",
@@ -595,12 +592,11 @@ function initAugmentations() {
         name:AugmentationNames.ENMCore, repCost:2.5e5, moneyCost:2.5e9,
         info:"The Core library is an implant that upgrades the firmware of the Embedded Netburner Module. " +
              "This upgrade allows the Embedded Netburner Module to generate its own data on a network.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 3%.<br>" +
-             "Increases the amount of money the player gains from hacking by 10%.<br>" +
-             "Increases the player's chance of successfully performing a hack by 3%.<br>" +
-             "Increases the player's hacking experience gain rate by 7%.<br>" +
-             "Increases the player's hacking skill by 7%.",
+             "Increases Hacking speed by 3%.<br>" +
+             "Increases money gained from Hacking by 10%.<br>" +
+             "Increases Hacking success chance by 3%.<br>" +
+             "Increases Hacking experience gain by 7%.<br>" +
+             "Increases Hacking by 7%.",
         prereqs:[AugmentationNames.ENM],
         hacking_speed_mult: 1.03,
         hacking_money_mult: 1.1,
@@ -621,12 +617,11 @@ function initAugmentations() {
              "This upgraded firmware allows the Embedded Netburner Module to control information on " +
              "a network by re-routing traffic, spoofing IP addresses, and altering the data inside network " +
              "packets.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 5%.<br>" +
-             "Increases the amount of money the player gains from hacking by 30%.<br>" +
-             "Increases the player's chance of successfully performing a hack by 5%.<br>" +
-             "Increases the player's hacking experience gain rate by 15%.<br>" +
-             "Increases the player's hacking skill by 8%.",
+             "Increases Hacking speed by 5%.<br>" +
+             "Increases money gained from Hacking by 30%.<br>" +
+             "Increases Hacking success chance by 5%.<br>" +
+             "Increases Hacking experience gain by 15%.<br>" +
+             "Increases Hacking by 8%.",
         prereqs:[AugmentationNames.ENMCore],
         hacking_speed_mult: 1.05,
         hacking_money_mult: 1.3,
@@ -646,12 +641,11 @@ function initAugmentations() {
         info:"The Core V3 library is an implant that upgrades the firmware of the Embedded Netburner Module. " +
              "This upgraded firmware allows the Embedded Netburner Module to seamlessly inject code into " +
              "any device on a network.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 5%.<br>" +
-             "Increases the amount of money the player gains from hacking by 40%.<br>" +
-             "Increases the player's chance of successfully performing a hack by 10%.<br>" +
-             "Increases the player's hacking experience gain rate by 25%.<br>" +
-             "Increases the player's hacking skill by 10%.",
+             "Increases Hacking speed by 5%.<br>" +
+             "Increases money gained from Hacking by 40%.<br>" +
+             "Increases Hacking success chance by 10%.<br>" +
+             "Increases Hacking experience gain by 25%.<br>" +
+             "Increases Hacking by 10%.",
         prereqs:[AugmentationNames.ENMCoreV2],
         hacking_speed_mult: 1.05,
         hacking_money_mult: 1.4,
@@ -670,7 +664,7 @@ function initAugmentations() {
         name:AugmentationNames.ENMAnalyzeEngine, repCost:6.25e5, moneyCost:6e9,
         info:"Installs the Analyze Engine for the Embedded Netburner Module, which is a CPU cluster " +
              "that vastly outperforms the Netburner Module's native single-core processor.<br><br>" +
-             "This augmentation increases the player's hacking speed by 10%.",
+             "Increases Hacking speed by 10%.",
         prereqs:[AugmentationNames.ENM],
         hacking_speed_mult: 1.1,
     });
@@ -686,9 +680,8 @@ function initAugmentations() {
         info:"This implant installs a Direct Memory Access (DMA) controller into the " +
              "Embedded Netburner Module. This allows the Module to send and receive data " +
              "directly to and from the main memory of devices on a network.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the amount of money the player gains from hacking by 40%.<br>"  +
-             "Increases the player's chance of successfully performing a hack by 20%.",
+             "Increases money gained from Hacking by 40%.<br>"  +
+             "Increases Hacking success chance by 20%.",
         prereqs:[AugmentationNames.ENM],
         hacking_money_mult: 1.4,
         hacking_chance_mult: 1.2,
@@ -704,10 +697,9 @@ function initAugmentations() {
         name:AugmentationNames.Neuralstimulator, repCost:5e4, moneyCost:3e9,
         info:"A cranial implant that intelligently stimulates certain areas of the brain " +
              "in order to improve cognitive functions.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 2%.<br>" +
-             "Increases the player's chance of successfully performing a hack by 10%.<br>" +
-             "Increases the player's hacking experience gain rate by 12%.",
+             "Increases Hacking speed by 2%.<br>" +
+             "Increases Hacking success chance by 10%.<br>" +
+             "Increases Hacking experience gain by 12%.",
         hacking_speed_mult: 1.02,
         hacking_chance_mult: 1.1,
         hacking_exp_mult: 1.12,
@@ -724,10 +716,9 @@ function initAugmentations() {
         name:AugmentationNames.NeuralAccelerator, repCost:2e5, moneyCost:1.75e9,
         info:"A microprocessor that accelerates the processing " +
              "speed of biological neural networks. This is a cranial implant that is embedded inside the brain.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking skill by 10%.<br>" +
-             "Increases the player's hacking experience gain rate by 15%.<br>" +
-             "Increases the amount of money the player gains from hacking by 20%.",
+             "Increases Hacking by 10%.<br>" +
+             "Increases Hacking experience gain by 15%.<br>" +
+             "Increases money gained from Hacking by 20%.",
         hacking_mult: 1.1,
         hacking_exp_mult: 1.15,
         hacking_money_mult: 1.2,
@@ -744,9 +735,8 @@ function initAugmentations() {
              "are a set of specialized microprocessors that are attached to " +
              "neurons in the brain. These chips process neural signals to quickly and automatically perform specific computations " +
              "so that the brain doesn't have to.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 1%.<br>" +
-             "Increases the player's hacking skill by 5%.",
+             "Increases Hacking speed by 1%.<br>" +
+             "Increases Hacking by 5%.",
         hacking_speed_mult: 1.01,
         hacking_mult: 1.05,
     });
@@ -762,10 +752,9 @@ function initAugmentations() {
             "are a set of specialized microprocessors that are attached to " +
             "neurons in the brain. These chips process neural signals to quickly and automatically perform specific computations " +
             "so that the brain doesn't have to.<br><br>" +
-            "This augmentation:<br>" +
-            "Increases the player's hacking speed by 2%.<br>" +
-            "Increases the player's chance of successfully performing a hack by 5%.<br>" +
-            "Increases the player's hacking skill by 7%.",
+            "Increases Hacking speed by 2%.<br>" +
+            "Increases Hacking success chance by 5%.<br>" +
+            "Increases Hacking by 7%.",
 	    prereqs:[AugmentationNames.CranialSignalProcessorsG1],
         hacking_speed_mult: 1.02,
         hacking_chance_mult: 1.05,
@@ -783,10 +772,9 @@ function initAugmentations() {
              "are a set of specialized microprocessors that are attached to " +
              "neurons in the brain. These chips process neural signals to quickly and automatically perform specific computations " +
              "so that the brain doesn't have to.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 2%.<br>" +
-             "Increases the amount of money the player gains from hacking by 15%.<br>" +
-             "Increases the player's hacking skill by 9%.",
+             "Increases Hacking speed by 2%.<br>" +
+             "Increases money gained from Hacking by 15%.<br>" +
+             "Increases Hacking by 9%.",
 	    prereqs:[AugmentationNames.CranialSignalProcessorsG2],
         hacking_speed_mult: 1.02,
         hacking_money_mult: 1.15,
@@ -804,9 +792,8 @@ function initAugmentations() {
              "are a set of specialized microprocessors that are attached to " +
              "neurons in the brain. These chips process neural signals to quickly and automatically perform specific computations " +
              "so that the brain doesn't have to.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking speed by 2%.<br>" +
-             "Increases the amount of money the player gains from hacking by 20%.<br>" +
+             "Increases Hacking speed by 2%.<br>" +
+             "Increases money gained from Hacking by 20%.<br>" +
              "Improves grow() by 25%.",
 	    prereqs:[AugmentationNames.CranialSignalProcessorsG3],
         hacking_speed_mult: 1.02,
@@ -825,9 +812,8 @@ function initAugmentations() {
              "are a set of specialized microprocessors that are attached to " +
              "neurons in the brain. These chips process neural signals to quickly and automatically perform specific computations " +
              "so that the brain doesn't have to.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking skill by 30%.<br>" +
-             "Increases the amount of money the player gains from hacking by 25%.<br>" +
+             "Increases Hacking by 30%.<br>" +
+             "Increases money gained from Hacking by 25%.<br>" +
              "Improves grow() by 75%.",
 	    prereqs:[AugmentationNames.CranialSignalProcessorsG4],
         hacking_mult: 1.3,
@@ -845,10 +831,9 @@ function initAugmentations() {
         info:"The brain is surgically re-engineered to have increased neuronal density " +
              "by decreasing the neuron gap junction. Then, the body is genetically modified " +
              "to enhance the production and capabilities of its neural stem cells.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's hacking skill by 15%.<br>" +
-             "Increases the player's hacking experience gain rate by 10%.<br>"+
-             "Increases the player's hacking speed by 3%.",
+             "Increases Hacking by 15%.<br>" +
+             "Increases Hacking experience gain by 10%.<br>"+
+             "Increases Hacking speed by 3%.",
         hacking_mult: 1.15,
         hacking_exp_mult: 1.1,
         hacking_speed_mult: 1.03,
@@ -865,8 +850,7 @@ function initAugmentations() {
         info:"This torso implant automatically injects nootropic supplements into " +
              "the bloodstream to improve memory, increase focus, and provide other " +
              "cognitive enhancements.<br><br>" +
-             "This augmentation increases the amount of reputation the player gains " +
-             "when working for a company by 20%.",
+             "Increases reputation gain from companies by 20%.",
         company_rep_mult: 1.2,
     });
     NuoptimalInjectorImplant.addToFactions(["Tian Di Hui", "Volhaven", "New Tokyo", "Chongqing",
@@ -881,9 +865,8 @@ function initAugmentations() {
         info:"An advanced neural implant that improves your speaking abilities, making " +
              "you more convincing and likable in conversations and overall improving your " +
              "social interactions.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the player's charisma by 10%.<br>" +
-             "Increases the amount of reputation the player gains when working for a company by 10%.",
+             "Increases Charisma by 10%.<br>" +
+             "Increases reputation gain from companies by 10%.",
         company_rep_mult: 1.1,
         charisma_mult: 1.1,
     });
@@ -898,10 +881,9 @@ function initAugmentations() {
         name:AugmentationNames.FocusWire, repCost:7.5e4, moneyCost:9e8,
         info:"A cranial implant that stops procrastination by blocking specific neural pathways " +
              "in the brain.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases all experience gains by 5%.<br>" +
-             "Increases the amount of money the player gains from working by 20%.<br>" +
-             "Increases the amount of reputation the player gains when working for a company by 10%.",
+             "Increases experience gain for all stats by 5%.<br>" +
+             "Increases money gained from working by 20%.<br>" +
+             "Increases reputation gain from companies by 10%.",
         hacking_exp_mult: 1.05,
         strength_exp_mult: 1.05,
         defense_exp_mult: 1.05,
@@ -922,9 +904,8 @@ function initAugmentations() {
         info:"Installs a Direct-Neural Interface jack into your arm that is compatible with most " +
              "computers. Connecting to a computer through this jack allows you to interface with " +
              "it using the brain's electrochemical signals.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the amount of reputation the player gains when working for a company by 30%.<br>" +
-             "Increases the player's hacking skill by 8%.",
+             "Increases reputation gain from companies by 30%.<br>" +
+             "Increases Hacking by 8%.",
         company_rep_mult: 1.3,
         hacking_mult: 1.08,
     });
@@ -939,9 +920,8 @@ function initAugmentations() {
         info:"This is a submodule upgrade to the PC Direct-Neural Interface augmentation. It " +
              "improves the performance of the interface and gives the user more control options " +
              "to a connected computer.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the amount of reputation the player gains when working for a company by 75%.<br>" +
-             "Increases the player's hacking skill by 10%.",
+             "Increases reputation gain from companies by 75%.<br>" +
+             "Increases Hacking by 10%.",
         prereqs:[AugmentationNames.PCDNI],
         company_rep_mult: 1.75,
         hacking_mult: 1.1,
@@ -958,10 +938,9 @@ function initAugmentations() {
              "PC Direct-Neural Interface augmentation. When connected to a computer, " +
              "The Neural Network upgrade allows the user to use their own brain's " +
              "processing power to aid the computer in computational tasks.<br><br>" +
-             "This augmentation:<br>" +
-             "Increases the amount of reputation the player gains when working for a company by 100%.<br>" +
-             "Increases the player's hacking skill by 10%.<br>" +
-             "Increases the player's hacking speed by 5%.",
+             "Increases reputation gain from companies by 100%.<br>" +
+             "Increases Hacking by 10%.<br>" +
+             "Increases Hacking speed by 5%.",
         prereqs:[AugmentationNames.PCDNI],
         company_rep_mult: 2,
         hacking_mult: 1.1,
@@ -978,7 +957,7 @@ function initAugmentations() {
         info:"The body is genetically re-engineered so that it produces the ADR-V1 pheromone, " +
              "an artificial pheromone discovered by scientists. The ADR-V1 pheromone, when excreted, " +
              "triggers feelings of admiration and approval in other people.<br><br>" +
-             "This augmentation increases the amount of reputation the player gains when working for a faction or company by 10%.",
+             "Increases reputation gain from factions and companies by 10%.",
         company_rep_mult: 1.1,
         faction_rep_mult: 1.1,
     });
@@ -993,7 +972,7 @@ function initAugmentations() {
         info:"The body is genetically re-engineered so that it produces the ADR-V2 pheromone, " +
              "which is similar to but more potent than ADR-V1. This pheromone, when excreted, " +
              "triggers feelings of admiration, approval, and respect in others.<br><br>" +
-             "This augmentation increases the amount of reputation the player gains when working for a faction or company by 20%.",
+             "Increases reputation gain from factions and companies by 20%.",
         company_rep_mult: 1.2,
         faction_rep_mult: 1.2,
     });
@@ -1010,7 +989,7 @@ function initAugmentations() {
               "criminal organizations and allows the user to project and control holographic " +
               "simulacrums within a large radius. These simulacrums are commonly used for " +
               "espionage and surveillance work.<br><br>" +
-              "This augmentation increases the amount of reputation the player gains when working for a faction or company by 15%.",
+              "Increases reputation gain from factions and companies by 15%.",
         company_rep_mult: 1.15,
         faction_rep_mult: 1.15,
     });


### PR DESCRIPTION
Augmentation descriptions are consistent with their assigned multipliers. 

Removed all references to "the player's".

Cleaned up wording and condensed sentence structure as appropriate.

Augmentation descriptions were changed based on the following rules:

hacking_mult: "Increases Hacking by number%."
strength_mult: "Increases Strength by number%."
defense_mult: "Increases Defense by number%."
dexterity_mult: "Increases Dexterity by number%."
agility_mult: "Increases Agility by number%."
charisma_mult: "Increases Charisma by number%."

hacking_exp_mult: "Increases Hacking experience gain by number%."
strength_exp_mult: "Increases Strength experience gain by number%."
defense_exp_mult: "Increases Defense experience gain by number%."
dexterity_exp_mult: "Increases Dexterity experience gain by number%."
agility_exp_mult: "Increases Agility experience gain by number%."
charisma_exp_mult: "Increases Charisma experience gain by number%."

hacking_chance_mult: "Increases Hacking success chance by number%."
hacking_speed_mult:  "Increases Hacking speed by number%."
hacking_money_mult: "Increases money gained from Hacking by number%."
hacking_grow_mult: "Improves grow() by number%."

faction_rep_mult: "Increases reputation gain from factions by number%."
company_rep_mult: "Increases reputation gain from companies by number%."

crime_money_mult: "Increases money gained from committing crimes by number%."
crime_success_mult: "Increases crime success rate by number%."
work_money_mult: "Increases money gained from working by number%."

hacknet_node_money_mult: "Increases money produced from Hacknet Nodes by number%."
hacknet_node_purchase_cost_mult: "Decreases the purchase cost of Hacknet Nodes by number%."
hacknet_node_level_cost_mult:  "Decreases the upgrade cost of Hacknet Nodes by number%.",

bladeburner_max_stamina_mult: "Increases Bladeburner Stamina by number%."
bladeburner_stamina_gain_mult: "Increases Bladeburner Stamina gain by number%."
bladeburner_analysis_mult: "Increases Bladeburner Field Analysis effectiveness by number%."
bladeburner_success_chance_mult: "Increases success chance in Bladeburner Contracts and Operations by number%."

// If an augment provides the same % bonus to all multipliers in any group

[
hacking_mult:
strength_mult:
defense_mult:
dexterity_mult:
agility_mult:
charisma_mult:
]

"Increases all stats by number%."

[
hacking_exp_mult:
strength_exp_mult:
defense_exp_mult:
dexterity_exp_mult:
agility_exp_mult:
charisma_exp_mult:
]

"Increases experience gain for all stats by number%."

[
strength_mult:
defense_mult:
dexterity_mult:
agility_mult:
]

"Increases all combat stats by number%."

[
strength_exp_mult:
defense_exp_mult:
dexterity_exp_mult:
agility_exp_mult:
]

"Increases experience gain for all combat stats by number%."

[
faction_rep_mult:
company_rep_mult:
]

"Increases reputation gain from factions and companies by number%."

// Unique

BladesSimulacrum:

"Allows the simultaneous performance of Bladeburner actions and other actions."

CashRoot:

"Provides {Money(1e6)} after a reset."
"Provides BruteSSH.exe after a reset."

Neurolink:

"Provides FTPCrack.exe and relaySMTP.exe after a reset."

NeuroFluxGovernor:

"Each level increases all multipliers by 1%."