### PR TITLE
fix(command:buy) don't wrap in typography

### DIFF
--- a/src/DarkWeb/DarkWeb.tsx
+++ b/src/DarkWeb/DarkWeb.tsx
@@ -6,7 +6,6 @@ import { Terminal } from "../Terminal";
 import { SpecialServers } from "../Server/data/SpecialServers";
 import { Money } from "../ui/React/Money";
 import { DarkWebItem } from "./DarkWebItem";
-import Typography from "@mui/material/Typography";
 
 //Posts a "help" message if connected to DarkWeb
 export function checkIfConnectedToDarkweb(): void {
@@ -31,9 +30,9 @@ export function listAllDarkwebItems(): void {
     );
 
     Terminal.printRaw(
-      <Typography>
+      <>
         <span>{item.program}</span> - <span>{cost}</span> - <span>{item.description}</span>
-      </Typography>,
+      </>,
     );
   }
 }


### PR DESCRIPTION
Wrapping the output in typography inserts a newline before/after, this fine until timestamps are enabled and the components don't fall inline, and the typography newline is then visible.

Resolves danielyxie/bitburner#2108