### PR TITLE
improve gang ascend modal

### DIFF
--- a/src/Gang/GangMember.ts
+++ b/src/Gang/GangMember.ts
@@ -218,28 +218,41 @@ export class GangMember {
     return points.hack > 0 || points.str > 0 || points.def > 0 || points.dex > 0 || points.agi > 0 || points.cha > 0;
   }
 
-  getAscensionResults(): IMults {
+  getCurrentAscensionMults(): IMults {
+    return {
+      hack: this.calculateAscensionMult(this.hack_asc_points),
+      str: this.calculateAscensionMult(this.str_asc_points),
+      def: this.calculateAscensionMult(this.def_asc_points),
+      dex: this.calculateAscensionMult(this.dex_asc_points),
+      agi: this.calculateAscensionMult(this.agi_asc_points),
+      cha: this.calculateAscensionMult(this.cha_asc_points)
+    }
+  }
+
+  getAscensionMultsAfterAscend(): IMults {
     const points = this.getGainedAscensionPoints();
     return {
-      hack:
-        this.calculateAscensionMult(this.hack_asc_points + points.hack) /
-        this.calculateAscensionMult(this.hack_asc_points),
-      str:
-        this.calculateAscensionMult(this.str_asc_points + points.str) /
-        this.calculateAscensionMult(this.str_asc_points),
-      def:
-        this.calculateAscensionMult(this.def_asc_points + points.def) /
-        this.calculateAscensionMult(this.def_asc_points),
-      dex:
-        this.calculateAscensionMult(this.dex_asc_points + points.dex) /
-        this.calculateAscensionMult(this.dex_asc_points),
-      agi:
-        this.calculateAscensionMult(this.agi_asc_points + points.agi) /
-        this.calculateAscensionMult(this.agi_asc_points),
-      cha:
-        this.calculateAscensionMult(this.cha_asc_points + points.cha) /
-        this.calculateAscensionMult(this.cha_asc_points),
-    };
+      hack: this.calculateAscensionMult(this.hack_asc_points + points.hack),
+      str: this.calculateAscensionMult(this.str_asc_points + points.str),
+      def: this.calculateAscensionMult(this.def_asc_points + points.def),
+      dex: this.calculateAscensionMult(this.dex_asc_points + points.dex),
+      agi: this.calculateAscensionMult(this.agi_asc_points + points.agi),
+      cha: this.calculateAscensionMult(this.cha_asc_points + points.cha),
+    }
+  }
+
+  getAscensionResults(): IMults {
+    const postAscend = this.getAscensionMultsAfterAscend();
+    const preAscend = this.getCurrentAscensionMults();
+
+    return {
+      hack: postAscend.hack / preAscend.hack,
+      str: postAscend.str / preAscend.str,
+      def: postAscend.def / preAscend.def,
+      dex: postAscend.dex / preAscend.dex,
+      agi: postAscend.agi / preAscend.agi,
+      cha: postAscend.cha / preAscend.cha,
+    }
   }
 
   ascend(): IAscensionResult {

--- a/src/Gang/ui/AscensionPopup.tsx
+++ b/src/Gang/ui/AscensionPopup.tsx
@@ -57,7 +57,9 @@ export function AscensionPopup(props: IProps): React.ReactElement {
     removePopup(props.popupId);
   }
 
-  const ascendBenefits = props.member.getAscensionResults();
+  // const ascendBenefits = props.member.getAscensionResults();
+  const preAscend = props.member.getCurrentAscensionMults();
+  const postAscend = props.member.getAscensionMultsAfterAscend();
 
   return (
     <>
@@ -72,17 +74,17 @@ export function AscensionPopup(props: IProps): React.ReactElement {
         <br />
         In return, they will gain the following permanent boost to stat multipliers:
         <br />
-        Hacking: x{numeralWrapper.format(ascendBenefits.hack, "0.000")}
+        Hacking: x{numeralWrapper.format(preAscend.hack, "0.000")} =&gt; x{numeralWrapper.format(postAscend.hack, "0.000")}
         <br />
-        Strength: x{numeralWrapper.format(ascendBenefits.str, "0.000")}
+        Strength: x{numeralWrapper.format(preAscend.str, "0.000")} =&gt; x{numeralWrapper.format(postAscend.str, "0.000")}
         <br />
-        Defense: x{numeralWrapper.format(ascendBenefits.def, "0.000")}
+        Defense: x{numeralWrapper.format(preAscend.def, "0.000")} =&gt; x{numeralWrapper.format(postAscend.def, "0.000")}
         <br />
-        Dexterity: x{numeralWrapper.format(ascendBenefits.dex, "0.000")}
+        Dexterity: x{numeralWrapper.format(preAscend.dex, "0.000")} =&gt; x{numeralWrapper.format(postAscend.dex, "0.000")}
         <br />
-        Agility: x{numeralWrapper.format(ascendBenefits.agi, "0.000")}
+        Agility: x{numeralWrapper.format(preAscend.agi, "0.000")} =&gt; x{numeralWrapper.format(postAscend.agi, "0.000")}
         <br />
-        Charisma: x{numeralWrapper.format(ascendBenefits.cha, "0.000")}
+        Charisma: x{numeralWrapper.format(preAscend.cha, "0.000")} =&gt; x{numeralWrapper.format(postAscend.cha, "0.000")}
         <br />
       </pre>
       <button className="std-button" onClick={confirm}>


### PR DESCRIPTION
ascend modal now shows `[old bonus] => [new bonus]`.
Slight quirk - which was presente before this change, too - is that the number being formatted to three decimal places means sometimes you can ascend and the popup shows no apparent change, e.g.:
hack x1.000 => x1.000 or whatever.

implements #1066 