### PR TITLE
implement #1242

### DIFF
--- a/src/Corporation/Warehouse.ts
+++ b/src/Corporation/Warehouse.ts
@@ -80,6 +80,11 @@ export class Warehouse {
     if (params.corp && params.industry) {
       this.updateSize(params.corp, params.industry);
     }
+
+    // Default smart supply to being enabled if the upgrade is unlocked
+    if (params.corp?.unlockUpgrades[1]) {
+      this.smartSupplyEnabled = true;
+    }
   }
 
   // Re-calculate how much space is being used by this Warehouse


### PR DESCRIPTION
Makes smartsupply enabled by default when purchasing a new warehouse, if the appropriate upgrade is unlocked.