### PR TITLE
#1766 - Fix blackjack double loss, black-on-black text

### DIFF
--- a/src/Casino/Blackjack.tsx
+++ b/src/Casino/Blackjack.tsx
@@ -217,28 +217,17 @@ export class Blackjack extends Game<Props, State> {
   };
 
   finishGame = (result: Result): void => {
-    let gains = 0;
-    if (this.isPlayerWinResult(result)) {
-      gains = this.state.bet;
-      // We 2x the gains because we took away money at the start, so we need to give the original bet back.
-      this.win(this.props.p, 2 * gains);
-    } else if (result === Result.DealerWon) {
-      gains = -1 * this.state.bet;
-      this.win(this.props.p, 0); // We took away the bet at the start, don't need to take more
-      // Dont need to take money here since we already did it at the start
-    } else if (result === Result.Tie) {
-      this.win(this.props.p, this.state.bet); // Get the original bet back
-    }
-
+    const gains = result === Result.DealerWon ? 0 : // We took away the bet at the start, don't need to take more
+      result === Result.Tie ? this.state.bet : // We took away the bet at the start, give it back
+      result === Result.PlayerWon ? 2 * this.state.bet : // Give back their bet plus their winnings
+      result === Result.PlayerWonByBlackjack ? 2.5 * this.state.bet : // Blackjack pays out 1.5x bet!
+      (() => { throw new Error(`Unexpected result: ${result}`); })(); // This can't happen, right?
+    this.win(this.props.p, gains);
     this.setState({
       gameInProgress: false,
       result,
-      gains: this.state.gains + gains,
+      gains: this.state.gains + gains - this.state.bet, // Not updated upfront - only tracks the final outcome
     });
-  };
-
-  isPlayerWinResult = (result: Result): boolean => {
-    return result === Result.PlayerWon || result === Result.PlayerWonByBlackjack;
   };
 
   wagerOnChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -356,20 +345,20 @@ export class Blackjack extends Game<Props, State> {
         )}
 
         {/* Main game part. Displays both if the game is in progress OR if there's a result so you can see
-         * the cards that led to that result. */}
+        * the cards that led to that result. */}
         {(gameInProgress || result !== Result.Pending) && (
           <>
             <Box display="flex">
               <Paper elevation={2}>
-                <pre>Player</pre>
+                <Typography>Player</Typography>
                 {playerHand.cards.map((card, i) => (
                   <ReactCard card={card} key={i} />
                 ))}
 
-                <pre>Value(s): </pre>
-                {playerHandValues.map((value, i) => (
-                  <pre key={i}>{value}</pre>
-                ))}
+                <Typography>Count: {
+                  playerHandValues.map<React.ReactNode>((value, i) => <span key={i}>{value}</span>)
+                    .reduce((prev, curr) => [prev, ' or ', curr])
+                }</Typography>
               </Paper>
             </Box>
 
@@ -377,7 +366,7 @@ export class Blackjack extends Game<Props, State> {
 
             <Box display="flex">
               <Paper elevation={2}>
-                <pre>Dealer</pre>
+                <Typography>Dealer</Typography>
                 {dealerHand.cards.map((card, i) => (
                   // Hide every card except the first while game is in progress
                   <ReactCard card={card} hidden={gameInProgress && i !== 0} key={i} />
@@ -385,10 +374,10 @@ export class Blackjack extends Game<Props, State> {
 
                 {!gameInProgress && (
                   <>
-                    <pre>Value(s): </pre>
-                    {dealerHandValues.map((value, i) => (
-                      <pre key={i}>{value}</pre>
-                    ))}
+                    <Typography>Count: {
+                      dealerHandValues.map<React.ReactNode>((value, i) => <span key={i}>{value}</span>)
+                        .reduce((prev, curr) => [prev, ' or ', curr])
+                    }</Typography>
                   </>
                 )}
               </Paper>
@@ -399,9 +388,10 @@ export class Blackjack extends Game<Props, State> {
         {/* Results from previous round */}
         {result !== Result.Pending && (
           <Typography>
-            {result}
-            {this.isPlayerWinResult(result) && <Money money={this.state.bet} />}
-            {result === Result.DealerWon && <Money money={this.state.bet} />}
+            {result}&nbsp;
+            {result === Result.PlayerWon && <Money money={this.state.bet} />}
+            {result === Result.PlayerWonByBlackjack && <Money money={this.state.bet * 1.5} />}
+            {result === Result.DealerWon && <Money money={-this.state.bet} />}
           </Typography>
         )}
       </>

--- a/src/Casino/Blackjack.tsx
+++ b/src/Casino/Blackjack.tsx
@@ -75,7 +75,7 @@ export class Blackjack extends Game<Props, State> {
     }
 
     // Take money from player right away so that player's dont just "leave" to avoid the loss (I mean they could
-    // always reload without saving but w.e)
+    // always reload without saving but w.e) TODO: Save/Restore the RNG state to limit the value of save-scumming.
     this.props.p.loseMoney(this.state.bet, "casino");
 
     const playerHand = new Hand([this.deck.safeDrawCard(), this.deck.safeDrawCard()]);
@@ -220,12 +220,11 @@ export class Blackjack extends Game<Props, State> {
     let gains = 0;
     if (this.isPlayerWinResult(result)) {
       gains = this.state.bet;
-
       // We 2x the gains because we took away money at the start, so we need to give the original bet back.
       this.win(this.props.p, 2 * gains);
     } else if (result === Result.DealerWon) {
       gains = -1 * this.state.bet;
-      this.win(this.props.p, -this.state.bet); // Get the original bet back
+      this.win(this.props.p, 0); // We took away the bet at the start, don't need to take more
       // Dont need to take money here since we already did it at the start
     } else if (result === Result.Tie) {
       this.win(this.props.p, this.state.bet); // Get the original bet back


### PR DESCRIPTION
I'll lead with this so it doesn't look like I snuck it in: Winning by blackjack is special and usually pays 1.5x so I made it so :) All the infrastructure was already in place.

Primary motivation though was to addresses issue #1766 
Bet was being removed twice instead of just once. This fact was accounted for in the win and tie if branches, but not the loss branch.

I also discovered that this screen isn't displaying text correctly. I'm used to seeing this:
![image](https://user-images.githubusercontent.com/2285037/143527607-36bffa3c-392e-4721-9260-c228fe8a9e7b.png)

Did you know the game counted your cards for you! This is fixed now:
![image](https://user-images.githubusercontent.com/2285037/143527805-fce06edd-b540-407a-95e4-2debfaa5d004.png)

I made a few other judgment calls and tidied up the output. Here's a sample of each (to prove I tested everything :p)

Tested everything thoroughly of course.

Win: (gain bet)
![image](https://user-images.githubusercontent.com/2285037/143527739-343214e7-dd65-45f2-8491-3c2855e24d7a.png)

Tie: (no net change)
![image](https://user-images.githubusercontent.com/2285037/143527849-e0bf8e40-2b44-4a6e-b698-1a911d4270ee.png)

Lose: (lose bet only once now!)
![image](https://user-images.githubusercontent.com/2285037/143527712-cebd5c7b-24e9-40bf-9692-2020b115d59b.png)

Blackjack!
![image](https://user-images.githubusercontent.com/2285037/143527925-50f54138-40af-4f3d-a592-361914431667.png)
