### PR TITLE
Update getActionEstimatedSuccessChance

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1809,6 +1809,8 @@ export class Bladeburner implements IBladeburner {
             case ActionTypes["Training"]:
             case ActionTypes["Field Analysis"]:
             case ActionTypes["FieldAnalysis"]:
+            case ActionTypes["Diplomacy"]:
+            case ActionTypes["Hyperbolic Regeneration Chamber"]:
                 return [1, 1];
             case ActionTypes["Recruitment"]:
                 const recChance = this.getRecruitmentSuccessChance(player);


### PR DESCRIPTION
ns.bladeburner.getActionEstimatedSuccessChance("general", "Diplomacy") returned [-1, -1] (as well as for "Hyperbolic Regeneration Chamber"), even though both tasks automatically succeed. Also Training and Field Analysis both previously returned [1, 1], so it seems these two were just missed.