### PR TITLE
attribute offline hacking gains to hacking rather than hacknet

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -253,7 +253,7 @@ const Engine: {
 
       let offlineReputation = 0;
       const offlineHackingIncome = (Player.moneySourceA.hacking / Player.playtimeSinceLastAug) * timeOffline * 0.75;
-      Player.gainMoney(offlineHackingIncome, "hacknet");
+      Player.gainMoney(offlineHackingIncome, "hacking");
       // Process offline progress
       loadAllRunningScripts(); // This also takes care of offline production for those scripts
       if (Player.isWorking) {


### PR DESCRIPTION
It seems like the offline hacking gains should be attributed to hacking not hacknet.

Here are some screenshots of a new game with just one script hacking an no hacknet nodes but after some offline time I see hacknet income and not enough hacking income. The after screenshot shows only hacking income as should be expected.

Before:
<img width="894" alt="Screen Shot 2021-11-10 at 9 06 44 PM" src="https://user-images.githubusercontent.com/5446367/141240951-f587aed6-d676-446e-9d16-79776b6a3afa.png">
<img width="862" alt="Screen Shot 2021-11-10 at 9 06 58 PM" src="https://user-images.githubusercontent.com/5446367/141240958-cb7996e9-1160-4747-b478-57b754bc8f2d.png">

After:
<img width="1180" alt="Screen Shot 2021-11-10 at 9 07 32 PM" src="https://user-images.githubusercontent.com/5446367/141240965-c3967251-f383-4ab2-aa2f-32fc21682c61.png">

