### PR TITLE
Change effect replacer text to x% instead of +x%

### DIFF
--- a/src/CotMG/ui/FragmentInspector.tsx
+++ b/src/CotMG/ui/FragmentInspector.tsx
@@ -55,7 +55,7 @@ export function FragmentInspector(props: IProps): React.ReactElement {
     charge = "N/A";
     effect = `${f.power}x adjacent fragment power`;
   } else {
-    effect = Effect(f.type).replace("+x%", numeralWrapper.formatPercentage(props.gift.effect(props.fragment) - 1));
+    effect = Effect(f.type).replace("x%", numeralWrapper.formatPercentage(props.gift.effect(props.fragment) - 1));
   }
 
   return (


### PR DESCRIPTION
This will make replacement work for hacknet cost (which is -x% so currently is not seen for replacement) and will keep the + or - for effectiveness (e.g. +12.3% hacking skill instead of just 12.3% hacking skill)