### PR TITLE
Add tooltip on backdoored location name

### DIFF
--- a/src/Locations/ui/GenericLocation.tsx
+++ b/src/Locations/ui/GenericLocation.tsx
@@ -29,6 +29,7 @@ import { GetServer } from "../../Server/AllServers";
 import { CorruptableText } from "../../ui/React/CorruptableText";
 import { use } from "../../ui/Context";
 import { serverMetadata } from "../../Server/data/servers";
+import { Tooltip } from "@mui/material";
 
 type IProps = {
   loc: Location;
@@ -92,8 +93,11 @@ export function GenericLocation({ loc }: IProps): React.ReactElement {
   return (
     <>
       <Button onClick={() => router.toCity()}>Return to World</Button>
-      <Typography variant="h4">
-        {backdoorInstalled && !Settings.DisableTextEffects ? <CorruptableText content={loc.name} /> : loc.name}
+      <Typography variant="h4" sx={{ mt: 1 }}>
+        {backdoorInstalled && !Settings.DisableTextEffects ? (
+          <Tooltip title={`Backdoor installed on ${loc.name}.`}>
+            <span><CorruptableText content={loc.name} /></span>
+          </Tooltip>) : loc.name}
       </Typography>
       {locContent}
     </>


### PR DESCRIPTION
Might help clarify the CorruptableText feature for certain users: https://github.com/danielyxie/bitburner/issues/2239

![firefox_0TQqK9Tsg1](https://user-images.githubusercontent.com/1521080/147820858-ad7ce048-88d7-4d53-9a36-b6ebea4f34c3.png)
