### PR TITLE
Changed setting to selling in getSaleGain

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1045,7 +1045,7 @@ export interface TIX {
   getPurchaseCost(sym: string, shares: number, posType: string): number;
 
   /**
-   * Calculate profit of setting stocks.
+   * Calculate profit of selling stocks.
    * @remarks
    * RAM cost: 2 GB
    * Calculates and returns how much you would gain from selling a given number of shares of a stock.


### PR DESCRIPTION
Looks like the word 'setting' was incorrectly used in place of selling in the method getSaleGain.