### PR TITLE
Allow shortcuts to work while doing unfocused work.

### DIFF
--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -273,7 +273,7 @@ export function SidebarRoot(props: IProps): React.ReactElement {
     //  Alt-o - Options
     function handleShortcuts(this: Document, event: KeyboardEvent): any {
       if (Settings.DisableHotkeys) return;
-      if (props.player.isWorking || redPillFlag) return;
+      if ((props.player.isWorking && props.player.focus) || redPillFlag) return;
       if (event.keyCode == KEY.T && event.altKey) {
         event.preventDefault();
         clickTerminal();


### PR DESCRIPTION
A lot of people thought keyboard shortcuts weren't working because the code to make them stop working was only checking if the player was working without checking if the player was also focused. If doing unfocused work, there's no reason not to allow keyboard shortcuts to keep working.