### PR TITLE
Update theme engine to cover some themeless elements

### DIFF
--- a/src/Locations/ui/City.tsx
+++ b/src/Locations/ui/City.tsx
@@ -17,10 +17,26 @@ import { IRouter } from "../../ui/Router";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import { LocationType } from "../LocationTypeEnum";
+import { Theme } from "@mui/material/styles";
+import makeStyles from "@mui/styles/makeStyles";
+import createStyles from "@mui/styles/createStyles";
 
 type IProps = {
   city: City;
 };
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    location: {
+      color: theme.colors.white,
+      whiteSpace: "nowrap",
+      margin: "0px",
+      padding: "0px",
+      cursor: "pointer",
+    },
+  })
+);
+
 
 function toLocation(router: IRouter, location: Location): void {
   if (location.name === LocationName.TravelAgency) {
@@ -35,6 +51,7 @@ function toLocation(router: IRouter, location: Location): void {
 function LocationLetter(location: Location): React.ReactElement {
   location.types;
   const router = use.Router();
+  const classes = useStyles();
   let L = "X";
   if (location.types.includes(LocationType.Company)) L = "C";
   if (location.types.includes(LocationType.Gym)) L = "G";
@@ -51,13 +68,7 @@ function LocationLetter(location: Location): React.ReactElement {
     <span
       aria-label={location.name}
       key={location.name}
-      style={{
-        color: "white",
-        whiteSpace: "nowrap",
-        margin: "0px",
-        padding: "0px",
-        cursor: "pointer",
-      }}
+      className={classes.location}
       onClick={() => toLocation(router, location)}
     >
       <b>{L}</b>

--- a/src/ui/React/Theme.tsx
+++ b/src/ui/React/Theme.tsx
@@ -21,6 +21,7 @@ declare module "@mui/material/styles" {
       successlight: React.CSSProperties["color"];
       success: React.CSSProperties["color"];
       successdark: React.CSSProperties["color"];
+      white: React.CSSProperties["color"];
     };
   }
   interface ThemeOptions {
@@ -38,6 +39,7 @@ declare module "@mui/material/styles" {
       successlight: React.CSSProperties["color"];
       success: React.CSSProperties["color"];
       successdark: React.CSSProperties["color"];
+      white: React.CSSProperties["color"];
     };
   }
 }
@@ -60,6 +62,7 @@ export function refreshTheme(): void {
       successlight: Settings.theme.successlight,
       success: Settings.theme.success,
       successdark: Settings.theme.successdark,
+      white: Settings.theme.white,
     },
     palette: {
       primary: {

--- a/src/ui/React/Theme.tsx
+++ b/src/ui/React/Theme.tsx
@@ -331,7 +331,7 @@ export function refreshTheme(): void {
             border: "1px solid " + Settings.theme.well,
           },
           standardSuccess: {
-            color: Settings.theme.primarylight,
+            color: Settings.theme.successlight,
           },
           standardError: {
             color: Settings.theme.errorlight,

--- a/src/ui/React/Theme.tsx
+++ b/src/ui/React/Theme.tsx
@@ -341,6 +341,8 @@ export function refreshTheme(): void {
       },
     },
   });
+
+  document.body.style.backgroundColor = theme.colors.black?.toString() ?? "black";
 }
 refreshTheme();
 

--- a/src/ui/React/Theme.tsx
+++ b/src/ui/React/Theme.tsx
@@ -93,6 +93,11 @@ export function refreshTheme(): void {
         main: Settings.theme.warning,
         dark: Settings.theme.warningdark,
       },
+      success: {
+        light: Settings.theme.successlight,
+        main: Settings.theme.success,
+        dark: Settings.theme.successdark,
+      },
       background: {
         default: Settings.theme.backgroundprimary,
         paper: Settings.theme.well,

--- a/src/ui/React/Theme.tsx
+++ b/src/ui/React/Theme.tsx
@@ -22,6 +22,7 @@ declare module "@mui/material/styles" {
       success: React.CSSProperties["color"];
       successdark: React.CSSProperties["color"];
       white: React.CSSProperties["color"];
+      black: React.CSSProperties["color"];
     };
   }
   interface ThemeOptions {
@@ -40,6 +41,7 @@ declare module "@mui/material/styles" {
       success: React.CSSProperties["color"];
       successdark: React.CSSProperties["color"];
       white: React.CSSProperties["color"];
+      black: React.CSSProperties["color"];
     };
   }
 }
@@ -63,6 +65,7 @@ export function refreshTheme(): void {
       success: Settings.theme.success,
       successdark: Settings.theme.successdark,
       white: Settings.theme.white,
+      black: Settings.theme.black,
     },
     palette: {
       primary: {

--- a/src/ui/React/WorldMap.tsx
+++ b/src/ui/React/WorldMap.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { CityName } from "../../Locations/data/CityNames";
 import Typography from "@mui/material/Typography";
 import Tooltip from "@mui/material/Tooltip";
+import { Theme } from "@mui/material/styles";
+import makeStyles from "@mui/styles/makeStyles";
+import createStyles from "@mui/styles/createStyles";
 
 interface ICityProps {
   currentCity: CityName;
@@ -9,13 +12,25 @@ interface ICityProps {
   onTravel: (city: CityName) => void;
 }
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+      travel: {
+        color: theme.colors.white,
+        lineHeight: "1em",
+        whiteSpace: "pre",
+        cursor: "pointer"
+      },
+    })
+);
+
 function City(props: ICityProps): React.ReactElement {
+  const classes = useStyles();
   if (props.city !== props.currentCity) {
     return (
       <Tooltip title={<Typography>{props.city}</Typography>}>
         <span
           onClick={() => props.onTravel(props.city)}
-          style={{ color: "white", lineHeight: "1em", whiteSpace: "pre", cursor: "pointer" }}
+          className={classes.travel}
         >
           {props.city[0]}
         </span>


### PR DESCRIPTION
A few minor changes and fixes to the theme system to make it more consistent overall. I loaded all default themes in the dev build and ensured they did not have any issues with the world and city maps, or the toast messages.

### Comparison Screenshots
Steam
![steam world map](https://user-images.githubusercontent.com/49107866/147698466-07b33932-a9d4-4017-b3ca-cbd28def5812.png)
Dev
![updated world map](https://user-images.githubusercontent.com/49107866/147698506-fb130f30-8e75-40b9-b132-8ee69bcbaf81.png)

Steam
![steam city map](https://user-images.githubusercontent.com/49107866/147698468-934bbe67-01e3-4303-a605-a102be3373a6.png)
Dev
![updated city map](https://user-images.githubusercontent.com/49107866/147698516-48b97c7c-8f81-4b27-bda0-1d8b66f96233.png)

Steam
![steam theme modal](https://user-images.githubusercontent.com/49107866/147698469-ed3e988a-8515-4dfa-953d-428fe29484af.png)
Dev
![updated theme modal](https://user-images.githubusercontent.com/49107866/147698521-3dd45d62-15d9-46d1-b2b8-1a7e36348d4d.png)


### List of Changes

- Added black & white to the theme interfaces.
- Added the success colors to the theme creation so that Mui gets the correct colors
- Added a line in the theme refresh that updates the background color with the "black" color. I wasn't sure if this should be the primary background or black. As the live version has it as just black, that is what I opted to use. It won't be hard to change if desired.
