### PR TITLE
Fix some achievements not triggered if hacked with backdoor command

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -285,6 +285,7 @@ export class Terminal implements ITerminal {
         return;
       }
       if (!(server instanceof Server)) throw new Error("server should be normal server");
+      server.backdoorInstalled = true;
       if (SpecialServers.WorldDaemon === server.hostname) {
         if (player.bitNodeN == null) {
           player.bitNodeN = 1;
@@ -292,7 +293,6 @@ export class Terminal implements ITerminal {
         router.toBitVerse(false, false);
         return;
       }
-      server.backdoorInstalled = true;
       this.print("Backdoor successful!");
     }
   }


### PR DESCRIPTION
Moving to BitVerse and returning from the function happens before setting backdoorInstalled property to true, so achievement handler believes the current BitNode was not finished (unless the player applied backdoor through hack command, which has a correct code, or doing with bladeburner).
To me, the bug happened with FAST_BN achievement, but probably it happens with any achievement that relies on https://github.com/danielyxie/bitburner/blob/16c51e8e8eaf48aaee6c1f16e3839ea4111dd173/src/Electron.tsx#L31 function.