### PR TITLE
Closing the final script in your editor will take you to the terminal

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -668,6 +668,7 @@ export function Root(props: IProps): React.ReactElement {
       // No more scripts are open
       setOpenScripts([]);
       setCurrentScript(null);
+      props.router.toTerminal();
     }
   }
 


### PR DESCRIPTION
Instead of leaving you in the script editor with this screen : https://imgur.com/SLBPVkw.png reminding you to use nano, the script editor will change the window to the terminal when you have zero opened scripts in the script editor.

As there is nothing useful to do on an empty script editor window, I think it is sensible to return them to the terminal without making them click it. They will still get the 'use nano to open stuff' window if they return to the script editor window without opening another file first.

Alternative could be to include something to do in an empty script editor, like a 'new file' button. I can implement that instead if there is interest.