### PR TITLE
Add electron launch option to directly export save game 

### DIFF
--- a/electron/export.html
+++ b/electron/export.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <title>Bitburner</title>
+    <link rel="stylesheet" href="main.css" />
+    <style>
+      body {
+        background-color: black;
+        color: #0c0;
+      }
+
+      div {
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      h1 {
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Close me when operation is completed.</h1>
+    </div>
+  </body>
+</html>

--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -9,6 +9,7 @@ const api = require("./api-server");
 const debug = process.argv.includes("--debug");
 
 async function createWindow(killall) {
+  const setStopProcessHandler = global.app_handlers.stopProcess
   const window = new BrowserWindow({
     show: false,
     backgroundThrottling: false,
@@ -45,7 +46,7 @@ async function createWindow(killall) {
   }
 
   menu.refreshMenu(window);
-  utils.setStopProcessHandler(app, window, true);
+  setStopProcessHandler(app, window, true);
 
   return window;
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,11 +1,12 @@
 /* eslint-disable no-process-exit */
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { app } = require("electron");
+const { app, BrowserWindow } = require("electron");
 const log = require("electron-log");
 const greenworks = require("./greenworks");
 const api = require("./api-server");
 const gameWindow = require("./gameWindow");
 const achievements = require("./achievements");
+const utils = require("./utils");
 
 log.catchErrors();
 log.info(`Started app: ${JSON.stringify(process.argv)}`);
@@ -88,7 +89,16 @@ global.app_handlers = {
   createWindow: startWindow,
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   log.info('Application is ready!');
-  startWindow(process.argv.includes("--no-scripts"));
+
+  if (process.argv.includes("--export-save")) {
+    const window = new BrowserWindow({ show: false });
+    await window.loadFile("export.html", false);
+    window.show();
+    setStopProcessHandler(app, window, true);
+    await utils.exportSave(window);
+  } else {
+    startWindow(process.argv.includes("--no-scripts"));
+  }
 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,7 +6,6 @@ const greenworks = require("./greenworks");
 const api = require("./api-server");
 const gameWindow = require("./gameWindow");
 const achievements = require("./achievements");
-const utils = require("./utils");
 
 log.catchErrors();
 log.info(`Started app: ${JSON.stringify(process.argv)}`);
@@ -48,7 +47,7 @@ function setStopProcessHandler(app, window, enabled) {
       if (!canRunJS) {
         // We're stuck, let's crash the process
         log.warn('Forcefully crashing the renderer process');
-        gameWindow.webContents.forcefullyCrashRenderer();
+        window.webContents.forcefullyCrashRenderer();
       }
 
       log.debug('Destroying the window');
@@ -84,10 +83,12 @@ function startWindow(noScript) {
   gameWindow.createWindow(noScript);
 }
 
-utils.initialize(setStopProcessHandler, startWindow);
+global.app_handlers = {
+  stopProcess: setStopProcessHandler,
+  createWindow: startWindow,
+}
 
-app.whenReady().then(async () => {
+app.whenReady().then(() => {
   log.info('Application is ready!');
-  utils.initialize(setStopProcessHandler, startWindow);
-  startWindow(process.argv.includes("--no-scripts"))
+  startWindow(process.argv.includes("--no-scripts"));
 });

--- a/electron/utils.js
+++ b/electron/utils.js
@@ -5,19 +5,10 @@ const log = require("electron-log");
 const achievements = require("./achievements");
 const api = require("./api-server");
 
-let setStopProcessHandler = () => {
-  // Will be overwritten by the initialize function called in main
-}
-let createWindowHandler = () => {
-  // Will be overwritten by the initialize function called in main
-}
-
-function initialize(stopHandler, createHandler) {
-  setStopProcessHandler = stopHandler;
-  createWindowHandler = createHandler
-}
-
 function reloadAndKill(window, killScripts) {
+  const setStopProcessHandler = global.app_handlers.stopProcess
+  const createWindowHandler = global.app_handlers.createWindow;
+
   log.info('Reloading & Killing all scripts...');
   setStopProcessHandler(app, window, false);
 
@@ -72,7 +63,6 @@ function showErrorBox(title, error) {
 }
 
 module.exports = {
-  initialize, setStopProcessHandler, reloadAndKill, showErrorBox,
+  reloadAndKill, showErrorBox,
   attachUnresponsiveAppHandler, detachUnresponsiveAppHandler,
 }
-

--- a/electron/utils.js
+++ b/electron/utils.js
@@ -62,7 +62,38 @@ function showErrorBox(title, error) {
   );
 }
 
+function exportSaveFromIndexedDb() {
+  return new Promise((resolve) => {
+    const dbRequest = indexedDB.open("bitburnerSave");
+    dbRequest.onsuccess = () => {
+      const db = dbRequest.result;
+      const transaction = db.transaction(['savestring'], "readonly");
+      const store = transaction.objectStore('savestring');
+      const request = store.get('save');
+      request.onsuccess = () => {
+        const file = new Blob([request.result], {type: 'text/plain'});
+        const a = document.createElement("a");
+        const url = URL.createObjectURL(file);
+        a.href = url;
+        a.download = 'save.json';
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(function () {
+          document.body.removeChild(a);
+          window.URL.revokeObjectURL(url);
+          resolve();
+        }, 0);
+      }
+    }
+  });
+}
+
+async function exportSave(window) {
+  await window.webContents
+    .executeJavaScript(`${exportSaveFromIndexedDb.toString()}; exportSaveFromIndexedDb();`, true);
+}
+
 module.exports = {
-  reloadAndKill, showErrorBox,
+  reloadAndKill, showErrorBox, exportSave,
   attachUnresponsiveAppHandler, detachUnresponsiveAppHandler,
 }


### PR DESCRIPTION
Depends on a commit from https://github.com/danielyxie/bitburner/pull/2237 (branched off it)

---

If --export-save is set, it will not launch the index.html and instead
launch a blank page. It then reads from the IndexedDb to fetch the
bitburnerSave value and prompts a save file dialog.

Can possibly be used to retrieve save files for users who have a broken state.

Feel free to discard this PR if not useful, this was just a quick test.