### PR TITLE
fix #2174 - icarus message will no longer stack infinitely

### DIFF
--- a/src/ui/React/AlertManager.tsx
+++ b/src/ui/React/AlertManager.tsx
@@ -3,12 +3,14 @@ import { EventEmitter } from "../../utils/EventEmitter";
 import { Modal } from "../../ui/React/Modal";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
+import {sha256} from "js-sha256";
 
 export const AlertEvents = new EventEmitter<[string | JSX.Element]>();
 
 interface Alert {
   id: string;
   text: string | JSX.Element;
+  hash: string;
 }
 
 let i = 0;
@@ -20,11 +22,17 @@ export function AlertManager(): React.ReactElement {
         const id = i + "";
         i++;
         setAlerts((old) => {
+          const hash = getMessageHash(text);
+          if (old.some(a => a.hash === hash)) {
+            console.log('Duplicate message');
+            return old;
+          }
           return [
             ...old,
             {
               id: id,
               text: text,
+              hash: hash,
             },
           ];
         });
@@ -41,6 +49,11 @@ export function AlertManager(): React.ReactElement {
     document.addEventListener("keydown", handle);
     return () => document.removeEventListener("keydown", handle);
   }, []);
+
+  function getMessageHash(text: string | JSX.Element): string {
+    if (typeof text === 'string') return sha256(text);
+    return sha256(JSON.stringify(text.props));
+  }
 
   function close(): void {
     setAlerts((old) => {


### PR DESCRIPTION
AlertManager now stores a hash for each incoming alert and will ignore any newly arriving alert if its hash matches against a message still in the queue. This fixes the issue of dozens of icarus messages, and should fix any other instances where a message would be queued up in the AlertManager more than once.