### PR TITLE
Fix export bonus not being applied when using options menu

### DIFF
--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -41,6 +41,7 @@ class BitburnerSaveObject {
   AllGangsSave = "";
   LastExportBonus = "";
   StaneksGiftSave = "";
+  SaveTimestamp = "";
 
   getSaveString(): string {
     this.PlayerSave = JSON.stringify(Player);
@@ -56,6 +57,8 @@ class BitburnerSaveObject {
     this.VersionSave = JSON.stringify(CONSTANTS.VersionNumber);
     this.LastExportBonus = JSON.stringify(ExportBonus.LastExportBonus);
     this.StaneksGiftSave = JSON.stringify(staneksGift);
+    this.SaveTimestamp = new Date().getTime().toString();
+
     if (Player.inGang()) {
       this.AllGangsSave = JSON.stringify(AllGangs);
     }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -389,7 +389,11 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
                   <GameOptionsRoot
                     player={player}
                     save={() => saveObject.saveGame()}
-                    export={() => saveObject.exportGame()}
+                    export={() => {
+                      // Apply the export bonus before saving the game
+                      onExport(player);
+                      saveObject.exportGame()
+                    }}
                     forceKill={killAllScripts}
                     softReset={() => {
                       dialogBoxCreate("Soft Reset!");
@@ -400,8 +404,9 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
                 ) : page === Page.Augmentations ? (
                   <AugmentationsRoot
                     exportGameFn={() => {
-                      saveObject.exportGame();
+                      // Apply the export bonus before saving the game
                       onExport(player);
+                      saveObject.exportGame();
                     }}
                     installAugmentationsFn={() => {
                       installAugmentations();

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -246,16 +246,14 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
         return;
       }
 
-
       const data: ImportData = {
         base64: contents,
         parsed: parsedSave,
       }
 
-      // We don't always seem to have this value in the save file. Exporting from the option menu does not set the bonus I think.
-      const exportTimestamp = parsedSave.data.LastExportBonus;
-      if (exportTimestamp && exportTimestamp !== '0') {
-        data.exportDate = new Date(parseInt(exportTimestamp, 10))
+      const timestamp = parsedSave.data.SaveTimestamp;
+      if (timestamp && timestamp !== '0') {
+        data.exportDate = new Date(parseInt(timestamp, 10))
       }
 
       setImportData(data)

--- a/tools/pretty-save.js
+++ b/tools/pretty-save.js
@@ -19,6 +19,7 @@ async function getSave(file) {
     VersionSave: JSON.parse(saveData.VersionSave),
     LastExportBonus: JSON.parse(saveData.LastExportBonus),
     StaneksGiftSave: JSON.parse(saveData.StaneksGiftSave),
+    SaveTimestamp: new Date(parseInt(saveData.SaveTimestamp ?? '0', 10)).toLocaleString(),
   }
 
   const serverStrings = JSON.parse(saveData.AllServersSave);


### PR DESCRIPTION
Fixes #2418

- Apply export bonus when using options menu
- Change order to apply the bonus before saving the game instead of after
- Add SaveTimestamp to saveString, used in import popup to show save time.
