### PR TITLE
Use numeral.js to format memory, allow use of GiB with an option

### DIFF
--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -113,6 +113,11 @@ interface IDefaultSettings {
    * Theme colors
    */
   theme: ITheme;
+  
+  /*
+   * Use GiB instead of GB
+   */
+  UseIEC60027_2: boolean;
 }
 
 /**
@@ -160,6 +165,7 @@ export const defaultSettings: IDefaultSettings = {
   SuppressBladeburnerPopup: false,
   SuppressTIXPopup: false,
   SuppressSavedGameToast: false,
+  UseIEC60027_2: false,
 
   theme: defaultTheme,
 };
@@ -192,6 +198,7 @@ export const Settings: ISettings & ISelfInitializer & ISelfLoading = {
   SuppressBladeburnerPopup: defaultSettings.SuppressBladeburnerPopup,
   SuppressTIXPopup: defaultSettings.SuppressTIXPopup,
   SuppressSavedGameToast: defaultSettings.SuppressSavedGameToast,
+  UseIEC60027_2: defaultSettings.UseIEC60027_2,
   MonacoTheme: "monokai",
   MonacoInsertSpaces: false,
   MonacoFontSize: 20,

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -78,6 +78,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
   const [enableBashHotkeys, setEnableBashHotkeys] = useState(Settings.EnableBashHotkeys);
   const [timestampFormat, setTimestampFormat] = useState(Settings.TimestampsFormat);
   const [saveGameOnFileSave, setSaveGameOnFileSave] = useState(Settings.SaveGameOnFileSave);
+  const [useIEC60027_2, setUseIEC60027_2] = useState(Settings.UseIEC60027_2);
 
   const [locale, setLocale] = useState(Settings.Locale);
   const [diagnosticOpen, setDiagnosticOpen] = useState(false);
@@ -153,6 +154,10 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
   function handleDisableASCIIArtChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setDisableASCIIArt(event.target.checked);
     Settings.DisableASCIIArt = event.target.checked;
+  }
+  function handleUseIEC60027_2Change(event: React.ChangeEvent<HTMLInputElement>): void {
+    setUseIEC60027_2(event.target.checked);
+    Settings.UseIEC60027_2 = event.target.checked;
   }
 
   function handleDisableTextEffectsChange(event: React.ChangeEvent<HTMLInputElement>): void {
@@ -509,6 +514,16 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
                     }
                   >
                     <Typography>Enable bash hotkeys</Typography>
+                  </Tooltip>
+                }
+              />
+            </ListItem>
+            <ListItem>
+              <FormControlLabel
+                control={<Switch checked={useIEC60027_2} onChange={handleUseIEC60027_2Change} />}
+                label={
+                  <Tooltip title={<Typography>If this is set all references to memory will use GiB instead of GB, in accordance with IEC 60027-2.</Typography>}>
+                    <Typography>Use GiB instead of GB</Typography>
                   </Tooltip>
                 }
               />

--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -14,10 +14,13 @@ import "numeral/locales/no";
 import "numeral/locales/pl";
 import "numeral/locales/ru";
 
+import { Settings } from "../Settings/Settings";
+
 /* eslint-disable class-methods-use-this */
 
 const extraFormats = [1e15, 1e18, 1e21, 1e24, 1e27, 1e30];
 const extraNotations = ["q", "Q", "s", "S", "o", "n"];
+const gigaMultiplier = { standard: 1e9, iec60027_2: 2 ** 30 };
 
 class NumeralFormatter {
   // Default Locale
@@ -110,11 +113,11 @@ class NumeralFormatter {
   }
 
   formatRAM(n: number): string {
-    if (n < 1e3) return this.format(n, "0.00") + "GB";
-    if (n < 1e6) return this.format(n / 1e3, "0.00") + "TB";
-    if (n < 1e9) return this.format(n / 1e6, "0.00") + "PB";
-    if (n < 1e12) return this.format(n / 1e9, "0.00") + "EB";
-    return this.format(n, "0.00") + "GB";
+    if(Settings.UseIEC60027_2)
+    {
+      return this.format(n * gigaMultiplier.iec60027_2, "0.00ib");
+    }
+    return this.format(n * gigaMultiplier.standard, "0.00b");
   }
 
   formatPercentage(n: number, decimalPlaces = 2): string {


### PR DESCRIPTION
numeral.js has a formatter for both kilobyte and kibibyte, so why use a custom formatter that only goes up to exabyte?

Also added a setting to allow people who really want to see GiB to enable that, even if it doesn't make sense. I added that just because numeral.js already has a formatter for kibibyte so it's just a matter of adding the correct multiplier and format string. I hope this is an acceptable compromise for people that want to use gibibytes.

I mostly just wanted formatRAM to use `format("0.00b")` so that it's obvious to anyone looking that they can use `ns.nformat("0.00b")` to format bytes in their own scripts.