### PR TITLE
fix ns.run args type definition

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -2720,7 +2720,7 @@ export declare interface NS extends Singularity {
      * @param args - Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the second argument numThreads must be filled in with a value.
      * @returns Returns the PID of a successfully started script, and 0 otherwise.
      */
-    run(script: string, numThreads?: number, ...args: string[]): number;
+    run(script: string, numThreads?: number, ...args: Array<string | number | boolean>): number;
 
     /**
      * Start another script on any server.
@@ -2760,7 +2760,7 @@ export declare interface NS extends Singularity {
      * @param args - Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the third argument numThreads must be filled in with a value.
      * @returns Returns the PID of a successfully started script, and 0 otherwise.
      */
-    exec(script: string, host: string, numThreads?: number, ...args: string[]): number;
+    exec(script: string, host: string, numThreads?: number, ...args: Array<string | number | boolean>): number;
 
     /**
      * Terminate current script and start another in 10s.

--- a/markdown/bitburner.ns.run.md
+++ b/markdown/bitburner.ns.run.md
@@ -9,7 +9,7 @@ Start another script on the current server.
 <b>Signature:</b>
 
 ```typescript
-run(script: string, numThreads?: number, ...args: string[]): number;
+run(script: string, numThreads?: number, ...args: Array<string | number | boolean>): number;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ run(script: string, numThreads?: number, ...args: string[]): number;
 |  --- | --- | --- |
 |  script | string | Filename of script to run. |
 |  numThreads | number | Optional thread count for new script. Set to 1 by default. Will be rounded to nearest integer. |
-|  args | string\[\] | Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the second argument numThreads must be filled in with a value. |
+|  args | Array<string | number | boolean> | Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the second argument numThreads must be filled in with a value. |
 
 <b>Returns:</b>
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4560,7 +4560,7 @@ export interface NS extends Singularity {
    * @param args - Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the second argument numThreads must be filled in with a value.
    * @returns Returns the PID of a successfully started script, and 0 otherwise.
    */
-  run(script: string, numThreads?: number, ...args: string[]): number;
+  run(script: string, numThreads?: number, ...args: Array<string | number | boolean>): number;
 
   /**
    * Start another script on any server.


### PR DESCRIPTION
ns.run has incorrect type definition - it allows the same behavior as exec - to pass either number, boolean or a string as an argument, but forbids to do so in it's type definition. This PR aims to change this inconsistency.

