### PR TITLE
Get rid of console spam in NetscriptFunctions.ts

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -952,7 +952,6 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       return runScriptFromScript("run", scriptServer, scriptname, args, workerScript, threads);
     },
     exec: function (scriptname: any, hostname: any, threads: any = 1, ...args: any[]): any {
-      console.log(`${scriptname} ${hostname} ${threads} ${JSON.stringify(args)}`);
       updateDynamicRam("exec", getRamCost("exec"));
       if (scriptname === undefined || hostname === undefined) {
         throw makeRuntimeErrorMsg("exec", "Usage: exec(scriptname, server, [numThreads], [arg1], [arg2]...)");


### PR DESCRIPTION
This was filling up the console and making it hard to debug anything other than `exec` calls.