### PR TITLE
Only run job shortcut if the player has a job

### DIFF
--- a/src/PersonObjects/IPlayer.ts
+++ b/src/PersonObjects/IPlayer.ts
@@ -242,6 +242,7 @@ export interface IPlayer {
   getIntelligenceBonus(weight: number): number;
   getCasinoWinnings(): number;
   quitJob(company: string): void;
+  hasJob(): boolean;
   createHacknetServer(): HacknetServer;
   startCreateProgramWork(router: IRouter, programName: string, time: number, reqLevel: number): void;
   queueAugmentation(augmentationName: string): void;

--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -247,6 +247,7 @@ export class PlayerObject implements IPlayer {
   getIntelligenceBonus: (weight: number) => number;
   getCasinoWinnings: () => number;
   quitJob: (company: string) => void;
+  hasJob: () => boolean;
   process: (router: IRouter, numCycles?: number) => void;
   createHacknetServer: () => HacknetServer;
   startCreateProgramWork: (router: IRouter, programName: string, time: number, reqLevel: number) => void;
@@ -531,6 +532,7 @@ export class PlayerObject implements IPlayer {
     this.applyForJob = generalMethods.applyForJob;
     this.getNextCompanyPosition = generalMethods.getNextCompanyPosition;
     this.quitJob = generalMethods.quitJob;
+    this.hasJob = generalMethods.hasJob;
     this.applyForSoftwareJob = generalMethods.applyForSoftwareJob;
     this.applyForSoftwareConsultantJob = generalMethods.applyForSoftwareConsultantJob;
     this.applyForItJob = generalMethods.applyForItJob;

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1782,6 +1782,15 @@ export function quitJob(this: IPlayer, company: string): void {
   delete this.jobs[company];
 }
 
+/**
+ * Method to see if the player has at least one job assigned to them
+ * @param this The player instance
+ * @returns Whether the user has at least one job
+ */
+export function hasJob(this: IPlayer): boolean {
+  return Boolean(Object.keys(this.jobs).length);
+}
+
 export function applyForSoftwareJob(this: IPlayer, sing = false): boolean {
   return this.applyForJob(CompanyPositions[posNames.SoftwareCompanyPositions[0]], sing);
 }

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -292,7 +292,7 @@ export function SidebarRoot(props: IProps): React.ReactElement {
       } else if (event.keyCode === KEY.W && event.altKey) {
         event.preventDefault();
         clickCity();
-      } else if (event.keyCode === KEY.J && event.altKey && !event.ctrlKey && !event.metaKey) {
+      } else if (event.keyCode === KEY.J && event.altKey && !event.ctrlKey && !event.metaKey && props.player.hasJob()) {
         // ctrl/cmd + alt + j is shortcut to open Chrome dev tools
         event.preventDefault();
         clickJob();


### PR DESCRIPTION
The shortcut was always allowed to run, meaning when the player doesn't have a job, they were sent to the job screen with no job and lost the view context/sidebar.

- Add utility method to check if the player 'hasJob', being at least 1 job.
- Check if player has job when the key combination is pressed

Resolves danielyxie/bitburner#2013

----

Currently the shortcut does nothing when there the player has no jobs, wasn't sure if it was worth adding a 'toast' to say "Can not go to job when you don't work!"... A further enhancement perhaps? 😄