### PR TITLE
Fix #1883: Add confirmation alerts for resets

### DIFF
--- a/src/Augmentation/ui/AugmentationsRoot.tsx
+++ b/src/Augmentation/ui/AugmentationsRoot.tsx
@@ -11,9 +11,11 @@ import { SourceFiles } from "./SourceFiles";
 
 import { canGetBonus } from "../../ExportBonus";
 import { use } from "../../ui/Context";
+import { Modal } from "../../ui/React/Modal";
 
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 import Box from "@mui/material/Box";
 
@@ -25,6 +27,7 @@ interface IProps {
 export function AugmentationsRoot(props: IProps): React.ReactElement {
   const player = use.Player();
   const setRerender = useState(false)[1];
+  const [isInstallationOpen, setInstallationOpen] = useState(false);
   function rerender(): void {
     setRerender((o) => !o);
   }
@@ -72,11 +75,34 @@ export function AugmentationsRoot(props: IProps): React.ReactElement {
       </Typography>
       <Box mx={2}>
         <Tooltip title={<Typography>'I never asked for this'</Typography>}>
-          <span>
-            <Button disabled={player.queuedAugmentations.length === 0} onClick={props.installAugmentationsFn}>
+          <>
+            <Button disabled={player.queuedAugmentations.length === 0} onClick={() => setInstallationOpen(true)}>
               Install Augmentations
             </Button>
-          </span>
+            <Modal open={isInstallationOpen} onClose={() => setInstallationOpen(false)}>
+              <Typography>
+                WARNING: THIS WILL PARTIALLY RESET YOUR PROGRESS
+                <br />
+                <br />
+                For your first installation, it is recommended to purchase most of the CSEC augmentations.
+                <br />
+                If you are unsure, you should EXPORT your save game as a backup before!
+                <br />
+                <br />
+                <Typography variant="subtitle2"><em>This is the first prestige mechanism.</em></Typography>
+              </Typography>
+              <br />
+
+              <ButtonGroup>
+                <Button onClick={() => setInstallationOpen(false)}>
+                  No, Cancel Installation
+                </Button>
+                <Button color="error" disabled={player.queuedAugmentations.length === 0} onClick={props.installAugmentationsFn}>
+                  Yes, Install Augmentations
+                </Button>
+              </ButtonGroup>
+            </Modal>
+          </>
         </Tooltip>
         <Tooltip title={<Typography>It's always a good idea to backup/export your save!</Typography>}>
           <Button sx={{ mx: 2 }} onClick={doExport} color="error">

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -13,6 +13,7 @@ import Switch from "@mui/material/Switch";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
 
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
@@ -28,7 +29,7 @@ import { FileDiagnosticModal } from "../../Diagnostic/FileDiagnosticModal";
 import { dialogBoxCreate } from "./DialogBox";
 import { ConfirmationModal } from "./ConfirmationModal";
 import { ThemeEditorModal } from "./ThemeEditorModal";
-
+import { Modal } from "../../ui/React/Modal";
 import { Settings } from "../../Settings/Settings";
 import { save, deleteGame } from "../../db";
 import { formatTime } from "../../utils/helpers/formatTime";
@@ -82,6 +83,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
   const [diagnosticOpen, setDiagnosticOpen] = useState(false);
   const [deleteGameOpen, setDeleteOpen] = useState(false);
   const [themeEditorOpen, setThemeEditorOpen] = useState(false);
+  const [softResetOpen, setSoftResetOpen] = useState(false);
 
   function handleExecTimeChange(event: any, newValue: number | number[]): void {
     setExecTime(newValue as number);
@@ -626,7 +628,28 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
                 </Typography>
               }
             >
-              <Button onClick={() => props.softReset()}>Soft Reset</Button>
+              <>
+                <Button onClick={() => setSoftResetOpen(true)}>Soft Reset</Button>
+                <Modal open={softResetOpen} onClose={() => setSoftResetOpen(false)}>
+                  <Typography>
+                    WARNING: THIS WILL RESET YOUR PROGRESS
+                    <br />
+                    <br />
+                    This feature should only be useful if you know what you are doing.
+                    <br />
+                    If you are unsure, you should EXPORT your save game as a backup before!
+                  </Typography>
+                  <br />
+                  <ButtonGroup>
+                    <Button onClick={() => setSoftResetOpen(false)}>
+                      No, Cancel Operation
+                    </Button>
+                    <Button color="error" onClick={() => props.softReset()}>
+                      Yes, Execute Soft Reset
+                    </Button>
+                  </ButtonGroup>
+                </Modal>
+              </>
             </Tooltip>
           </Box>
           <Box>


### PR DESCRIPTION
Add a yes/no alert for augmentation installation & soft reset

Augmentations

![firefox_YdpAxHJwaJ](https://user-images.githubusercontent.com/1521080/146477678-5cad6aff-1cdc-474b-8891-000ea3a9259b.png)

Soft Reset

![firefox_33G76gBsex](https://user-images.githubusercontent.com/1521080/146477683-ee4ca717-0053-4ea7-aaf5-c59b48bd51a7.png)
