### PR TITLE
Fixes Corporation bribe uninentionally affect Bladeburners under cert…

### DIFF
--- a/css/popupboxes.scss
+++ b/css/popupboxes.scss
@@ -25,7 +25,7 @@
   overflow-y: auto;
   z-index: 11; /* Sit on top of the container */
   color: var(--my-font-color);
-  box-shadow: 0px 3px 5px -1px #090, 0px 5px 8px 0px #090, 0px 1px 14px 0px #090;
+  box-shadow: 0 3px 5px -1px #090, 0 5px 8px 0 #090, 0 1px 14px 0 #090;
 }
 
 .popup-box-input-div {

--- a/src/Corporation/ui/BribeFactionPopup.tsx
+++ b/src/Corporation/ui/BribeFactionPopup.tsx
@@ -17,7 +17,7 @@ export function BribeFactionPopup(props: IProps): React.ReactElement {
   const [money, setMoney] = useState<number | null>(0);
   const [stock, setStock] = useState<number | null>(0);
   const [selectedFaction, setSelectedFaction] = useState(
-    props.player.factions.length > 0 ? props.player.factions[0] : "",
+    props.player.factions.length > 0 ? props.player.factions.filter(faction => Factions[faction].getInfo().offersWork())[0] : ""
   );
 
   function onMoneyChange(event: React.ChangeEvent<HTMLInputElement>): void {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -375,7 +375,7 @@ function NetscriptFunctions(workerScript: WorkerScript): NS {
   };
 
   // Utility function to get Hacknet Node object
-  const getHacknetNode = function (i: any, callingFn: string = ""): HacknetNode | HacknetServer {
+  const getHacknetNode = function (i: any, callingFn = ""): HacknetNode | HacknetServer {
     if (isNaN(i)) {
       throw makeRuntimeErrorMsg(callingFn, "Invalid index specified for Hacknet Node: " + i);
     }


### PR DESCRIPTION
I messed up and wrote the explanation and fix in [1383](https://github.com/danielyxie/bitburner/issues/1383). Copied here for posterity: 

If the player has joined the Bladeburners faction first before other factions, and the Bribe Factions dropdown in Corporation menu is not changed to another faction, then the bribe will go to Bladeburners despite the faction in the dropdown. Considering there is no way to affect Bladeburners reputation besides Bladeburner tasks, this is presumably a bug. This is caused by how the factions in the dropdown are chosen.

From [here](https://github.com/danielyxie/bitburner/blob/dev/src/Corporation/ui/BribeFactionPopup.tsx#L82-L90) -
Specifically, factions are filtered by this method: `Factions[name].getInfo().offersWork()` 

versus the initial state for the variable:

From [here](https://github.com/danielyxie/bitburner/blob/dev/src/Corporation/ui/BribeFactionPopup.tsx#L20) -
The initial state is set by `props.player.factions.length > 0 ? props.player.factions[0] : "",`

All I've done is update the former initial value in `useState()` for `selectedFaction` to be in-line with the above.
`props.player.factions.length > 0 ? props.player.factions.filter(faction => Factions[faction].getInfo().offersWork())[0] : ""`
