### PR TITLE
Fix for ns.commitCrime description in the Documentation

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1719,9 +1719,9 @@ export interface Singularity {
    * function will automatically cancel that action and give you your
    * earnings.
    *
-   * This function returns the number of seconds it takes to attempt the specified
-   * crime (e.g It takes 60 seconds to attempt the ‘Rob Store’ crime, so running
-   * `commitCrime('rob store')` will return 60).
+   * This function returns the number of milliseconds it takes to attempt the 
+   * specified crime (e.g It takes 60 seconds to attempt the ‘Rob Store’ crime, 
+   * so running `commitCrime('rob store')` will return 60000).
    *
    * Warning: I do not recommend using the time returned from this function to try
    * and schedule your crime attempts. Instead, I would use the isBusy Singularity


### PR DESCRIPTION
Typo or changed the return? ¯\_(ツ)_/¯ 

