### PR TITLE
fix typo in Prestige.js

### DIFF
--- a/src/Prestige.js
+++ b/src/Prestige.js
@@ -41,7 +41,7 @@ function prestigeAugmentation() {
     "Blade Industries",
     "NWO",
     "Clarke Incorporated",
-    "Omnitek Incorporated",
+    "OmniTek Incorporated",
     "Four Sigma",
     "KuaiGong International",
     "Fulcrum Secret Technologies",


### PR DESCRIPTION
Should now maintain membership in OmniTek, which was mis-spelled in the file before