### PR TITLE
Fix #1902: Set default electron color to black

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -14,6 +14,7 @@ function createWindow(killall) {
   win = new BrowserWindow({
     show: false,
     backgroundThrottling: false,
+    backgroundColor: '#000000',
   });
 
   win.removeMenu();


### PR DESCRIPTION
If loading of the index.html is slow, there should be no white
background anymore.

Not sure if this fixes the issue completely or partially.

![bitburner_wtzgoozmFb](https://user-images.githubusercontent.com/1521080/146533886-c89de126-c51f-41a9-b006-aa3112b892a9.png)
.