### PR TITLE
#1773 - Fix duplicate file extensions

### DIFF
--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -56,7 +56,7 @@ export class Script {
    * Download the script as a file
    */
   download(): void {
-    const filename = this.filename + ".js";
+    const filename = this.filename;
     const file = new Blob([this.code], { type: "text/plain" });
     const navigator = window.navigator as any;
     if (navigator.msSaveOrOpenBlob) {

--- a/src/Terminal/commands/download.ts
+++ b/src/Terminal/commands/download.ts
@@ -19,43 +19,29 @@ export function download(
       return;
     }
     const fn = args[0] + "";
-    if (fn === "*" || fn === "*.script" || fn === "*.txt") {
-      // Download all scripts as a zip
+    // If the parameter starts with *, download all files that match the wildcard pattern
+    if (fn.startsWith("*")) {
+      const matchEnding = fn.length == 1 || fn === "*.*" ? null : fn.slice(1); // Treat *.* the same as *
       const zip = new JSZip();
-      if (fn === "*" || fn === "*.script") {
-        for (let i = 0; i < server.scripts.length; ++i) {
-          const file = new Blob([server.scripts[i].code], {
-            type: "text/plain",
-          });
-          let name = server.scripts[i].filename;
-          if (name.startsWith("/")) {
-            name = name.slice(1);
-          }
-          zip.file(name + ".js", file);
+      // Helper function to zip any file contents whose name matches the pattern
+      let zipFiles = (fileNames: string[], fileContents: string[]) => {
+        for (let i = 0; i < fileContents.length; ++i) {
+          let name = fileNames[i];
+          if (name.startsWith("/")) name = name.slice(1);
+          if (!matchEnding || name.endsWith(matchEnding))
+            zip.file(name, new Blob([fileContents[i]], { type: "text/plain" }));
         }
-      }
-      if (fn === "*" || fn === "*.txt") {
-        for (let i = 0; i < server.textFiles.length; ++i) {
-          const file = new Blob([server.textFiles[i].text], {
-            type: "text/plain",
-          });
-          zip.file(server.textFiles[i].fn, file);
-        }
-      }
-
-      let zipFn = "";
-      switch (fn) {
-        case "*.script":
-          zipFn = "bitburnerScripts.zip";
-          break;
-        case "*.txt":
-          zipFn = "bitburnerTexts.zip";
-          break;
-        default:
-          zipFn = "bitburnerFiles.zip";
-          break;
-      }
-
+      };
+      // In the case of script files, we pull from the server.scripts array
+      if (!matchEnding || isScriptFilename(matchEnding))
+        zipFiles(server.scripts.map(s => s.filename), server.scripts.map(s => s.code));
+      // In the case of text files, we pull from the server.scripts array
+      if (!matchEnding || matchEnding.endsWith(".txt"))
+        zipFiles(server.textFiles.map(s => s.fn), server.textFiles.map(s => s.text));
+      // Return an error if no files matched, rather than an empty zip folder
+      if (Object.keys(zip.files).length == 0)
+        return terminal.error(`No files match the pattern ${fn}`);
+      const zipFn = `bitburner${isScriptFilename(fn) ? "Scripts" : fn === "*.txt" ? "Texts" : "Files"}.zip`;
       zip.generateAsync({ type: "blob" }).then((content: any) => FileSaver.saveAs(content, zipFn));
       return;
     } else if (isScriptFilename(fn)) {


### PR DESCRIPTION
Addresses #1773 

For some time now, filenames have included the extension, so there's no need to append ".js" either on a single-file download or zip download.

Here's an example of the bug we're fixing:
![image](https://user-images.githubusercontent.com/2285037/143520851-489287f3-17ef-4ba5-99d8-b16afabf814c.png)

While I was in the area, I also fixed .txt files in a folder - they had the same bug as scripts used to (appear in the zip as an underscore). I consolidated the code since it was the same for script files and text files.

I also added the ability to download *.js and *.ns (previously only supported *, *.script, and *.txt)

Here's a demo of all that working now:
![image](https://user-images.githubusercontent.com/2285037/143520734-80473677-7438-4c8c-ae5b-8980a448d1ca.png)

I also made the wildcard matching just a bit more flexible, so if someone really wanted to, they could go "download *blah.js" and get all scripts ending with that pattern 
Here's a demo of a feature no-one will ever use (but it came for free with the code ¯\_(ツ)_/¯ )
![image](https://user-images.githubusercontent.com/2285037/143520767-9995ecef-fdf3-49c6-b988-11cf71c40a50.png)