### PR TITLE
Allow `.exe` (programs) to be ran in a case-insensitive `run`

### DIFF
--- a/src/Terminal/commands/runProgram.ts
+++ b/src/Terminal/commands/runProgram.ts
@@ -33,7 +33,7 @@ export function runProgram(
   }
 
   for (const program of Object.values(Programs)) {
-    if (program.name === programName) {
+    if (program.name.toLocaleLowerCase() === programName.toLocaleLowerCase()) {
       program.run(
         router,
         terminal,


### PR DESCRIPTION
Allow the user to run programs (.exe) in a case insensitive manor, i.e. `run nUkE.eXe`

Resolves danielyxie/bitburner#1958