### PR TITLE
Set default editorconfig to indent_size=2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,12 +2,9 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[package.json]
-indent_size = 2
 
 [md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Prettier already formats the code like that, so it causes a mismatch for
devs using editorconfig as well.

There seem to be a few .js files using indent 4 though, in /scripts.