### PR TITLE
add bladeburner_analysis_mult to getPlayer()

### DIFF
--- a/src/NetscriptFunctions.js
+++ b/src/NetscriptFunctions.js
@@ -3029,6 +3029,7 @@ function NetscriptFunctions(workerScript) {
                 has4SDataTixApi:                 Player.has4SDataTixApi,
                 bladeburner_max_stamina_mult:    Player.bladeburner_max_stamina_mult,
                 bladeburner_stamina_gain_mult:   Player.bladeburner_stamina_gain_mult,
+                bladeburner_analysis_mult:       Player.bladeburner_analysis_mult,
                 bladeburner_success_chance_mult: Player.bladeburner_success_chance_mult,
                 bitNodeN:                        Player.bitNodeN,
                 totalPlaytime:                   Player.totalPlaytime,


### PR DESCRIPTION
seems like maybe this was forgotten on getPlayer(), as other bladeburner related multipliers on the player object are added, but not this one.

found it from this code:
https://github.com/danielyxie/bitburner/blob/11cbda6974acd85fab61960d4bd0b778d1f60858/src/SourceFile/applySourceFile.ts#L113

and I want it here so i can calculate if field analysis is better than investigation or undercover operations for increasing accuracy of population estimates.

didn't test but the change is pretty simple.