### PR TITLE
Fix error throwing for unknown errors

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -138,7 +138,8 @@ function startNetscript2Script(workerScript: WorkerScript): Promise<WorkerScript
       workerScript.errorMessage = e;
       throw workerScript;
     }
-    throw e; // Don't know what to do with it, let's rethrow.
+    workerScript.errorMessage = makeRuntimeRejectMsg(workerScript, "Unknown error: " + JSON.stringify(e));
+    throw workerScript;
   });
 }
 


### PR DESCRIPTION
Fix error throwing for unknown errors.

This should prevent unknown script/unknown error message and allow players to see what is being thrown.