### PR TITLE
Include electron-log in achievements file

### DIFF
--- a/electron/achievements.js
+++ b/electron/achievements.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const greenworks = require("./greenworks");
+const log = require("electron-log");
 
 function enableAchievementsInterval(window) {
    // This is backward but the game fills in an array called `document.achievements` and we retrieve it from


### PR DESCRIPTION
When the timer throws an exception, it tried to log the error but log
was not defined.
![ConEmu64_jlqhnpojfp](https://user-images.githubusercontent.com/1521080/148275986-06bde73b-aae5-4b9b-bbc8-00f23d209064.png)
