### PR TITLE
Instakill player when automating infiltration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 Changelog.txt
 Netburner.txt
 /doc/build

--- a/src/Infiltration/ui/BackwardGame.tsx
+++ b/src/Infiltration/ui/BackwardGame.tsx
@@ -46,7 +46,7 @@ export function BackwardGame(props: IMinigameProps): React.ReactElement {
         <GameTimer millis={timer} onExpire={props.onFailure} />
         <Grid item xs={12}>
             <h1 className={"noselect"}>Type it backward</h1>
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
         <Grid item xs={6}>
             <p style={{transform: 'scaleX(-1)'}}>{answer}</p>

--- a/src/Infiltration/ui/BracketGame.tsx
+++ b/src/Infiltration/ui/BracketGame.tsx
@@ -78,7 +78,7 @@ export function BracketGame(props: IMinigameProps): React.ReactElement {
         <Grid item xs={12}>
             <h1 className={"noselect"}>Close the brackets</h1>
             <p style={{fontSize: '5em'}}>{`${left}${right}`}<BlinkingCursor /></p>
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
     </Grid>)
 }

--- a/src/Infiltration/ui/BribeGame.tsx
+++ b/src/Infiltration/ui/BribeGame.tsx
@@ -51,7 +51,7 @@ export function BribeGame(props: IMinigameProps): React.ReactElement {
         <GameTimer millis={timer} onExpire={props.onFailure} />
         <Grid item xs={12}>
             <h1>Say something nice about the guard.</h1>
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
         <Grid item xs={6}>
             <h2 style={{fontSize: "2em"}}>↑</h2>

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -47,7 +47,7 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
         <Grid item xs={12}>
             <h1 className={"noselect"}>Enter the Code!</h1>
             <p style={{fontSize: '5em'}}>{code[index]}</p>
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
     </Grid>)
 }

--- a/src/Infiltration/ui/Cyberpunk2077Game.tsx
+++ b/src/Infiltration/ui/Cyberpunk2077Game.tsx
@@ -86,7 +86,7 @@ export function Cyberpunk2077Game(props: IMinigameProps): React.ReactElement {
                     return <span key={`${x}${y}`} style={{fontSize: fontSize, color: 'blue'}}>{cell}&nbsp;</span>
                 return <span key={`${x}${y}`} style={{fontSize: fontSize}}>{cell}&nbsp;</span>
             })}</pre><br /></div>)}
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
     </Grid>)
 }

--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -85,10 +85,13 @@ export function Game(props: IProps): React.ReactElement {
         })
     }
 
-    function failure(): void {
+    function failure(options?: { automated: boolean }): void {
         setStage(Stage.Countdown);
         pushResult(false);
-        if(props.Player.takeDamage(props.StartingDifficulty*3)) {
+        // Kill the player immediately if they use automation, so
+        // it's clear they're not meant to
+        const damage = options?.automated ? props.Player.hp : props.StartingDifficulty*3;
+        if(props.Player.takeDamage(damage)) {
             const menu = document.getElementById("mainmenu-container");
             if(menu === null) throw new Error("mainmenu-container not found");
             menu.style.visibility = "visible";

--- a/src/Infiltration/ui/IMinigameProps.tsx
+++ b/src/Infiltration/ui/IMinigameProps.tsx
@@ -1,5 +1,8 @@
 export interface IMinigameProps {
     onSuccess: () => void;
-    onFailure: () => void;
+    onFailure: (options?: {
+        /** Failed due to using untrusted events (automation) */
+        automated: boolean;
+    }) => void;
     difficulty: number;
 }

--- a/src/Infiltration/ui/KeyHandler.tsx
+++ b/src/Infiltration/ui/KeyHandler.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 
 interface IProps {
     onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+    onFailure: (options?: { automated: boolean }) => void;
 }
 
 export function KeyHandler(props: IProps): React.ReactElement {
@@ -9,7 +10,12 @@ export function KeyHandler(props: IProps): React.ReactElement {
     useEffect(() => elem.focus());
 
     function onKeyDown(event: React.KeyboardEvent<HTMLElement>): void {
-        if(!event.isTrusted) return;
+        console.log("isTrusted?", event.isTrusted)
+        if(!event.isTrusted) {
+            console.log("untrusted event!")
+            props.onFailure({ automated: true });
+            return;
+        }
         props.onKeyDown(event);
     }
 

--- a/src/Infiltration/ui/MinesweeperGame.tsx
+++ b/src/Infiltration/ui/MinesweeperGame.tsx
@@ -94,7 +94,7 @@ export function MinesweeperGame(props: IMinigameProps): React.ReactElement {
                     return <span key={x}>[&nbsp;]&nbsp;</span>
                 }
             })}</pre><br /></div>)}
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
     </Grid>)
 }

--- a/src/Infiltration/ui/SlashGame.tsx
+++ b/src/Infiltration/ui/SlashGame.tsx
@@ -54,7 +54,7 @@ export function SlashGame(props: IMinigameProps): React.ReactElement {
         <Grid item xs={12}>
             <h1 className={"noselect"}>Slash when his guard is down!</h1>
             <p style={{fontSize: '5em'}}>{guarding ? "!Guarding!" : "!ATTACKING!"}</p>
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
     </Grid>)
 }

--- a/src/Infiltration/ui/WireCuttingGame.tsx
+++ b/src/Infiltration/ui/WireCuttingGame.tsx
@@ -111,7 +111,7 @@ export function WireCuttingGame(props: IMinigameProps): React.ReactElement {
                 })}
                 </pre>
             </div>)}
-            <KeyHandler onKeyDown={press} />
+            <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
         </Grid>
     </Grid>)
 }


### PR DESCRIPTION
Make it clear that infiltration is not meant to be automated by killing the player instantly if they send in untrusted events.
(This would have saved me some time today, plus I think it's fun.)

I'd like to have a custom message when this happens, but I might need some guidance on the best way to do that.