### PR TITLE
Toast() crashes window on object argument #1868

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -2128,7 +2128,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
     toast: function (message: any, variant: any = "success"): void {
       if (!["success", "info", "warning", "error"].includes(variant))
         throw new Error(`variant must be one of "success", "info", "warning", or "error"`);
-      SnackbarEvents.emit(message, variant);
+      SnackbarEvents.emit(message.toString(), variant);
     },
     prompt: function (txt: any): any {
       if (!isString(txt)) {

--- a/src/ThirdParty/JSInterpreter.js
+++ b/src/ThirdParty/JSInterpreter.js
@@ -1915,6 +1915,9 @@ Interpreter.Object.prototype.toString = function () {
     }
     return message ? name + ": " + message : String(name);
   }
+  if (this.class === "Object") {
+      return JSON.stringify(this.properties)
+  }
 
   // RegExp, Date, and boxed primitives.
   if (this.data !== null) {


### PR DESCRIPTION
> Note: this is my first contribution. Please make sure this change won't break anything.

This PR allows using objects in a toast() function. It will use `Interpreter.Object.toString()` function in case of non-primitive type.
Example NetScript:
```
toast(1)
toast('str')
toast(['a', 'b'])
toast({a: 12, b: 'str'})
```
Will produce the following toast notifications:
![image](https://user-images.githubusercontent.com/26609879/146311827-125774f6-03b5-4b10-a62b-472b56b08e35.png)
