### PR TITLE
Adding support for ctrl + arrow key navigation around open files in script-editor

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -223,7 +223,7 @@ export function Root(props: IProps): React.ReactElement {
     function changeActiveTab(event: KeyboardEvent): void {
       if (Settings.DisableHotkeys) return;
 
-      if ((event.ctrlKey || event.metaKey || event.altKey) && ['ArrowLeft', 'ArrowRight'].includes(event.key)) {
+      if (((event.ctrlKey || event.metaKey) && event.altKey) && ['ArrowLeft', 'ArrowRight'].includes(event.key)) {
         event.preventDefault();
         event.stopPropagation();
 

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -223,7 +223,7 @@ export function Root(props: IProps): React.ReactElement {
     function changeActiveTab(event: KeyboardEvent): void {
       if (Settings.DisableHotkeys) return;
 
-      if ((event.ctrlKey || event.metaKey) && ['ArrowLeft', 'ArrowRight'].includes(event.key)) {
+      if ((event.ctrlKey || event.metaKey || event.altKey) && ['ArrowLeft', 'ArrowRight'].includes(event.key)) {
         event.preventDefault();
         event.stopPropagation();
 


### PR DESCRIPTION
This listens for the keyup event instead of keypress or keydown because, I believe, Monaco is swallowing those events when pressing buttons that don't enter printable characters