### PR TITLE
Alias command regular expression mismatch

### DIFF
--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -38,7 +38,7 @@ export function printAliases(): void {
 export function parseAliasDeclaration(dec: string, global = false): boolean {
   const re = /^([\w|!|%|,|@|-]+)=(("(.+)")|('(.+)'))$/;
   const matches = dec.match(re);
-  if (matches == null || matches.length != 3) {
+  if (matches == null || matches.length != 7) {
     return false;
   }
   if (global) {

--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -41,10 +41,11 @@ export function parseAliasDeclaration(dec: string, global = false): boolean {
   if (matches == null || matches.length != 7) {
     return false;
   }
+
   if (global) {
-    addGlobalAlias(matches[1], matches[2]);
+    addGlobalAlias(matches[1], matches[4] || matches[6]);
   } else {
-    addAlias(matches[1], matches[2]);
+    addAlias(matches[1], matches[4] || matches[6]);
   }
   return true;
 }


### PR DESCRIPTION
The alias command was expecting fewer capture groups than the regex introduced in #2196 was providing. 

The following changes were made:

- Update the match count with the correct number of capture groups
- Updated the addGlobalAlias/addAlias calls to choose the correct capture group for the command text

I have tested it as follows:

- Successfully added and used an alias created from single quotes, created new.
- Successfully added and used an alias created from double quotes, overwriting the existing one.
- Successfully deleted the alias.
- Successfully added and used an alias created from double quotes, created new.
- Repeat above using global alias overwritten by local alias.
- Repeat above using local alias overwritten by global alias.



