### PR TITLE
Feature/add grep option to ps

### DIFF
--- a/doc/source/basicgameplay/terminal.rst
+++ b/doc/source/basicgameplay/terminal.rst
@@ -432,10 +432,10 @@ empty file will be created.
 ps
 ^^
 
-    $ ps [-g pattern]
+    $ ps [-g, --grep pattern]
 
 Prints all scripts that are currently running on the current server.
-The :code:`-g pattern` option will only output running scripts where the name matches the provided pattern.
+The :code:`-g, --grep pattern` option will only output running scripts where the name matches the provided pattern.
 
 rm
 ^^

--- a/doc/source/basicgameplay/terminal.rst
+++ b/doc/source/basicgameplay/terminal.rst
@@ -432,10 +432,10 @@ empty file will be created.
 ps
 ^^
 
-    $ ps [| grep pattern]
+    $ ps [-g pattern]
 
 Prints all scripts that are currently running on the current server.
-The :code:`| grep pattern` option will only output running scripts where the name matches the provided pattern.
+The :code:`-g pattern` option will only output running scripts where the name matches the provided pattern.
 
 rm
 ^^

--- a/doc/source/basicgameplay/terminal.rst
+++ b/doc/source/basicgameplay/terminal.rst
@@ -432,7 +432,10 @@ empty file will be created.
 ps
 ^^
 
+    $ ps [| grep pattern]
+
 Prints all scripts that are currently running on the current server.
+The :code:`| grep pattern` option will only output running scripts where the name matches the provided pattern.
 
 rm
 ^^

--- a/src/Terminal/commands/ps.ts
+++ b/src/Terminal/commands/ps.ts
@@ -10,16 +10,32 @@ export function ps(
   server: BaseServer,
   args: (string | number | boolean)[],
 ): void {
-  if (args.length !== 0) {
-    terminal.error("Incorrect usage of ps command. Usage: ps");
+  if (args.length === 1 || args.length === 2 || args.length > 3) {
+    terminal.error("Incorrect usage of ps command. Usage: ps [| grep <pattern>]");
     return;
   }
-  for (let i = 0; i < server.runningScripts.length; i++) {
-    const rsObj = server.runningScripts[i];
-    let res = `(PID - ${rsObj.pid}) ${rsObj.filename}`;
-    for (let j = 0; j < rsObj.args.length; ++j) {
-      res += " " + rsObj.args[j].toString();
+  if(args[0] === '|' && args[1] === 'grep'){
+    const pattern = new RegExp(`${args[2].toString()}`)
+    const matching = server.runningScripts.filter((x) => pattern.test(x.filename))
+    for(let i = 0; i < matching.length; i++){
+      const rsObj = matching[i];
+      let res = `(PID - ${rsObj.pid}) ${rsObj.filename}`;
+      for (let j = 0; j < rsObj.args.length; ++j) {
+        res += " " + rsObj.args[j].toString();
+      }
+      terminal.print(res);
     }
-    terminal.print(res);
+  }else if(args.length === 0){
+    for (let i = 0; i < server.runningScripts.length; i++) {
+      const rsObj = server.runningScripts[i];
+      let res = `(PID - ${rsObj.pid}) ${rsObj.filename}`;
+      for (let j = 0; j < rsObj.args.length; ++j) {
+        res += " " + rsObj.args[j].toString();
+      }
+      terminal.print(res);
+    }
+  }else{
+    terminal.error("Incorrect usage of ps command. Usage: ps [| grep <pattern>]");
+    return;
   }
 }


### PR DESCRIPTION
added the option to pass in a regular expression to match running process names against in ps

| use case | example |
|-|-|
|show all running processes (unchanged)|![image](https://user-images.githubusercontent.com/42522883/147306094-aa249007-c72b-4390-8bf8-4b3e3c28e1bb.png)|
|show all processes staring with `a`|![image](https://user-images.githubusercontent.com/42522883/147306143-783b31af-d72a-4b4f-ba2d-1b424fb1bcad.png)|
|show all processes starting with `a[^n] \| b`|![image](https://user-images.githubusercontent.com/42522883/147306206-315ca148-529c-4629-b703-09b32b758c92.png)|

|error case| example |
|-|-|
|missing `grep` |![image](https://user-images.githubusercontent.com/42522883/147306353-16a0a74e-c8be-4a45-ae57-134f04afaf00.png)|
|missing `\|`|![image](https://user-images.githubusercontent.com/42522883/147306403-7c11d00c-034c-409f-bde8-d88497af884b.png)|
|missing both|![image](https://user-images.githubusercontent.com/42522883/147306443-d636950c-f67b-43a1-8007-086fd516e018.png)|