### PR TITLE
Allow hyphens in command aliases

### DIFF
--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -36,7 +36,7 @@ export function printAliases(): void {
 
 // Returns true if successful, false otherwise
 export function parseAliasDeclaration(dec: string, global = false): boolean {
-  const re = /^([_|\w|!|%|,|@]+)="(.+)"$/;
+  const re = /^([\w|!|%|,|@|-]+)="(.+)"$/;
   const matches = dec.match(re);
   if (matches == null || matches.length != 3) {
     return false;


### PR DESCRIPTION
- Allow hyphens in aliases
- Remove redundant underscore, covered by '\w'

Resolves danielyxie/bitburner#2000