### PR TITLE
Fix unresponsive handler being attached many times

### DIFF
--- a/electron/utils.js
+++ b/electron/utils.js
@@ -48,11 +48,12 @@ function promptForReload(window) {
 }
 
 function attachUnresponsiveAppHandler(window) {
-  window.on('unresponsive', () => promptForReload(window));
+  window.unresponsiveHandler = () => promptForReload(window);
+  window.on('unresponsive', window.unresponsiveHandler);
 }
 
 function detachUnresponsiveAppHandler(window) {
-  window.off('unresponsive', () => promptForReload(window));
+  window.off('unresponsive', window.unresponsiveHandler);
 }
 
 function showErrorBox(title, error) {


### PR DESCRIPTION
Would cause events to not be unattached when dismissing the popup, cause exponentially more popups each time.