### PR TITLE
Concise exp job gains

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -667,12 +667,12 @@ export function finishWork(this: IPlayer, cancelled: boolean, sing = false): str
       <Money money={this.workMoneyGained} />
       <br />
       <Reputation reputation={this.workRepGained} /> reputation for the company <br />
-      {numeralWrapper.formatExp(this.workHackExpGained)} hacking exp <br />
-      {numeralWrapper.formatExp(this.workStrExpGained)} strength exp <br />
-      {numeralWrapper.formatExp(this.workDefExpGained)} defense exp <br />
-      {numeralWrapper.formatExp(this.workDexExpGained)} dexterity exp <br />
-      {numeralWrapper.formatExp(this.workAgiExpGained)} agility exp <br />
-      {numeralWrapper.formatExp(this.workChaExpGained)} charisma exp
+      {this.workHackExpGained > 0  && <>{numeralWrapper.formatExp(this.workHackExpGained)} hacking exp <br /></>}
+      {this.workStrExpGained > 0  && <>{numeralWrapper.formatExp(this.workStrExpGained)} strength exp <br /></>}
+      {this.workDefExpGained > 0  && <>{numeralWrapper.formatExp(this.workDefExpGained)} defense exp <br /></>}
+      {this.workDexExpGained > 0  && <>{numeralWrapper.formatExp(this.workDexExpGained)} dexterity exp <br /></>}
+      {this.workAgiExpGained > 0  && <>{numeralWrapper.formatExp(this.workAgiExpGained)} agility exp <br /></>}
+      {this.workChaExpGained > 0  && <>{numeralWrapper.formatExp(this.workChaExpGained)} charisma exp <br /></>}
       <br />
     </>
   );

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -654,6 +654,8 @@ export function finishWork(this: IPlayer, cancelled: boolean, sing = false): str
     this.workRepGained *= this.cancelationPenalty();
   }
 
+  const penaltyString = this.cancelationPenalty() === 0.5 ? "half" : "three-quarters";
+
   const company = Companies[this.companyName];
   company.playerReputation += this.workRepGained;
 
@@ -680,7 +682,7 @@ export function finishWork(this: IPlayer, cancelled: boolean, sing = false): str
       <>
         You worked a short shift of {convertTimeMsToTimeElapsedString(this.timeWorked)} <br />
         <br />
-        Since you cancelled your work early, you only gained half of the reputation you earned. <br />
+        Since you cancelled your work early, you only gained {penaltyString} of the reputation you earned. <br />
         <br />
         {content}
       </>

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -62,20 +62,14 @@ export function WorkInProgressRoot(): React.ReactElement {
             <Reputation reputation={player.workRepGained} /> (
             <ReputationRate reputation={player.workRepGainRate * CYCLES_PER_SEC} />) reputation for this faction <br />
             <br />
-            {numeralWrapper.formatExp(player.workHackExpGained)} (
-            {numeralWrapper.formatExp(player.workHackExpGainRate * CYCLES_PER_SEC)} / sec) hacking exp <br />
+            {player.workHackExpGained > 0 && <>{numeralWrapper.formatExp(player.workHackExpGained)} ({numeralWrapper.formatExp(player.workHackExpGainRate * CYCLES_PER_SEC)} / sec) hacking exp <br /></>}
             <br />
-            {numeralWrapper.formatExp(player.workStrExpGained)} (
-            {numeralWrapper.formatExp(player.workStrExpGainRate * CYCLES_PER_SEC)} / sec) strength exp <br />
-            {numeralWrapper.formatExp(player.workDefExpGained)} (
-            {numeralWrapper.formatExp(player.workDefExpGainRate * CYCLES_PER_SEC)} / sec) defense exp <br />
-            {numeralWrapper.formatExp(player.workDexExpGained)} (
-            {numeralWrapper.formatExp(player.workDexExpGainRate * CYCLES_PER_SEC)} / sec) dexterity exp <br />
-            {numeralWrapper.formatExp(player.workAgiExpGained)} (
-            {numeralWrapper.formatExp(player.workAgiExpGainRate * CYCLES_PER_SEC)} / sec) agility exp <br />
+            {player.workStrExpGained > 0 && <>{numeralWrapper.formatExp(player.workStrExpGained)} ({numeralWrapper.formatExp(player.workStrExpGainRate * CYCLES_PER_SEC)} / sec) strength exp <br /></>}
+            {player.workDefExpGained > 0 && <>{numeralWrapper.formatExp(player.workDefExpGained)} ({numeralWrapper.formatExp(player.workDefExpGainRate * CYCLES_PER_SEC)} / sec) defense exp <br /></>}
+            {player.workDexExpGained > 0 && <>{numeralWrapper.formatExp(player.workDexExpGained)} ({numeralWrapper.formatExp(player.workDexExpGainRate * CYCLES_PER_SEC)} / sec) dexterity exp <br /></>}
+            {player.workAgiExpGained > 0 && <>{numeralWrapper.formatExp(player.workAgiExpGained)} ({numeralWrapper.formatExp(player.workAgiExpGainRate * CYCLES_PER_SEC)} / sec) agility exp <br /></>}
             <br />
-            {numeralWrapper.formatExp(player.workChaExpGained)} (
-            {numeralWrapper.formatExp(player.workChaExpGainRate * CYCLES_PER_SEC)} / sec) charisma exp <br />
+            {player.workChaExpGained > 0 && <>{numeralWrapper.formatExp(player.workChaExpGained)} ({numeralWrapper.formatExp(player.workChaExpGainRate * CYCLES_PER_SEC)} / sec) charisma exp <br /></>}
             <br />
             You will automatically finish after working for 20 hours. You can cancel earlier if you wish.
             <br />
@@ -123,18 +117,12 @@ export function WorkInProgressRoot(): React.ReactElement {
             <br />
             <br />
             You have gained: <br />
-            {numeralWrapper.formatExp(player.workHackExpGained)} (
-            {numeralWrapper.formatExp(player.workHackExpGainRate * CYCLES_PER_SEC)} / sec) hacking exp <br />
-            {numeralWrapper.formatExp(player.workStrExpGained)} (
-            {numeralWrapper.formatExp(player.workStrExpGainRate * CYCLES_PER_SEC)} / sec) strength exp <br />
-            {numeralWrapper.formatExp(player.workDefExpGained)} (
-            {numeralWrapper.formatExp(player.workDefExpGainRate * CYCLES_PER_SEC)} / sec) defense exp <br />
-            {numeralWrapper.formatExp(player.workDexExpGained)} (
-            {numeralWrapper.formatExp(player.workDexExpGainRate * CYCLES_PER_SEC)} / sec) dexterity exp <br />
-            {numeralWrapper.formatExp(player.workAgiExpGained)} (
-            {numeralWrapper.formatExp(player.workAgiExpGainRate * CYCLES_PER_SEC)} / sec) agility exp <br />
-            {numeralWrapper.formatExp(player.workChaExpGained)} (
-            {numeralWrapper.formatExp(player.workChaExpGainRate * CYCLES_PER_SEC)} / sec) charisma exp <br />
+            {player.workHackExpGained > 0 && <>{numeralWrapper.formatExp(player.workHackExpGained)} ({numeralWrapper.formatExp(player.workHackExpGainRate * CYCLES_PER_SEC)} / sec) hacking exp <br /></>}
+            {player.workStrExpGained > 0 && <>{numeralWrapper.formatExp(player.workStrExpGained)} ({numeralWrapper.formatExp(player.workStrExpGainRate * CYCLES_PER_SEC)} / sec) strength exp <br /></>}
+            {player.workDefExpGained > 0 && <>{numeralWrapper.formatExp(player.workDefExpGained)} ({numeralWrapper.formatExp(player.workDefExpGainRate * CYCLES_PER_SEC)} / sec) defense exp <br /></>}
+            {player.workDexExpGained > 0 && <>{numeralWrapper.formatExp(player.workDexExpGained)} ({numeralWrapper.formatExp(player.workDexExpGainRate * CYCLES_PER_SEC)} / sec) dexterity exp <br /></>}
+            {player.workAgiExpGained > 0 && <>{numeralWrapper.formatExp(player.workAgiExpGained)} ({numeralWrapper.formatExp(player.workAgiExpGainRate * CYCLES_PER_SEC)} / sec) agility exp <br /></>}
+            {player.workChaExpGained > 0 && <>{numeralWrapper.formatExp(player.workChaExpGained)} ({numeralWrapper.formatExp(player.workChaExpGainRate * CYCLES_PER_SEC)} / sec) charisma exp <br /></>}
             You may cancel at any time
           </Typography>
         </Grid>
@@ -185,26 +173,26 @@ export function WorkInProgressRoot(): React.ReactElement {
             <Reputation reputation={player.workRepGained} /> (
             <ReputationRate reputation={player.workRepGainRate * CYCLES_PER_SEC} />) reputation for this company <br />
             <br />
-            {numeralWrapper.formatExp(player.workHackExpGained)} (
+            {player.workHackExpGained > 0 && <>{numeralWrapper.formatExp(player.workHackExpGained)} (
             {`${numeralWrapper.formatExp(player.workHackExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) hacking exp <br />
+            ) hacking exp <br /></>}
             <br />
-            {numeralWrapper.formatExp(player.workStrExpGained)} (
+            {player.workStrExpGained > 0 && <>{numeralWrapper.formatExp(player.workStrExpGained)} (
             {`${numeralWrapper.formatExp(player.workStrExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) strength exp <br />
-            {numeralWrapper.formatExp(player.workDefExpGained)} (
+            ) strength exp <br /></>}
+            {player.workDefExpGained > 0 && <>{numeralWrapper.formatExp(player.workDefExpGained)} (
             {`${numeralWrapper.formatExp(player.workDefExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) defense exp <br />
-            {numeralWrapper.formatExp(player.workDexExpGained)} (
+            ) defense exp <br /></>}
+            {player.workDexExpGained > 0 && <>{numeralWrapper.formatExp(player.workDexExpGained)} (
             {`${numeralWrapper.formatExp(player.workDexExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) dexterity exp <br />
-            {numeralWrapper.formatExp(player.workAgiExpGained)} (
+            ) dexterity exp <br /></>}
+            {player.workAgiExpGained > 0 && <>{numeralWrapper.formatExp(player.workAgiExpGained)} (
             {`${numeralWrapper.formatExp(player.workAgiExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) agility exp <br />
+            ) agility exp <br /></>}
             <br />
-            {numeralWrapper.formatExp(player.workChaExpGained)} (
+            {player.workChaExpGained > 0 && <>{numeralWrapper.formatExp(player.workChaExpGained)} (
             {`${numeralWrapper.formatExp(player.workChaExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) charisma exp <br />
+            ) charisma exp <br /></>}
             <br />
             You will automatically finish after working for 8 hours. You can cancel earlier if you wish, but you will
             only gain {penaltyString} of the reputation you've earned so far.
@@ -256,26 +244,26 @@ export function WorkInProgressRoot(): React.ReactElement {
             <ReputationRate reputation={player.workRepGainRate * CYCLES_PER_SEC} />
             ) reputation for this company <br />
             <br />
-            {numeralWrapper.formatExp(player.workHackExpGained)} (
+            {player.workHackExpGained > 0 && <>{numeralWrapper.formatExp(player.workHackExpGained)} (
             {`${numeralWrapper.formatExp(player.workHackExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) hacking exp <br />
+            ) hacking exp <br /></>}
             <br />
-            {numeralWrapper.formatExp(player.workStrExpGained)} (
+            {player.workStrExpGained > 0 && <>{numeralWrapper.formatExp(player.workStrExpGained)} (
             {`${numeralWrapper.formatExp(player.workStrExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) strength exp <br />
-            {numeralWrapper.formatExp(player.workDefExpGained)} (
+            ) strength exp <br /></>}
+            {player.workDefExpGained > 0 && <>{numeralWrapper.formatExp(player.workDefExpGained)} (
             {`${numeralWrapper.formatExp(player.workDefExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) defense exp <br />
-            {numeralWrapper.formatExp(player.workDexExpGained)} (
+            ) defense exp <br /></>}
+            {player.workDexExpGained > 0 && <>{numeralWrapper.formatExp(player.workDexExpGained)} (
             {`${numeralWrapper.formatExp(player.workDexExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) dexterity exp <br />
-            {numeralWrapper.formatExp(player.workAgiExpGained)} (
+            ) dexterity exp <br /></>}
+            {player.workAgiExpGained > 0 && <>{numeralWrapper.formatExp(player.workAgiExpGained)} (
             {`${numeralWrapper.formatExp(player.workAgiExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) agility exp <br />
+            ) agility exp <br /></>}
             <br />
-            {numeralWrapper.formatExp(player.workChaExpGained)} (
+            {player.workChaExpGained > 0 && <>{numeralWrapper.formatExp(player.workChaExpGained)} (
             {`${numeralWrapper.formatExp(player.workChaExpGainRate * CYCLES_PER_SEC)} / sec`}
-            ) charisma exp <br />
+            ) charisma exp <br /></>}
             <br />
             You will automatically finish after working for 8 hours. You can cancel earlier if you wish, and there will
             be no penalty because this is a part-time job.


### PR DESCRIPTION
Also fixes #2160 - Rep penalty message was incorrect if you quit work early with certain augments.

Exp gain summaries will now skip over skills you are not gaining exp in.

e.g. Training Dex at a gym no longer shows all the other stats.
![Screenshot_2021-12-23_19-19-21](https://user-images.githubusercontent.com/47489928/147283574-a0280b99-db1f-499e-8164-3a98b6815ddb.png)

Did I miss any lategame dialog boxes that do this, too?