### PR TITLE
Fix: Use global references for electron event handlers

### DIFF
--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -9,6 +9,7 @@ const api = require("./api-server");
 const debug = process.argv.includes("--debug");
 
 async function createWindow(killall) {
+  const setStopProcessHandler = global.app_handlers.stopProcess
   const window = new BrowserWindow({
     show: false,
     backgroundThrottling: false,
@@ -45,7 +46,7 @@ async function createWindow(killall) {
   }
 
   menu.refreshMenu(window);
-  utils.setStopProcessHandler(app, window, true);
+  setStopProcessHandler(app, window, true);
 
   return window;
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,7 +6,6 @@ const greenworks = require("./greenworks");
 const api = require("./api-server");
 const gameWindow = require("./gameWindow");
 const achievements = require("./achievements");
-const utils = require("./utils");
 
 log.catchErrors();
 log.info(`Started app: ${JSON.stringify(process.argv)}`);
@@ -48,7 +47,7 @@ function setStopProcessHandler(app, window, enabled) {
       if (!canRunJS) {
         // We're stuck, let's crash the process
         log.warn('Forcefully crashing the renderer process');
-        gameWindow.webContents.forcefullyCrashRenderer();
+        window.webContents.forcefullyCrashRenderer();
       }
 
       log.debug('Destroying the window');
@@ -84,10 +83,12 @@ function startWindow(noScript) {
   gameWindow.createWindow(noScript);
 }
 
-utils.initialize(setStopProcessHandler, startWindow);
+global.app_handlers = {
+  stopProcess: setStopProcessHandler,
+  createWindow: startWindow,
+}
 
-app.whenReady().then(async () => {
+app.whenReady().then(() => {
   log.info('Application is ready!');
-  utils.initialize(setStopProcessHandler, startWindow);
-  startWindow(process.argv.includes("--no-scripts"))
+  startWindow(process.argv.includes("--no-scripts"));
 });

--- a/electron/utils.js
+++ b/electron/utils.js
@@ -5,19 +5,10 @@ const log = require("electron-log");
 const achievements = require("./achievements");
 const api = require("./api-server");
 
-let setStopProcessHandler = () => {
-  // Will be overwritten by the initialize function called in main
-}
-let createWindowHandler = () => {
-  // Will be overwritten by the initialize function called in main
-}
-
-function initialize(stopHandler, createHandler) {
-  setStopProcessHandler = stopHandler;
-  createWindowHandler = createHandler
-}
-
 function reloadAndKill(window, killScripts) {
+  const setStopProcessHandler = global.app_handlers.stopProcess
+  const createWindowHandler = global.app_handlers.createWindow;
+
   log.info('Reloading & Killing all scripts...');
   setStopProcessHandler(app, window, false);
 
@@ -72,7 +63,6 @@ function showErrorBox(title, error) {
 }
 
 module.exports = {
-  initialize, setStopProcessHandler, reloadAndKill, showErrorBox,
+  reloadAndKill, showErrorBox,
   attachUnresponsiveAppHandler, detachUnresponsiveAppHandler,
 }
-


### PR DESCRIPTION
I messed up the handlers reference in the last commit so the events were not properly attached. Changed it to use global variables for now. It screwed with the fixes for the application closing events.