### PR TITLE
feat(command:buy): show owned items in buy list

### DIFF
--- a/src/DarkWeb/DarkWeb.tsx
+++ b/src/DarkWeb/DarkWeb.tsx
@@ -6,6 +6,7 @@ import { Terminal } from "../Terminal";
 import { SpecialServers } from "../Server/data/SpecialServers";
 import { Money } from "../ui/React/Money";
 import { DarkWebItem } from "./DarkWebItem";
+import Typography from "@mui/material/Typography";
 
 //Posts a "help" message if connected to DarkWeb
 export function checkIfConnectedToDarkweb(): void {
@@ -22,10 +23,17 @@ export function checkIfConnectedToDarkweb(): void {
 export function listAllDarkwebItems(): void {
   for (const key in DarkWebItems) {
     const item = DarkWebItems[key];
+
+    const cost = Player.getHomeComputer().programs.includes(item.program) ? (
+      <span style={{ color: `green` }}>[OWNED]</span>
+    ) : (
+      <Money money={item.price} />
+    );
+
     Terminal.printRaw(
-      <>
-        {item.program} - <Money money={item.price} /> - {item.description}
-      </>,
+      <Typography>
+        <span>{item.program}</span> - <span>{cost}</span> - <span>{item.description}</span>
+      </Typography>,
     );
   }
 }


### PR DESCRIPTION
Just a little output change when you `buy -l`, to show you which items you already own.
I couldn't access the theme when importing it here for use, it kept crashing the app so the [OWNED} shows up always as green.. Which isn't the end of the world considering the money always shows up in Yellow, disregarding any theme values.

I think this area of code/output could do with a little bit more love at some point.

![image](https://user-images.githubusercontent.com/1098786/146803796-08e8c085-126b-406d-ad8b-a6eb2ba918df.png)

Resolves danielyxie/bitburner#2069