### PR TITLE
docs: update the markdown documentation for commitCrime()

### DIFF
--- a/markdown/bitburner.singularity.commitcrime.md
+++ b/markdown/bitburner.singularity.commitcrime.md
@@ -30,7 +30,7 @@ RAM cost: 5 GB
 
 This function is used to automatically attempt to commit crimes. If you are already in the middle of some ‘working’ action (such as working for a company or training at a gym), then running this function will automatically cancel that action and give you your earnings.
 
-This function returns the number of seconds it takes to attempt the specified crime (e.g It takes 60 seconds to attempt the ‘Rob Store’ crime, so running `commitCrime('rob store')` will return 60).
+This function returns the number of milliseconds it takes to attempt the specified crime (e.g It takes 60 seconds to attempt the ‘Rob Store’ crime, so running `commitCrime('rob store')` will return 60,000).
 
 Warning: I do not recommend using the time returned from this function to try and schedule your crime attempts. Instead, I would use the isBusy Singularity function to check whether you have finished attempting a crime. This is because although the game sets a certain crime to be X amount of seconds, there is no guarantee that your browser will follow that time limit.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1767,7 +1767,7 @@ export interface Singularity {
    *
    * This function returns the number of milliseconds it takes to attempt the 
    * specified crime (e.g It takes 60 seconds to attempt the ‘Rob Store’ crime, 
-   * so running `commitCrime('rob store')` will return 60000).
+   * so running `commitCrime('rob store')` will return 60,000).
    *
    * Warning: I do not recommend using the time returned from this function to try
    * and schedule your crime attempts. Instead, I would use the isBusy Singularity


### PR DESCRIPTION
`Singularity#commitCrime()` returns the result in milliseconds, not seconds.