### PR TITLE
Fix some achievements not triggered if hacked with backdoor command

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -285,6 +285,7 @@ export class Terminal implements ITerminal {
         return;
       }
       if (!(server instanceof Server)) throw new Error("server should be normal server");
+      server.backdoorInstalled = true;
       if (SpecialServers.WorldDaemon === server.hostname) {
         if (player.bitNodeN == null) {
           player.bitNodeN = 1;
@@ -292,7 +293,6 @@ export class Terminal implements ITerminal {
         router.toBitVerse(false, false);
         return;
       }
-      server.backdoorInstalled = true;
       this.print("Backdoor successful!");
     }
   }


### PR DESCRIPTION
(see pull request #2299, previously i mistakenly pushed it into the wrong branch)
Moving to BitVerse and returning from function happened before setting backdoorInstalled property to true, so Achievement Handler believed the current BitNode was not finished (unless we applied backdoor through hack command, which has correct code).