### PR TITLE
Added Solarized dark and light themes to code editor.

### DIFF
--- a/src/ScriptEditor/ui/OptionsModal.tsx
+++ b/src/ScriptEditor/ui/OptionsModal.tsx
@@ -45,7 +45,9 @@ export function OptionsModal(props: IProps): React.ReactElement {
           <MenuItem value="vs-dark">dark</MenuItem>
           <MenuItem value="light">light</MenuItem>
           <MenuItem value="monokai">monokai</MenuItem>
-        </Select>
+          <MenuItem value="solarish-dark">solarish-dark</MenuItem>
+	  <MenuItem value="solarish-light">solarish-light</MenuItem>
+	</Select>
       </Box>
 
       <Box display="flex" flexDirection="row" alignItems="center">

--- a/src/ScriptEditor/ui/themes.ts
+++ b/src/ScriptEditor/ui/themes.ts
@@ -63,4 +63,135 @@ export async function loadThemes(monaco: { editor: any }): Promise<void> {
       "editor.selectionHighlightBorder": "#222218",
     },
   });
+
+  monaco.editor.defineTheme("solarish-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [
+      {
+        background: "002b36",
+        token: "",
+      },
+      {
+        foreground: "586e75",
+        token: "comment",
+      },
+      {
+        foreground: "b58900",
+        token: "string",
+      },
+      {
+        token: "number",
+        foreground: "2aa198",
+      },
+      {
+        token: "otherkeyvars",
+        foreground: "ae81ff",
+      },
+      {
+        foreground: "93a1a1",
+        token: "function",
+      },
+      {
+        foreground: "d33682",
+        token: "keyword",
+      },
+      {
+        token: "storage.type.function.js",
+        foreground: "ae81ff",
+      },
+      {
+        token: "ns",
+        foreground: "97d92b",
+      },
+      {
+        token: "netscriptfunction",
+        foreground: "cb4b16",
+      },
+      {
+        token: "otherkeywords",
+        foreground: "cb4b16",
+      },
+      {
+        token: "this",
+        foreground: "fd971f",
+      },
+    ],
+    colors: {
+      "editor.foreground": "#839496",
+      "editor.background": "#002b36",
+      "editor.selectionBackground": "#073642",
+      "editor.lineHighlightBackground": "#073642",
+      "editorCursor.foreground": "#F8F8F0",
+      "editorWhitespace.foreground": "#3B3A32",
+      "editorIndentGuide.activeBackground": "#9D550FB0",
+      "editor.selectionHighlightBorder": "#222218",
+    },
+  });
+
+  monaco.editor.defineTheme("solarish-light", {
+    base: "vs",
+    inherit: true,
+    rules: [
+      {
+        foreground: "657b83",
+	background: "fdf6e3",
+        token: "",
+      },
+      {
+        foreground: "93a1a1",
+        token: "comment",
+      },
+      {
+        foreground: "b58900",
+        token: "string",
+      },
+      {
+        token: "number",
+        foreground: "2aa198",
+      },
+      {
+        token: "otherkeyvars",
+        foreground: "ae81ff",
+      },
+      {
+        foreground: "93a1a1",
+        token: "function",
+      },
+      {
+        foreground: "d33682",
+        token: "keyword",
+      },
+      {
+        token: "storage.type.function.js",
+        foreground: "ae81ff",
+      },
+      {
+        token: "ns",
+        foreground: "97d92b",
+      },
+      {
+        token: "netscriptfunction",
+        foreground: "cb4b16",
+      },
+      {
+        token: "otherkeywords",
+        foreground: "cb4b16",
+      },
+      {
+        token: "this",
+        foreground: "fd971f",
+      },
+    ],
+    colors: {
+      "editor.foreground": "#657b83",
+      "editor.background": "#fdf6e3",
+      "editor.selectionBackground": "#eee8d5",
+      "editor.lineHighlightBackground": "#073642",
+      "editorCursor.foreground": "#657b83",
+      "editorWhitespace.foreground": "#3B3A32",
+      "editorIndentGuide.activeBackground": "#073642",
+      "editor.selectionHighlightBorder": "#073642",
+    },
+  });
 }


### PR DESCRIPTION
Added two themes for the code editor based on Solarized: https://ethanschoonover.com/solarized/
![image](https://user-images.githubusercontent.com/75910435/137805087-99aeac66-f8fb-4111-9022-bfe94c92e1fc.png)
![image](https://user-images.githubusercontent.com/75910435/137805139-f8af5429-c420-43c2-8580-6f804b4b9153.png)
