### PR TITLE
Remove alpha from color picker

### DIFF
--- a/src/ui/React/ThemeEditorModal.tsx
+++ b/src/ui/React/ThemeEditorModal.tsx
@@ -46,6 +46,7 @@ function ColorEditor({ name, onColorChange, color, defaultColor }: IColorEditorP
                 deferred
                 value={color}
                 onChange={(newColor: Color) => onColorChange(name, "#" + newColor.hex)}
+                disableAlpha
               />
             </>
           ),


### PR DESCRIPTION
Opacity is not currently supported in the themes, so might as well remove
the alpha option from the picker.

![firefox_Jp1vL2FaYl](https://user-images.githubusercontent.com/1521080/147830082-a5eb33b9-c7af-42f2-b560-741996eb27c3.png)
