### PR TITLE
Rename "Delete all active scripts" to "Kill all active scripts"

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,7 +581,7 @@
                     Copy Save data to Clipboard
                 </button>
                 <button id="debug-delete-scripts-link" class="a-link-button tooltip">
-                    Delete all active scripts
+                    Kill all active scripts
                     <span class="tooltiptextleft">
                         Forcefully kill all active running scripts, in case there is a bug or some unexpected issue with the game. After
                         using this, save the game and then reload the page.

--- a/src/index.html
+++ b/src/index.html
@@ -594,7 +594,7 @@ if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
                     Copy Save data to Clipboard
                 </button>
                 <button id="debug-delete-scripts-link" class="a-link-button tooltip">
-                    Delete all active scripts
+                    Kill all active scripts
                     <span class="tooltiptextleft">
                         Forcefully kill all active running scripts, in case there is a bug or some unexpected issue with the game. After
                         using this, save the game and then reload the page.


### PR DESCRIPTION
The option to stop a runaway script is labelled "Delete all active scripts", which makes it sound destructive. This just renames it to "kill".