### PR TITLE
Issue #2048 fix

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -319,7 +319,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
           ) : (
             <Box display="flex" flexDirection="row" width="100%">
               <SidebarRoot player={player} router={Router} page={page} />
-              <Box className={classes.root} flexGrow={1} display="block" px={1} height="100vh">
+              <Box className={classes.root} flexGrow={1} display="block" px={1} min-height="100vh">
                 {page === Page.Terminal ? (
                   <TerminalRoot terminal={terminal} router={Router} player={player} />
                 ) : page === Page.Sleeves ? (


### PR DESCRIPTION
Issue #2048 fix.
Not tested, based on fix in devtools in running game.

Although, I would suggest applying background-primary color to \<html\> element directly.
Or to the \<body\>, but remove its padding, because there are not-so-nice gaps, as shown below:
<img width="1297" alt="Снимок экрана 2021-12-20 в 00 16 45" src="https://user-images.githubusercontent.com/25911879/146691079-6096d50e-d044-43a1-8781-73d6404da126.png">
