### PR TITLE
Removed console warning for Sleeves

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -409,7 +409,7 @@ export class Sleeve extends Person {
 
       return jobPerformance * this.company_rep_mult * favorMult;
     } else {
-      console.warn(`Sleeve.getRepGain() called for invalid task type: ${this.currentTask}`);
+      // console.warn(`Sleeve.getRepGain() called for invalid task type: ${this.currentTask}`);
       return 0;
     }
   }


### PR DESCRIPTION
As the function `getRepGain` is called every time when `ns.sleeve.getInformation` is called, it will always give a warning. To prevent the console from filling up, this warning should be removed.