### PR TITLE
modify BasicHGWOptions definition to mark threads parameter as optional

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -229,7 +229,7 @@ export interface AugmentationStats {
  */
 export interface BasicHGWOptions {
   /** Number of threads to use for this function. Must be less than or equal to the number of threads the script is running with. */
-  threads: number;
+  threads?: number;
   /** Set to true this action will affect the stock market. */
   stock?: boolean;
 }


### PR DESCRIPTION
this is used by hack, grow and weaken all of which dont require it to be defined

as it is defined currently if you try to pass an object to these functions to enable stock market effects, typescript will fail to compile due to the threads parameter not being defined, despite all three functions that use this having a default behaviour defined for if it isnt