### PR TITLE
Fixed ambiguous NS.hackAnalyze description

### DIFF
--- a/markdown/bitburner.ns.hackanalyze.md
+++ b/markdown/bitburner.ns.hackanalyze.md
@@ -4,7 +4,7 @@
 
 ## NS.hackAnalyze() method
 
-Get the percent of money stolen with a single thread.
+Get the part of money stolen with a single thread.
 
 <b>Signature:</b>
 
@@ -22,13 +22,13 @@ hackAnalyze(host: string): number;
 
 number
 
-The percentage of money you will steal from the target server with a single hack.
+The part of money you will steal from the target server with a single thread hack.
 
 ## Remarks
 
 RAM cost: 1 GB
 
-Returns the percentage of the specified server’s money you will steal with a single hack. This value is returned in percentage form, not decimal (Netscript functions typically return in decimal form, but not this one).
+Returns the part of the specified server’s money you will steal with a single thread hack.
 
 ## Example
 
@@ -36,6 +36,6 @@ Returns the percentage of the specified server’s money you will steal with a s
 ```ts
 //For example, assume the following returns 0.01:
 hackAnalyze("foodnstuff");
-//This means that if hack the foodnstuff server, then you will steal 1% of its total money. If you hack using N threads, then you will steal N*0.01 times its total money.
+//This means that if hack the foodnstuff server using a single thread, then you will steal 1%, or 0.01 of its total money. If you hack using N threads, then you will steal N*0.01 times its total money.
 ```
 

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -111,7 +111,7 @@ export async function main(ns) {
 |  [growthAnalyze(host, growthAmount, cores)](./bitburner.ns.growthanalyze.md) | Calculate the number of grow thread needed to grow a server by a certain multiplier. |
 |  [growthAnalyzeSecurity(threads)](./bitburner.ns.growthanalyzesecurity.md) | Calculate the security increase for a number of thread. |
 |  [hack(host, opts)](./bitburner.ns.hack.md) | Steal a servers money. |
-|  [hackAnalyze(host)](./bitburner.ns.hackanalyze.md) | Get the percent of money stolen with a single thread. |
+|  [hackAnalyze(host)](./bitburner.ns.hackanalyze.md) | Get the part of money stolen with a single thread. |
 |  [hackAnalyzeChance(host)](./bitburner.ns.hackanalyzechance.md) | Get the chance of successfully hacking a server. |
 |  [hackAnalyzeSecurity(threads)](./bitburner.ns.hackanalyzesecurity.md) | Get the security increase for a number of thread. |
 |  [hackAnalyzeThreads(host, hackAmount)](./bitburner.ns.hackanalyzethreads.md) | Predict the effect of hack. |


### PR DESCRIPTION
The description of NS.hackAnalyze function in the markdown documentation is misleading, as while it mentions a percentage value being returned instead of a 'decimal' form, the value returned has nothing to do with percentages - it is simply a multiplier of the total money available on the server. The provided example and my experiments in-game make it clear that this behaviour is intended and the description is incorrect.