### PR TITLE
Add save file warning for detailed ram usage

### DIFF
--- a/src/Terminal/commands/mem.ts
+++ b/src/Terminal/commands/mem.ts
@@ -43,6 +43,11 @@ export function mem(
     for (const entry of verboseEntries) {
       terminal.print(`${numeralWrapper.formatRAM(entry.cost * numThreads).padStart(8)} | ${entry.name} (${entry.type})`);
     }
+
+    if (ramUsage > 0 && verboseEntries.length === 0) {
+      // Let's warn the user that he might need to save his script again to generate the detailed entries
+      terminal.warn('You might have to open & save this script to see the detailed RAM usage information.');
+    }
   } catch (e) {
     terminal.error(e + "");
   }


### PR DESCRIPTION
Since the detailed info is only generated at save, some older scripts might not have the data.

![firefox_fzixbqTAtI](https://user-images.githubusercontent.com/1521080/148480333-a9e40fe8-4490-4e8b-b2fb-ddf68814aaef.png)
