### PR TITLE
Fix CorporationInfo.state

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -496,7 +496,7 @@ export function NetscriptCorporation(
         shareSaleCooldown: corporation.shareSaleCooldown,
         issuedShares: corporation.issuedShares,
         sharePrice: corporation.sharePrice,
-        state: corporation.state + "",
+        state: corporation.state.getState(),
       };
     },
   };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6128,7 +6128,7 @@ interface CorporationInfo {
   issuedShares: number;
   /** Price of the shares */
   sharePrice: number;
-  /** State of the corporation, like PRODUCTION or EXPORT */
+  /** State of the corporation. Possible states are START, PURCHASE, PRODUCTION, SALE, EXPORT. */
   state: string;
 }
 


### PR DESCRIPTION
Before:
`CorporationInfo.state` was returning `"[Object object]"`.

After:
`CorporationInfo.state` returns an actual state like START, PURCHASE, PRODUCTION, SALE, EXPORT.

Also updated doc for `CorporationInfo.state`.