### PR TITLE
Crash render process when javascript won't execute

### DIFF
--- a/electron/exit.html
+++ b/electron/exit.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <title>Bitburner</title>
+    <link rel="stylesheet" href="main.css" />
+    <style>
+      body {
+        background-color: black;
+        color: #0c0;
+      }
+
+      div {
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      h1 {
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Exiting ...</h1>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This prevents the default closing event and tries to execute javascript on the webContent. If it doesn't work after 200ms, crash the renderer process, otherwise clean exit.

It fixes the renderer process staying up after close when the user scripts are
waiting for an unresolved promise.

To reproduce before fix:
https://discord.com/channels/415207508303544321/923428513405599815/923514970166140968
![Discord_PYO5r3Utwd](https://user-images.githubusercontent.com/1521080/147240966-0bcdb521-dfd3-4963-90f5-92f92b2c93cf.png)

