### PR TITLE
Better feedback when looking for a running script.

### DIFF
--- a/src/Script/isScriptFilename.ts
+++ b/src/Script/isScriptFilename.ts
@@ -1,3 +1,5 @@
+export const validScriptExtensions: Array<string> = [`.js`, `.script`, `.ns`];
+
 export function isScriptFilename(f: string): boolean {
-  return f.endsWith(".js") || f.endsWith(".script") || f.endsWith(".ns");
+  return validScriptExtensions.some((ext) => f.endsWith(ext));
 }

--- a/src/Terminal/commands/check.ts
+++ b/src/Terminal/commands/check.ts
@@ -19,7 +19,7 @@ export function check(
     // Can only tail script files
     if (!isScriptFilename(scriptName)) {
       terminal.error(
-        `'check' can only be called on .script files (filename must end with ${validScriptExtensions.join(", ")})`,
+        `'check' can only be called on scripts files (filename must end with ${validScriptExtensions.join(", ")})`,
       );
       return;
     }

--- a/src/Terminal/commands/check.ts
+++ b/src/Terminal/commands/check.ts
@@ -3,7 +3,7 @@ import { IRouter } from "../../ui/Router";
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { BaseServer } from "../../Server/BaseServer";
 import { findRunningScript } from "../../Script/ScriptHelpers";
-import { isScriptFilename } from "../../Script/isScriptFilename";
+import { isScriptFilename, validScriptExtensions } from "../../Script/isScriptFilename";
 
 export function check(
   terminal: ITerminal,
@@ -13,19 +13,21 @@ export function check(
   args: (string | number | boolean)[],
 ): void {
   if (args.length < 1) {
-    terminal.error("Incorrect number of arguments. Usage: check [script] [arg1] [arg2]...");
+    terminal.error(`Incorrect number of arguments. Usage: check [script] [arg1] [arg2]...`);
   } else {
     const scriptName = terminal.getFilepath(args[0] + "");
     // Can only tail script files
     if (!isScriptFilename(scriptName)) {
-      terminal.error("tail can only be called on .script files (filename must end with .script)");
+      terminal.error(
+        `'check' can only be called on .script files (filename must end with ${validScriptExtensions.join(", ")})`,
+      );
       return;
     }
 
-    // Check that the script exists on this machine
+    // Check that the script is running on this machine
     const runningScript = findRunningScript(scriptName, args.slice(1), server);
     if (runningScript == null) {
-      terminal.error("No such script exists");
+      terminal.error(`No script named ${scriptName} is not running on the server`);
       return;
     }
     runningScript.displayLog();

--- a/src/Terminal/commands/check.ts
+++ b/src/Terminal/commands/check.ts
@@ -27,7 +27,7 @@ export function check(
     // Check that the script is running on this machine
     const runningScript = findRunningScript(scriptName, args.slice(1), server);
     if (runningScript == null) {
-      terminal.error(`No script named ${scriptName} is not running on the server`);
+      terminal.error(`No script named ${scriptName} is running on the server`);
       return;
     }
     runningScript.displayLog();

--- a/src/Terminal/commands/kill.ts
+++ b/src/Terminal/commands/kill.ts
@@ -27,7 +27,7 @@ export function kill(
       if (res) {
         terminal.print(`Killing script with PID ${pid}`);
       } else {
-        terminal.error(`Failed to kill script with PID ${pid}. No such script exists`);
+        terminal.error(`Failed to kill script with PID ${pid}. No such script is running`);
       }
 
       return;

--- a/src/Terminal/commands/mem.ts
+++ b/src/Terminal/commands/mem.ts
@@ -29,7 +29,7 @@ export function mem(
 
     const script = terminal.getScript(player, scriptName);
     if (script == null) {
-      terminal.error("No such script exists!");
+      terminal.error("mem failed. No such script exists!");
       return;
     }
 

--- a/src/Terminal/commands/scp.ts
+++ b/src/Terminal/commands/scp.ts
@@ -90,7 +90,7 @@ export function scp(
       }
     }
     if (sourceScript == null) {
-      terminal.error("scp() failed. No such script exists");
+      terminal.error("scp failed. No such script exists");
       return;
     }
 

--- a/src/Terminal/commands/tail.ts
+++ b/src/Terminal/commands/tail.ts
@@ -20,7 +20,7 @@ export function tail(
     } else if (typeof commandArray[0] === "string") {
       const scriptName = terminal.getFilepath(commandArray[0]);
       if (!isScriptFilename(scriptName)) {
-        terminal.error(`tail can only be called on ${validScriptExtensions.join(", ")} files, or by pid`);
+        terminal.error(`tail can only be called on ${validScriptExtensions.join(", ")} files, or by PID`);
         return;
       }
 
@@ -66,11 +66,11 @@ export function tail(
       }
 
       // if there's no candidate then we just don't know.
-      terminal.error(`No script named ${scriptName} is not running on the server`);
+      terminal.error(`No script named ${scriptName} is running on the server`);
     } else if (typeof commandArray[0] === "number") {
       const runningScript = findRunningScriptByPid(commandArray[0], server);
       if (runningScript == null) {
-        terminal.error(`No script with pid ${commandArray[0]} is not running on the server`);
+        terminal.error(`No script with PID ${commandArray[0]} is running on the server`);
         return;
       }
       LogBoxEvents.emit(runningScript);

--- a/src/Terminal/commands/tail.ts
+++ b/src/Terminal/commands/tail.ts
@@ -3,7 +3,7 @@ import { IRouter } from "../../ui/Router";
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { BaseServer } from "../../Server/BaseServer";
 import { findRunningScriptByPid } from "../../Script/ScriptHelpers";
-import { isScriptFilename } from "../../Script/isScriptFilename";
+import { isScriptFilename, validScriptExtensions } from "../../Script/isScriptFilename";
 import { compareArrays } from "../../utils/helpers/compareArrays";
 import { LogBoxEvents } from "../../ui/React/LogBoxManager";
 
@@ -20,7 +20,7 @@ export function tail(
     } else if (typeof commandArray[0] === "string") {
       const scriptName = terminal.getFilepath(commandArray[0]);
       if (!isScriptFilename(scriptName)) {
-        terminal.error("tail can only be called on .script, .ns, .js files, or by pid");
+        terminal.error(`tail can only be called on ${validScriptExtensions.join(", ")} files, or by pid`);
         return;
       }
 
@@ -66,11 +66,11 @@ export function tail(
       }
 
       // if there's no candidate then we just don't know.
-      terminal.error("No such script exists.");
+      terminal.error(`No script named ${scriptName} is not running on the server`);
     } else if (typeof commandArray[0] === "number") {
       const runningScript = findRunningScriptByPid(commandArray[0], server);
       if (runningScript == null) {
-        terminal.error("No such script exists");
+        terminal.error(`No script with pid ${commandArray[0]} is not running on the server`);
         return;
       }
       LogBoxEvents.emit(runningScript);


### PR DESCRIPTION
Found most (hopefully all) places where the error message wording incorrectly was shown to the tune of 'no script exists', where it should have been showing to the effect of 'script is not running'.
Also cleaned up some of the consistency in the wording and added a 'helper' export for knowing valid script extensions used in validation of 'isScriptFilename', so we can have consistent error messaging.

Resolves danielyxie/bitburner#1966