### PR TITLE
Add Function Call signatures to ns.kill so typescript is able to call ns.kill correctly

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1009,7 +1009,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
         workerScript.log("spawn", () => "Exiting...");
       }
     },
-    kill: function (filename: any, hostname: any, ...scriptArgs: any): any {
+    kill: function (filename: any, hostname?: any, ...scriptArgs: any): any {
       updateDynamicRam("kill", getRamCost("kill"));
 
       let res;

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -2025,7 +2025,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       return calculateWeakenTime(server, Player) * 1000;
     },
-    getScriptIncome: function (scriptname: any, hostname: any, ...args: any[]): any {
+    getScriptIncome: function (scriptname?: any, hostname?: any, ...args: any[]): any {
       updateDynamicRam("getScriptIncome", getRamCost("getScriptIncome"));
       if (arguments.length === 0) {
         const res = [];
@@ -2054,7 +2054,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
         return runningScriptObj.onlineMoneyMade / runningScriptObj.onlineRunningTime;
       }
     },
-    getScriptExpGain: function (scriptname: any, hostname: any, ...args: any[]): any {
+    getScriptExpGain: function (scriptname?: any, hostname?: any, ...args: any[]): any {
       updateDynamicRam("getScriptExpGain", getRamCost("getScriptExpGain"));
       if (arguments.length === 0) {
         let total = 0;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4680,8 +4680,10 @@ export interface NS extends Singularity {
    * @param args - Arguments to identify which script to kill.
    * @returns True if the script is successfully killed, and false otherwise.
    */
-  kill(script: string | number, host: string, ...args: string[]): boolean;
-
+   kill(script: number): boolean;
+   kill(script: string, host: string, ...args: string[]): boolean;
+   kill(script: string | number, host: string, ...args: string[]): boolean;
+ 
   /**
    * Terminate all scripts on a server.
    * @remarks

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4682,7 +4682,6 @@ export interface NS extends Singularity {
    */
    kill(script: number): boolean;
    kill(script: string, host: string, ...args: string[]): boolean;
-   kill(script: string | number, host: string, ...args: string[]): boolean;
  
   /**
    * Terminate all scripts on a server.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5545,7 +5545,8 @@ export interface NS extends Singularity {
    * @param args - Arguments that the script is running with.
    * @returns Amount of income the specified script generates while online.
    */
-  getScriptIncome(script: string, host: string, ...args: string[]): number | [number, number];
+  getScriptIncome(): [number, number];
+  getScriptIncome(script: string, host: string, ...args: string[]): number;
 
   /**
    * Get the exp gain of a script.
@@ -5564,6 +5565,7 @@ export interface NS extends Singularity {
    * @param args - Arguments that the script is running with.
    * @returns Amount of hacking experience the specified script generates while online.
    */
+  getScriptExpGain(): number;
   getScriptExpGain(script: string, host: string, ...args: string[]): number;
 
   /**


### PR DESCRIPTION
previously this would fail to compile due to not providing a host argument
`
const pid: number = 42;
ns.kill(pid)
`