### PR TITLE
Add `grow()` function name to offline log report

### DIFF
--- a/src/Script/ScriptHelpers.ts
+++ b/src/Script/ScriptHelpers.ts
@@ -39,7 +39,7 @@ export function scriptCalculateOfflineProduction(runningScript: RunningScript): 
       const timesGrown = Math.round(
         ((0.5 * runningScript.dataMap[hostname][2]) / runningScript.onlineRunningTime) * timePassed,
       );
-      runningScript.log(`Called on ${serv.hostname} ${timesGrown} times while offline`);
+      runningScript.log(`Called grow() on ${serv.hostname} ${timesGrown} times while offline`);
       const host = GetServer(runningScript.server);
       if (host === null) throw new Error("getServer of null key?");
       if (!(serv instanceof Server)) throw new Error("trying to grow a non-normal server");


### PR DESCRIPTION
Brings offline grow reporting more in line with how weaken is reported, e.g.

```
Called weaken() on foodnstuff 1 times while offline
```