### PR TITLE
Add dialog when app is unresponsive to reload

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -34,6 +34,7 @@ import { parse } from "acorn";
 import { simple as walksimple } from "acorn-walk";
 import { areFilesEqual } from "./Terminal/DirectoryHelpers";
 import { Player } from "./Player";
+import { Terminal } from "./Terminal";
 
 // Netscript Ports are instantiated here
 export const NetscriptPorts: IPort[] = [];
@@ -609,6 +610,7 @@ export function updateOnlineScriptTimes(numCycles = 1): void {
 export function loadAllRunningScripts(): void {
   const skipScriptLoad = window.location.href.toLowerCase().indexOf("?noscripts") !== -1;
   if (skipScriptLoad) {
+    Terminal.warn('Skipped loading player scripts during startup');
     console.info("Skipping the load of any scripts during startup");
   }
   for (const server of GetAllServers()) {


### PR DESCRIPTION
Checks the electron event 'unresponsive' and triggers a reload / cancel
dialog. Allows all scripts to be killed, checked by default.
Also adds a warning to the terminal when noScript has been executed.

![De1YprRDo2](https://user-images.githubusercontent.com/1521080/147148378-54e80411-0dc7-4a2a-b94d-6d611dd2b6d7.gif)

---


![bitburner_RmYJ1bkyYN](https://user-images.githubusercontent.com/1521080/147148359-a4d6e11c-d088-418b-a8bb-5d66f81b766a.png)
![bitburner_BZAMJgOV8G](https://user-images.githubusercontent.com/1521080/147148353-41220dd0-4dcd-4526-99f4-b8e892bda7d4.png)


