### PR TITLE
ns.hackAnalyze definition fix to match markdown

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4079,31 +4079,28 @@ export interface NS extends Singularity {
   hackAnalyzeThreads(host: string, hackAmount: number): number;
 
   /**
-   * Get the percent of money stolen with a single thread.
+   * Get the part of money stolen with a single thread.
    * @remarks
    * RAM cost: 1 GB
    *
-   * Returns the percentage of the specified server’s money you will steal with a single hack.
-   * This value is returned in percentage form, not decimal
-   * (Netscript functions typically return in decimal form, but not this one).
-   * This percentage is influenced by the player's hacking skill.
+   * Returns the part of the specified server’s money you will steal with a single thread hack.
    *
    * @example
    * ```ts
    * // NS1:
    * //For example, assume the following returns 0.01:
    * var hackAmount = hackAnalyze("foodnstuff");
-   * //This means that if hack the foodnstuff server, then you will steal 1% of its total money. If you hack using N threads, then you will steal N*0.01 times its total money.
+   * //This means that if hack the foodnstuff server using a single thread, then you will steal 1%, or 0.01 of its total money. If you hack using N threads, then you will steal N*0.01 times its total money.
    * ```
    * @example
    * ```ts
    * // NS2:
    * //For example, assume the following returns 0.01:
    * const hackAmount = ns.hackAnalyze("foodnstuff");
-   * //This means that if hack the foodnstuff server, then you will steal 1% of its total money. If you hack using N threads, then you will steal N*0.01 times its total money.
+   * //This means that if hack the foodnstuff server using a single thread, then you will steal 1%, or 0.01 of its total money. If you hack using N threads, then you will steal N*0.01 times its total money.
    * ```
    * @param host - Hostname of the target server.
-   * @returns The percentage of money you will steal from the target server with a single hack.
+   * @returns The part of money you will steal from the target server with a single thread hack.
    */
   hackAnalyze(host: string): number;
 


### PR DESCRIPTION
In the pull request #2277 I requested a change to the markdown, but I didn't notice that the description is automatically generated from src/ScriptEditor/NetscriptDefinitions.d.ts - this commit changes the definition file, so that the previous change isn't overridden in the future.