### PR TITLE
Script editor fixes for .txt files

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -203,7 +203,7 @@ export function Root(props: IProps): React.ReactElement {
   // Generates a new model for the script
   function regenerateModel(script: OpenScript): void {
     if (monacoRef.current !== null) {
-      script.model = monacoRef.current.editor.createModel(script.code, "javascript");
+      script.model = monacoRef.current.editor.createModel(script.code, script.fileName.endsWith(".txt") ? "plaintext" : "javascript");
     }
   }
 
@@ -338,7 +338,7 @@ export function Root(props: IProps): React.ReactElement {
           props.code,
           props.hostname,
           new monacoRef.current.Position(0, 0),
-          monacoRef.current.editor.createModel(props.code, "javascript"),
+          monacoRef.current.editor.createModel(props.code, props.filename.endsWith(".txt") ? "plaintext" : "javascript"),
         );
         setOpenScripts((oldArray) => [...oldArray, newScript]);
         setCurrentScript({ ...newScript });

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -217,6 +217,10 @@ export function Root(props: IProps): React.ReactElement {
   );
 
   async function updateRAM(newCode: string): Promise<void> {
+    if (currentScript != null && currentScript.fileName.endsWith(".txt")) {
+      debouncedSetRAM("");
+      return;
+    }
     setUpdatingRam(true);
     const codeCopy = newCode + "";
     const ramUsage = await calculateRamUsage(codeCopy, props.player.getCurrentServer().scripts);


### PR DESCRIPTION
- Disable RAM calculation for text files
- No syntax highlighting or syntax errors for text files

Before:
![before](https://user-images.githubusercontent.com/79430821/146848651-d12c71f2-1f6a-46bc-8964-17e126055821.PNG)

After:
![after](https://user-images.githubusercontent.com/79430821/146848663-eea01dfd-624e-49e6-a913-a7bd215f9da3.PNG)
