### PR TITLE
Restrict log window to visible window

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -181,7 +181,7 @@ function LogWindow(props: IProps): React.ReactElement {
   }
 
   return (
-    <Draggable handle=".drag">
+    <Draggable handle=".drag" bounds=":root">
       <Paper
         style={{
           display: "flex",


### PR DESCRIPTION
Sets the bounds of log windows so that they can't be lost outside the visible window space.

Addresses #2067