### PR TITLE
Update print and tprint signatures to match code

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4233,22 +4233,22 @@ export interface NS extends Singularity {
   asleep(millis: number): Promise<void>;
 
   /**
-   * Prints a value or a variable to the script’s logs.
+   * Prints one or move values or variables to the script’s logs.
    * @remarks
    * RAM cost: 0 GB
    *
-   * @param msg - Value to be printed.
+   * @param args - Value(s) to be printed.
    */
-  print(msg: any): void;
+  print(...args: any[]): void;
 
   /**
-   * Prints a value or a variable to the Terminal.
+   * Prints one or more values or variables to the Terminal.
    * @remarks
    * RAM cost: 0 GB
    *
-   * @param msg - Value to be printed.
+   * @param args - Value(s) to be printed.
    */
-  tprint(msg: any): void;
+  tprint(...args: any[]): void;
 
   /**
    * Prints a raw value or a variable to the Terminal.


### PR DESCRIPTION
In https://github.com/danielyxie/bitburner/pull/1380, print() and tprint() were both changed to allow for variadic arguments, but this wasn't documented in NetscriptDefinitions.d.ts. This changes the documentation to reflect how they actually behave.

I tried to generate the `markdown/` documentation, but running `npm run doc` on my machine makes API extractor generate a bunch of stuff that's not currently there and that includes some weird stuff like a duplicated `kill` 
![https://i.tigercat2000.net/2022/01/wish_0v95EUnRw7.png](https://i.tigercat2000.net/2022/01/wish_0v95EUnRw7.png)

Not sure what that's about, let me know if I need to just manually edit some of the markdown, or if this is some other problem that needs to be resolved.