### PR TITLE
Fix problems finding root files in cat and ns.read

### DIFF
--- a/src/Terminal/DirectoryHelpers.ts
+++ b/src/Terminal/DirectoryHelpers.ts
@@ -185,7 +185,7 @@ export function getDestinationFilepath(destination: string, source: string, cwd:
     return destination;
   } else {
     // Append the filename to the directory provided.
-    let t_path = removeTrailingSlash(dstDir);
+    const t_path = removeTrailingSlash(dstDir);
     const fileName = getFileName(source);
     return t_path + "/" + fileName;
   }

--- a/src/Terminal/commands/cat.ts
+++ b/src/Terminal/commands/cat.ts
@@ -39,7 +39,7 @@ export function cat(
       }
     }
   } else if (filename.endsWith(".txt")) {
-    const txt = terminal.getTextFile(player, filename);
+    const txt = terminal.getTextFile(player, "/" + filename);
     if (txt != null) {
       txt.show();
       return;

--- a/src/Terminal/commands/cat.ts
+++ b/src/Terminal/commands/cat.ts
@@ -16,7 +16,8 @@ export function cat(
     terminal.error("Incorrect usage of cat command. Usage: cat [file]");
     return;
   }
-  const filename = terminal.getFilepath(args[0] + "");
+  const relative_filename = args[0] + "";
+  const filename = terminal.getFilepath(relative_filename);
   if (!filename.endsWith(".msg") && !filename.endsWith(".lit") && !filename.endsWith(".txt")) {
     terminal.error(
       "Only .msg, .txt, and .lit files are viewable with cat (filename must end with .msg, .txt, or .lit)",
@@ -39,7 +40,7 @@ export function cat(
       }
     }
   } else if (filename.endsWith(".txt")) {
-    const txt = terminal.getTextFile(player, "/" + filename);
+    const txt = terminal.getTextFile(player, relative_filename);
     if (txt != null) {
       txt.show();
       return;

--- a/src/TextFile.ts
+++ b/src/TextFile.ts
@@ -1,6 +1,7 @@
 import { dialogBoxCreate } from "./ui/React/DialogBox";
 import { BaseServer } from "./Server/BaseServer";
 import { Generic_fromJSON, Generic_toJSON, Reviver } from "./utils/JSONReviver";
+import { removeLeadingSlash, isInRootDirectory } from "./Terminal/DirectoryHelpers"
 
 /**
  * Represents a plain text file that is typically stored on a server.
@@ -101,7 +102,11 @@ Reviver.constructors.TextFile = TextFile;
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getTextFile(fn: string, server: BaseServer): TextFile | null {
-  const filename: string = !fn.endsWith(".txt") ? `${fn}.txt` : fn;
+  let filename: string = !fn.endsWith(".txt") ? `${fn}.txt` : fn;
+
+  if (isInRootDirectory(filename)) {
+    filename = removeLeadingSlash(filename);
+  }
 
   for (const file of server.textFiles as TextFile[]) {
     if (file.fn === filename) {


### PR DESCRIPTION
Cat ends up translating the path it receives from relative to absolute twice, which I fix by changing the filename to an absolute path before it's passed to getTextFile with a leading "/" so that it doesn't interpret the filename as being relative.

Read I fixed by causing getTextFile to remove the leading "/" from files that are in the root directory, since that is required to translate their name into the native "filesystem"s format.

The cat changes can be tested via the following:
`
nano test_root_file.txt
test root file text
ctrl-b
nano test_directory/test_dir_file.txt

ctrl-b
cd test_directory
cat test_root_file.txt
`
And the ns.read() change via the attached file:
[ns_read_bugfix_test.zip](https://github.com/danielyxie/bitburner/files/7738748/ns_read_bugfix_test.zip)
