### PR TITLE
change status-text-container's position to fixed

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -331,7 +331,7 @@ a:visited {
 
 #status-text-container {
   background-color: transparent;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 50%;
 }

--- a/main.css
+++ b/main.css
@@ -282,7 +282,7 @@ a:visited {
 
 #status-text-container {
   background-color: transparent;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 50%; }
 


### PR DESCRIPTION
this should make it so the status text appears even if you're scrolled way down on a page. Mostly useful for the terminal page.
temporary fix until status texts use toasts/snackbars