### PR TITLE
Update ls.tsx

### DIFF
--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -17,7 +17,7 @@ export function ls(
     terminal.error("Incorrect usage of ls command. Usage: ls [dir] [| grep pattern]");
   }
 
-  if (numArgs > 5 || numArgs === 3) {
+  if (numArgs > 4 || numArgs === 2) {
     return incorrectUsage();
   }
 
@@ -30,12 +30,12 @@ export function ls(
     prefix += "/";
   }
 
-  // If there are 4+ arguments, then the last 3 must be for grep
-  if (numArgs >= 4) {
-    if (args[numArgs - 1] !== "grep" || args[numArgs - 2] !== "|") {
+  // If there are 3+ arguments, then the last 3 must be for grep
+  if (numArgs >= 3) {
+    if (args[numArgs - 2] !== "grep" || args[numArgs - 3] !== "|") {
       return incorrectUsage();
     }
-    filter = args[numArgs] + "";
+    filter = args[numArgs - 1] + "";
   }
 
   // If the second argument is not a pipe, then it must be for listing a directory


### PR DESCRIPTION
`args[numArgs - 1]` is the last argument in the list, so correct usage was being flagged as incorrect, and incorrect usage wasn't working anyway because the filter was `"undefined"`.

Additionally, the function seemed confused as to whether or not `ls` counted as an argument (AFAICT, it isn't).

Fixes #1994.