### PR TITLE
Update all general actions to have infinity count

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1845,8 +1845,11 @@ export class Bladeburner implements IBladeburner {
                     return 1;
                 }
             case ActionTypes["Training"]:
+            case ActionTypes["Recruitment"]:
             case ActionTypes["Field Analysis"]:
             case ActionTypes["FieldAnalysis"]:
+            case ActionTypes["Diplomacy"]:
+            case ActionTypes["Hyperbolic Regeneration Chamber"]:
                 return Infinity;
             default:
                 workerScript.log("bladeburner.getActionCountRemaining", errorLogText);


### PR DESCRIPTION
ns.bladeburner.getActionCountRemaining("general", "Diplomacy") currently returns -1. I think it'd be more intuitive if all the general actions returned Infinity, instead of just two of them.