### PR TITLE
Update ns.toast() signature

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -3678,8 +3678,9 @@ export declare interface NS extends Singularity {
      * Queue a toast (bottom-right notification).
      * @param msg - Message in the toast.
      * @param variant - Type of toast, must be one of success, info, warning, error. Defaults to success.
+     * @param duration - Duration of toast in ms, defaults to 2000
      */
-    toast(msg: any, variant?: string): void;
+    toast(msg: any, variant?: string, duration?: number): void;
 
     /**
      * Download a file from the internet.


### PR DESCRIPTION
Updates the signature of `ns.toast()` in `bitburner.d.ts` to match its definition in `NetscriptDefinitions.d.ts` (adds the `duration` argument).