### PR TITLE
DRY: Consolidated the code for retrieving a port so it will have consistent errors checks.

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1758,6 +1758,12 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       return res;
     },
     writePort: function (port: any, data: any = ""): any {
+      if (typeof data !== "string" && typeof data !== "number") {
+        throw makeRuntimeErrorMsg(
+          "writePort",
+          `Trying to write invalid data to a port: only strings and numbers are valid.`,
+        );
+      }
       const iport = helper.getValidPort("writePort", port);
       return Promise.resolve(iport.write(data));
     },

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -454,7 +454,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       if (port < 1 || port > CONSTANTS.NumNetscriptPorts) {
         throw makeRuntimeErrorMsg(
           funcName,
-          `Trying to write to invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
+          `Trying to use an invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
         );
       }
       const iport = NetscriptPorts[port - 1];


### PR DESCRIPTION
Most `*Port` methods (ie, `readPort`) did not validate that the provided port was a real number. This caused the error "Could not find port. This is a bug. Report to dev." even though it was a user bug rather than a dev bug. Only `getPortHandle` and `peek` actually checked for NaN.

By moving all the repeated code for getting the port from NetscriptPorts into a single DRY method, the error checking will be consistent across all port methods. Any new validation can be added to this method without having to change all methods.