### PR TITLE
fix script log box staying behind when scrolling

### DIFF
--- a/css/popupboxes.scss
+++ b/css/popupboxes.scss
@@ -81,7 +81,7 @@
   flex-flow: column;
   background-color: gray;
   width: 50%;
-  position: absolute;
+  position: fixed;
   left: 50%;
   top: 40%;
   margin: -10% 0 0 -25%;


### PR DESCRIPTION
setting the position to 'fixed' means all log boxes will always stay in the visible part of the screen, and you can still drag them around with the mouse.