### PR TITLE
hackAnalyzeThreads will no longer return NaN under some circumstances

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -509,6 +509,8 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       if (hackAmount < 0 || hackAmount > server.moneyAvailable) {
         return -1;
+      } else if (hackAmount === 0) {
+        return 0;
       }
 
       const percentHacked = calculatePercentMoneyHacked(server, Player);


### PR DESCRIPTION
Fixes #2023 

Analyzing the effect of hack on a server with zero cash with zero threads returns zero instead of NaN.