### PR TITLE
Make corporation delayed functions check if script has been stopped

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -311,6 +311,9 @@ export function NetscriptCorporation(
       const job = helper.string("assignJob", "job", ajob);
       const employee = getEmployee(divisionName, cityName, employeeName);
       return netscriptDelay(1000, workerScript).then(function () {
+        if (workerScript.env.stopFlag) {
+          return Promise.reject(workerScript);
+        }
         return Promise.resolve(AssignJob(employee, job));
       });
     },
@@ -341,6 +344,9 @@ export function NetscriptCorporation(
         (60 * 1000) / (player.hacking_speed_mult * calculateIntelligenceBonus(player.intelligence, 1)),
         workerScript,
       ).then(function () {
+        if (workerScript.env.stopFlag) {
+          return Promise.reject(workerScript);
+        }
         return Promise.resolve(ThrowParty(corporation, office, costPerEmployee));
       });
     },
@@ -353,6 +359,9 @@ export function NetscriptCorporation(
         (60 * 1000) / (player.hacking_speed_mult * calculateIntelligenceBonus(player.intelligence, 1)),
         workerScript,
       ).then(function () {
+        if (workerScript.env.stopFlag) {
+          return Promise.reject(workerScript);
+        }
         return Promise.resolve(BuyCoffee(corporation, getDivision(divisionName), getOffice(divisionName, cityName)));
       });
     },


### PR DESCRIPTION
Currently corporation functions are neither wrapped in NetscriptWorker, nor do they check whether the script has been stopped once the delay resolves. This can result in a corporation script invisibly running reassigning employees / throwing parties / making coffee, even though the game considers that script dead and gone.

This fixes the worst cause of the problem by making the delayed corporation functions check for script stop flag after delay.