### PR TITLE
Cache the blobs generated by scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "file-saver": "^1.3.8",
         "fs": "^0.0.1-security",
         "jquery": "^3.5.0",
+        "js-sha256": "^0.9.0",
         "jszip": "^3.7.0",
         "material-ui-color": "^1.2.0",
         "monaco-editor": "^0.27.0",
@@ -13698,6 +13699,11 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -32342,6 +32348,11 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "file-saver": "^1.3.8",
     "fs": "^0.0.1-security",
     "jquery": "^3.5.0",
+    "js-sha256": "^0.9.0",
     "jszip": "^3.7.0",
     "material-ui-color": "^1.2.0",
     "monaco-editor": "^0.27.0",

--- a/src/NetscriptEvaluator.ts
+++ b/src/NetscriptEvaluator.ts
@@ -1,7 +1,6 @@
 import { isString } from "./utils/helpers/isString";
 import { GetServer } from "./Server/AllServers";
 import { WorkerScript } from "./Netscript/WorkerScript";
-import { BlobsMap } from "./NetscriptJSEvaluator";
 
 export function netscriptDelay(time: number, workerScript: WorkerScript): Promise<void> {
   return new Promise(function (resolve) {
@@ -22,8 +21,8 @@ export function makeRuntimeRejectMsg(workerScript: WorkerScript, msg: string): s
     throw new Error(`WorkerScript constructed with invalid server ip: ${workerScript.hostname}`);
   }
 
-  for (const url in BlobsMap) {
-    msg = msg.replace(new RegExp(url, "g"), BlobsMap[url]);
+  for (const scriptUrl of workerScript.scriptRef.dependencies) {
+    msg = msg.replace(new RegExp(scriptUrl.url, "g"), scriptUrl.filename);
   }
 
   return "|DELIMITER|" + server.hostname + "|DELIMITER|" + workerScript.name + "|DELIMITER|" + msg;

--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -2,9 +2,10 @@ import { makeRuntimeRejectMsg } from "./NetscriptEvaluator";
 import { ScriptUrl } from "./Script/ScriptUrl";
 import { WorkerScript } from "./Netscript/WorkerScript";
 import { Script } from "./Script/Script";
+import { computeHash } from "./utils/helpers/computeHash";
+import { BlobCache } from "./utils/BlobCache";
+import { ImportCache } from "./utils/ImportCache";
 import { areImportsEquals } from "./Terminal/DirectoryHelpers";
-
-export const BlobsMap: { [key: string]: string } = {};
 
 // Makes a blob that contains the code of a given script.
 function makeScriptBlob(code: string): Blob {
@@ -22,13 +23,22 @@ export async function compile(script: Script, scripts: Script[]): Promise<void> 
   // by placing it inside an eval call.
   await script.updateRamUsage(scripts);
   const uurls = _getScriptUrls(script, scripts, []);
-  if (script.url) {
-    URL.revokeObjectURL(script.url); // remove the old reference.
-    delete BlobsMap[script.url];
+  const url = uurls[uurls.length - 1].url;
+  if (script.url && script.url !== url) {
+    // Thoughts: Should we be revoking any URLs here?
+    // If a script is modified repeatedly between two states,
+    // we could reuse the blob at a later time.
+    // BlobCache.removeByValue(script.url);
+    // URL.revokeObjectURL(script.url);
+    // if (script.dependencies.length > 0) {
+    //   script.dependencies.forEach((dep) => {
+    //     removeBlobFromCache(dep.url);
+    //     URL.revokeObjectURL(dep.url);
+    //   });
+    // }
   }
-  if (script.dependencies.length > 0) script.dependencies.forEach((dep) => URL.revokeObjectURL(dep.url));
-  script.url = uurls[uurls.length - 1].url;
-  script.module = new Promise((resolve) => resolve(eval("import(uurls[uurls.length - 1].url)")));
+  script.url = url;
+  script.module = new Promise((resolve) => resolve(eval("import(url)")));
   script.dependencies = uurls;
 }
 
@@ -124,12 +134,21 @@ function _getScriptUrls(script: Script, scripts: Script[], seen: Script[]): Scri
         // Find the corresponding script.
         const [importedScript] = scripts.filter((s) => areImportsEquals(s.filename, filename));
 
-        // Try to get a URL for the requested script and its dependencies.
-        const urls = _getScriptUrls(importedScript, scripts, seen);
+        // Check to see if the urls for this script are stored in the cache by the hash value.
+        let urls = ImportCache.get(importedScript.hash());
+        // If we don't have it in the cache, then we need to generate the urls for it.
+        if (!urls) {
+          // Try to get a URL for the requested script and its dependencies.
+          urls = _getScriptUrls(importedScript, scripts, seen);
+        }
 
         // The top url in the stack is the replacement import file for this script.
         urlStack.push(...urls);
-        return [prefix, urls[urls.length - 1].url, suffix].join("");
+        const blob = urls[urls.length - 1].url;
+        ImportCache.store(importedScript.hash(), urls);
+
+        // Replace the blob inside the import statement.
+        return [prefix, blob, suffix].join("");
       },
     );
 
@@ -137,11 +156,19 @@ function _getScriptUrls(script: Script, scripts: Script[], seen: Script[]): Scri
     // accidental calls to window.print() do not bring up the "print screen" dialog
     transformedCode += `\n\nfunction print() {throw new Error("Invalid call to window.print(). Did you mean to use Netscript's print()?");}`;
 
-    // If we successfully transformed the code, create a blob url for it and
-    // push that URL onto the top of the stack.
-    const su = new ScriptUrl(script.filename, URL.createObjectURL(makeScriptBlob(transformedCode)));
-    urlStack.push(su);
-    BlobsMap[su.url] = su.filename;
+    // If we successfully transformed the code, create a blob url for it
+    // Compute the hash for the transformed code
+    const transformedHash = computeHash(transformedCode);
+    // Check to see if this transformed hash is in our cache
+    let blob = BlobCache.get(transformedHash);
+    if (!blob) {
+      blob = URL.createObjectURL(makeScriptBlob(transformedCode));
+    }
+    // Store this blob in the cache. Any script that transforms the same
+    // (e.g. same scripts on server, same hash value, etc) can use this blob url.
+    BlobCache.store(transformedHash, blob);
+    // Push the blob URL onto the top of the stack.
+    urlStack.push(new ScriptUrl(script.filename, blob));
     return urlStack;
   } catch (err) {
     // If there is an error, we need to clean up the URLs.

--- a/src/Script/RunningScript.ts
+++ b/src/Script/RunningScript.ts
@@ -3,6 +3,7 @@
  * A Script can have multiple active instances
  */
 import { Script } from "./Script";
+import { ScriptUrl } from "./ScriptUrl";
 import { Settings } from "../Settings/Settings";
 import { IMap } from "../types";
 import { Terminal } from "../Terminal";
@@ -58,6 +59,9 @@ export class RunningScript {
   // Number of threads that this script is running with
   threads = 1;
 
+  // Script urls for the current running script for translating urls back to file names in errors
+  dependencies: ScriptUrl[] = [];
+
   constructor(script: Script | null = null, args: any[] = []) {
     if (script == null) {
       return;
@@ -66,6 +70,7 @@ export class RunningScript {
     this.args = args;
     this.server = script.server;
     this.ramUsage = script.ramUsage;
+    this.dependencies = script.dependencies;
   }
 
   log(txt: string): void {

--- a/src/utils/BlobCache.ts
+++ b/src/utils/BlobCache.ts
@@ -2,7 +2,7 @@
 const blobCache: { [hash: string]: string } = {};
 
 export class BlobCache {
-  static get(hash: string) {
+  static get(hash: string): string {
     return blobCache[hash];
   }
 
@@ -11,7 +11,7 @@ export class BlobCache {
     blobCache[hash] = value;
   }
 
-  static removeByValue(value: string) {
+  static removeByValue(value: string): void {
     const keys = Object.keys(blobCache).filter((key) => blobCache[key] === value);
     keys.forEach((key) => delete blobCache[key]);
   }

--- a/src/utils/BlobCache.ts
+++ b/src/utils/BlobCache.ts
@@ -1,0 +1,18 @@
+
+const blobCache: { [hash: string]: string } = {};
+
+export class BlobCache {
+  static get(hash: string) {
+    return blobCache[hash];
+  }
+
+  static store(hash: string, value: string): void {
+    if (blobCache[hash]) return;
+    blobCache[hash] = value;
+  }
+
+  static removeByValue(value: string) {
+    const keys = Object.keys(blobCache).filter((key) => blobCache[key] === value);
+    keys.forEach((key) => delete blobCache[key]);
+  }
+}

--- a/src/utils/ImportCache.ts
+++ b/src/utils/ImportCache.ts
@@ -1,0 +1,14 @@
+import { ScriptUrl } from "../Script/ScriptUrl";
+
+const importCache: { [hash: string]: ScriptUrl[] } = {};
+
+export class ImportCache {
+  static get(hash: string) {
+    return importCache[hash];
+  }
+
+  static store(hash: string, value: ScriptUrl[]): void {
+    if (importCache[hash]) return;
+    importCache[hash] = value;
+  }
+}

--- a/src/utils/ImportCache.ts
+++ b/src/utils/ImportCache.ts
@@ -3,7 +3,7 @@ import { ScriptUrl } from "../Script/ScriptUrl";
 const importCache: { [hash: string]: ScriptUrl[] } = {};
 
 export class ImportCache {
-  static get(hash: string) {
+  static get(hash: string): ScriptUrl[] {
     return importCache[hash];
   }
 

--- a/src/utils/helpers/computeHash.ts
+++ b/src/utils/helpers/computeHash.ts
@@ -6,7 +6,7 @@ import { sha256 } from "js-sha256";
  * @returns The SHA-256 hash in hex
  */
 export function computeHash(message: string): string {
-  var hash = sha256.create();
+  const hash = sha256.create();
   hash.update(message);
   return hash.hex();
 }

--- a/src/utils/helpers/computeHash.ts
+++ b/src/utils/helpers/computeHash.ts
@@ -1,0 +1,12 @@
+import { sha256 } from "js-sha256";
+
+/**
+ * Computes a SHA-256 hash of a string synchronously
+ * @param message The input string
+ * @returns The SHA-256 hash in hex
+ */
+export function computeHash(message: string): string {
+  var hash = sha256.create();
+  hash.update(message);
+  return hash.hex();
+}


### PR DESCRIPTION
When running a script, generate a hash of the code used by that script. If that hash is in our blob cache, we reuse the blob URL. If not, a new blob is generated and stored in the cache.

Some notes:
* This still has the issue that scripts are recompiled on soft reset, but the hash of the script should not change, so the blobs and ScriptUrls will still be the same.
* We are no longer calling URL.revokeObjectURL on URLs since they could be in use by another script. This will leave blob URLs leaked on occasion, but that leaking should be at a minimum with the cache. As far as I can tell, URL.revokeObjectURL doesn't remove the URL from the DevTools anyways, so those URLs are in memory somewhere.
  * Example, this only generates 4 blobs total (1 for the main script, 1 for helpers.js, and one each for the flip/flop):
   ```js
    import {
        getNsDataThroughFile
    } from './helpers.js'
    
    /** @param {NS} ns */
    async function getCurrentFactionFavour(ns, factionName) {
        return await getNsDataThroughFile(ns, `ns.getFactionFavor('${factionName}')`, '/Temp/faction-favor.txt');
    }
    
    /** @param {NS} ns **/
    export async function main(ns) {
        while (true) {
            let currentFavor = await getCurrentFactionFavour(ns, "Bachman & Associates");
            ns.tprint(currentFavor);
            currentFavor = await getCurrentFactionFavour(ns, "Sector-12");
            ns.tprint(currentFavor);
            await ns.sleep(5000);
        }
    }
    ```
* Scripts running across multiple servers or multiple filenames with the same hash will have the same blobs, so this necessitated a change with how we lookup blob urls to script name mappings.
* A 3rd party library is imported for sha256 hashing since the browser based hashing method is async and we needed synchronous calculation of the hash in several places.