### PR TITLE
Handle electron process uncaught exceptions

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,11 +1,21 @@
+/* eslint-disable no-process-exit */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { app, BrowserWindow, Menu, shell, dialog } = require("electron");
+const log = require('electron-log');
 const greenworks = require("./greenworks");
 
+log.catchErrors();
+log.info(`Started app: ${JSON.stringify(process.argv)}`);
+
+process.on('uncaughtException', function () {
+  // The exception will already have been logged by electron-log
+  process.exit(1);
+});
+
 if (greenworks.init()) {
-  console.log("Steam API has been initialized.");
+  log.info("Steam API has been initialized.");
 } else {
-  console.log("Steam API has failed to initialize.");
+  log.warn("Steam API has failed to initialize.");
 }
 
 const debug = false;
@@ -67,6 +77,7 @@ function createWindow(killall) {
   win.achievementsIntervalID = intervalID;
 
   const reloadAndKill = (killScripts = true) => {
+    log.info('Reloading & Killing all scripts...');
     setStopProcessHandler(app, win, false);
     if (intervalID) clearInterval(intervalID);
     win.webContents.forcefullyCrashRenderer();
@@ -168,8 +179,8 @@ function setStopProcessHandler(app, window, enabled) {
 
   const stopProcessHandler = () => {
     if (process.platform !== "darwin") {
+      log.info('Quitting the app...');
       app.quit();
-      // eslint-disable-next-line no-process-exit
       process.exit(0);
     }
   };
@@ -184,6 +195,7 @@ function setStopProcessHandler(app, window, enabled) {
 }
 
 app.whenReady().then(() => {
+  log.info('Application is ready!');
   const win = createWindow(process.argv.includes("--no-scripts"));
   setStopProcessHandler(app, win, true);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "bitburner",
       "version": "1.2.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
@@ -62,6 +63,7 @@
         "babel-loader": "^8.0.5",
         "cypress": "^8.3.1",
         "electron": "^14.0.2",
+        "electron-log": "^4.4.3",
         "electron-packager": "^15.4.0",
         "eslint": "^7.24.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
@@ -7628,6 +7630,12 @@
       "engines": {
         "node": ">= 8.6"
       }
+    },
+    "node_modules/electron-log": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.3.tgz",
+      "integrity": "sha512-IWxkiVLSpbI4if61kTSLMErYwz+Jq/gnHeTtQ8jcAjtlU8rgTIScWBgZJxk3fVnyvW6M+Ci3Bn9ogHgjgDSvNg==",
+      "dev": true
     },
     "node_modules/electron-notarize": {
       "version": "1.1.1",
@@ -27695,6 +27703,12 @@
           "dev": true
         }
       }
+    },
+    "electron-log": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.3.tgz",
+      "integrity": "sha512-IWxkiVLSpbI4if61kTSLMErYwz+Jq/gnHeTtQ8jcAjtlU8rgTIScWBgZJxk3fVnyvW6M+Ci3Bn9ogHgjgDSvNg==",
+      "dev": true
     },
     "electron-notarize": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "babel-loader": "^8.0.5",
     "cypress": "^8.3.1",
     "electron": "^14.0.2",
+    "electron-log": "^4.4.3",
     "electron-packager": "^15.4.0",
     "eslint": "^7.24.0",
     "fork-ts-checker-webpack-plugin": "^6.3.3",
@@ -112,8 +113,8 @@
     "test:watch": "jest --watch",
     "watch": "webpack --watch --mode production",
     "watch:dev": "webpack --watch --mode development",
-    "package-electron": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png",
-    "electron": "cp -r electron/* .package && cp index.html .package && cp main.bundle.js .package && cp dist/vendor.bundle.js .package/dist/ && cp -r dist/ext .package/dist/ && electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png",
+    "electron": "sh ./package.sh",
+    "electron:packager": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png --no-prune",
     "allbuild": "npm run build && npm run electron && git add --all && git commit --amend --no-edit && git push -f -u origin dev"
   }
 }

--- a/package.sh
+++ b/package.sh
@@ -1,11 +1,13 @@
-# npm install electron --save-dev
-# npm install electron-packager --save-dev
+#!/bin/sh
 
 mkdir -p .package/dist/src/ThirdParty || true
 mkdir -p .package/src/ThirdParty || true
+mkdir -p .package/node_modules || true
 
 cp index.html .package
-cp electron/* .package
+cp -r electron/* .package
+cp -r dist/ext .package/dist
+
 # The css files
 cp dist/vendor.css .package/dist
 cp main.css .package/main.css
@@ -14,6 +16,7 @@ cp main.css .package/main.css
 cp dist/vendor.bundle.js .package/dist/vendor.bundle.js
 cp main.bundle.js .package/main.bundle.js
 
-cp src/ThirdParty/raphael.min.js .package/src/ThirdParty/raphael.min.js
+# Adding electron-log dependency
+cp -r node_modules/electron-log .package/node_modules/electron-log
 
-npm run package-electron
+npm run electron:packager


### PR DESCRIPTION
I managed to reproduce one version of the dangling bitburner.exe processes in Windows. When steamworks.init() throws an Error before the window is ready, the app crashes and keeps 3 processes running. 
To reproduce: remove steam_appid.txt and run the .exe directly, get a crash, check task manager.

Adding an event handler to the process and closing the app at that point seem to properly kill the
dangling processes.

Also added [electron-log](https://github.com/megahertz/electron-log) to logs to a text file.
By default, it writes logs to the following locations:

    on Linux: ~/.config/{app name}/logs/{process type}.log
    on macOS: ~/Library/Logs/{app name}/{process type}.log
    on Windows: %USERPROFILE%\AppData\Roaming\{app name}\logs\{process type}.log
