### PR TITLE
Fix #1974: Change default input to deferred

### DIFF
--- a/src/ui/React/ThemeEditorModal.tsx
+++ b/src/ui/React/ThemeEditorModal.tsx
@@ -40,6 +40,7 @@ function ColorEditor({ name, onColorChange, color, defaultColor }: IColorEditorP
             <>
               <ColorPicker
                 hideTextfield
+                deferred
                 value={color}
                 onChange={(newColor: Color) => onColorChange(name, "#" + newColor.hex)}
               />


### PR DESCRIPTION
The value does not change automatically now, there's a "Set" button in
the popup to trigger the onColorChange event
![firefox_tWHJnm65RD](https://user-images.githubusercontent.com/1521080/146573026-42f5fe46-898f-4691-900c-00ea364ce9f5.png)
.