### PR TITLE
Fix 2119

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -120,6 +120,15 @@ export function Root(props: IProps): React.ReactElement {
     vim: props.vim || Settings.MonacoVim,
   });
 
+  // Prevent Crash if script is open on deleted server
+  openScripts = openScripts.filter((script) => {
+    return GetServer(script.hostname) !== null;
+  })
+  if (currentScript && (GetServer(currentScript.hostname) === null)) {
+    currentScript = openScripts[0];
+  }
+
+
   const [dimensions, setDimensions] = useState({
     height: window.innerHeight,
     width: window.innerWidth,

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -126,6 +126,7 @@ export function Root(props: IProps): React.ReactElement {
   })
   if (currentScript && (GetServer(currentScript.hostname) === null)) {
     currentScript = openScripts[0];
+    if (currentScript === undefined) currentScript = null;
   }
 
 


### PR DESCRIPTION
Fixes #2119 close open scripts that exist on deleted servers
This prevents a crash by trying to open the script editor with a script
open that exists on a server that has been deleted

This is achieved by filtering the list of open scripts whenever the
editor is opened and removing any that exist on a server that has been deleted
It also handles the case of the selected script being one that was
removed in which case it defaults to selecting the first script