### PR TITLE
UI Fix: text style on Investopedia

### DIFF
--- a/src/StockMarket/ui/InfoAndPurchases.tsx
+++ b/src/StockMarket/ui/InfoAndPurchases.tsx
@@ -176,7 +176,7 @@ export function InfoAndPurchases(props: IProps): React.ReactElement {
     <>
       <Typography>Welcome to the World Stock Exchange (WSE)!</Typography>
       <Link href={documentationLink} target={"_blank"}>
-        Investopedia
+        <Typography>Investopedia</Typography>
       </Link>
       <br />
       <PurchaseWseAccountButton {...props} />


### PR DESCRIPTION
Hello,

I just noticed that the text style of "Investopedia" is somewhat weird, as it was not under `<Typography>` tag.

It's really small detailed fix, hope this will help the game maintain a consistent UI style.
I attatch screenshot on before and after fix.

J



![investopedia-before](https://user-images.githubusercontent.com/9479730/147776385-283550d7-afd3-492c-a0c7-166ad95b3686.png)

![investopedia-after](https://user-images.githubusercontent.com/9479730/147776398-1db10489-6730-4997-9fcf-e45d7d57f349.png)


