### PR TITLE
Validate RAM amount in ns.purchaseServer()

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1639,7 +1639,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       const cost = getPurchaseServerCost(ram);
       if (cost === Infinity) {
-        workerScript.log("purchaseServer", () => `Invalid argument: ram='${ram}' must be power of 2`);
+        workerScript.log("purchaseServer", () => `Invalid argument: ram='${ram}' must be a positive power of 2`);
         return "";
       }
 

--- a/src/Server/ServerPurchases.ts
+++ b/src/Server/ServerPurchases.ts
@@ -20,7 +20,7 @@ import { isPowerOfTwo } from "../utils/helpers/isPowerOfTwo";
  */
 export function getPurchaseServerCost(ram: number): number {
   const sanitizedRam = Math.round(ram);
-  if (isNaN(sanitizedRam) || !isPowerOfTwo(sanitizedRam)) {
+  if (isNaN(sanitizedRam) || !isPowerOfTwo(sanitizedRam) || !(Math.sign(sanitizedRam) === 1)) {
     return Infinity;
   }
 


### PR DESCRIPTION
Validates that the RAM amount specified is a positive integer for `ns.purchaseServer()` and `ns.getPurchasedServerCost()`.

Addresses  #2276