### PR TITLE
Fix issue of space in server name and server counting when made with same name

### DIFF
--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -16,22 +16,25 @@ import { isValidNumber } from "../utils/helpers/isValidNumber";
  * does not have a duplicate hostname/ip.
  */
 export function safetlyCreateUniqueServer(params: IConstructorParams): Server {
+  let hostname: string = params.hostname.replace(/ /g, `-`);
+
   if (params.ip != null && ipExists(params.ip)) {
     params.ip = createUniqueRandomIp();
   }
 
-  if (GetServer(params.hostname) != null) {
+  if (GetServer(hostname) != null) {
+    hostname = `${hostname}-0`;
+
     // Use a for loop to ensure that we don't get suck in an infinite loop somehow
-    let hostname: string = params.hostname;
     for (let i = 0; i < 200; ++i) {
-      hostname = `${params.hostname}-${i}`;
+      hostname = hostname.replace(/-[0-9]+$/, `-${i}`);
       if (GetServer(hostname) == null) {
         break;
       }
     }
-    params.hostname = hostname;
   }
 
+  params.hostname = hostname;
   return new Server(params);
 }
 

--- a/src/Server/ServerPurchases.ts
+++ b/src/Server/ServerPurchases.ts
@@ -96,7 +96,7 @@ export function purchaseServer(hostname: string, ram: number, cost: number, p: I
 
   p.loseMoney(cost, "servers");
 
-  dialogBoxCreate("Server successfully purchased with hostname " + hostname);
+  dialogBoxCreate("Server successfully purchased with hostname " + newServ.hostname);
 }
 
 // Manually upgrade RAM on home computer (NOT through Netscript)


### PR DESCRIPTION
Replace the space in a server name with a hyphen (-), also noticed some interesting behaviour with the 'count up naming', so tweaked that.

## Video:

https://user-images.githubusercontent.com/1098786/146663473-7701073e-ce4d-4ff0-8835-16a3239494a0.mp4

_Note: With these changes, if you make multiple servers with the host `my-server-5`, it will start the count after this name, so another `my-server-5` will result in `my-server-5-0`, `my-server-5-1`, `my-server-5-2`, etc._

Resolves danielyxie/bitburner#1999