### PR TITLE
fix joe's guns stock is not found using symbol

### DIFF
--- a/src/StockMarket/data/StockSymbols.ts
+++ b/src/StockMarket/data/StockSymbols.ts
@@ -35,7 +35,7 @@ StockSymbols[LocationName.Sector12FoodNStuff] = "FNS";
 
 // Stocks for other companies
 StockSymbols["Sigma Cosmetics"] = "SGC";
-StockSymbols["Joes Guns"] = "JGN";
+StockSymbols[LocationName.Sector12JoesGuns] = "JGN";
 StockSymbols["Catalyst Ventures"] = "CTYS";
 StockSymbols["Microdyne Technologies"] = "MDYN";
 StockSymbols["Titan Laboratories"] = "TITN";


### PR DESCRIPTION
After https://github.com/danielyxie/bitburner/pull/2213 joe's guns stock is not found using its symbol JGN in stock functions.