### PR TITLE
fix(editor): Fix vim mode quit and add `wq`

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -178,7 +178,12 @@ export function Root(props: IProps): React.ReactElement {
             save();
           });
           MonacoVim.VimMode.Vim.defineEx("quit", "q", function () {
+            props.router.toTerminal();
+          });
+          // "wqriteandquit" is not a typo, prefix must be found in full string
+          MonacoVim.VimMode.Vim.defineEx("wqriteandquit", "wq", function () {
             save();
+            props.router.toTerminal();
           });
           editor.focus();
         });


### PR DESCRIPTION
This changes `:q` to be quit (w/o saving) and added `:wq` to save *and* close.