### PR TITLE
Add singularity RAM cost info to typings

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -69,7 +69,7 @@ export const RamCostConstants: IMap<number> = {
   ScriptStanekDeleteAt: 0.15,
 };
 
-function SF4Cost(cost: number): (player: IPlayer) => number {
+export function SF4Cost(cost: number): (player: IPlayer) => number {
   return (player: IPlayer): number => {
     if (player.bitNodeN === 4) return cost;
     const sf4 = player.sourceFileLvl(4);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1302,7 +1302,7 @@ export interface Singularity {
    * SF4.1 - Take university class.
    *
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will automatically set you to start taking a course at a university.
@@ -1323,7 +1323,7 @@ export interface Singularity {
    * SF4.1 - Workout at the gym.
    *
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
 
    * This function will automatically set you to start working out at a gym to train
@@ -1343,7 +1343,7 @@ export interface Singularity {
   /**
    * SF4.1 - Travel to another city.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function allows the player to travel to any city. The cost for using this
@@ -1357,7 +1357,7 @@ export interface Singularity {
   /**
    * SF4.1 - Purchase the TOR router.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function allows you to automatically purchase a TOR router. The cost for
@@ -1371,7 +1371,7 @@ export interface Singularity {
   /**
    * SF4.1 - Purchase a program from the dark web.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function allows you to automatically purchase programs. You MUST have a
@@ -1397,7 +1397,7 @@ export interface Singularity {
   /**
    * SF4.1 - Check if the player is busy.
    * @remarks
-   * RAM cost: 0.5 GB
+   * RAM cost: 0.5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Returns a boolean indicating whether or not the player is currently performing an
@@ -1411,7 +1411,7 @@ export interface Singularity {
   /**
    * SF4.1 - Stop the current action.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 1 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function is used to end whatever ‘action’ the player is currently performing.
@@ -1434,7 +1434,7 @@ export interface Singularity {
   /**
    * SF4.2 - Upgrade home computer RAM.
    * @remarks
-   * RAM cost: 3 GB
+   * RAM cost: 3 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will upgrade amount of RAM on the player’s home computer. The cost is
@@ -1449,7 +1449,7 @@ export interface Singularity {
   /**
    * SF4.2 - Upgrade home computer cores.
    * @remarks
-   * RAM cost: 3 GB
+   * RAM cost: 3 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will upgrade amount of cores on the player’s home computer. The cost is
@@ -1464,7 +1464,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get the price of upgrading home RAM.
    * @remarks
-   * RAM cost: 1.5 GB
+   * RAM cost: 1.5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Returns the cost of upgrading the player’s home computer RAM.
@@ -1476,7 +1476,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get the price of upgrading home cores.
    * @remarks
-   * RAM cost: 1.5 GB
+   * RAM cost: 1.5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Returns the cost of upgrading the player’s home computer cores.
@@ -1488,7 +1488,7 @@ export interface Singularity {
   /**
    * SF4.2 - Work for a company.
    * @remarks
-   * RAM cost: 3 GB
+   * RAM cost: 3 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will automatically set you to start working at the company
@@ -1530,7 +1530,7 @@ export interface Singularity {
   /**
    * SF4.2 - Apply for a job at a company.
    * @remarks
-   * RAM cost: 3 GB
+   * RAM cost: 3 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will automatically try to apply to the specified company
@@ -1551,7 +1551,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get company reputation.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 1 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will return the amount of reputation you have at the specified company.
@@ -1565,7 +1565,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get company favor.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 1 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will return the amount of favor you have at the specified company.
@@ -1579,7 +1579,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get company favor gain.
    * @remarks
-   * RAM cost: 0.75 GB
+   * RAM cost: 0.75 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will return the amount of favor you will gain for the specified
@@ -1593,7 +1593,7 @@ export interface Singularity {
   /**
    * SF4.2 - List all current faction invitations.
    * @remarks
-   * RAM cost: 3 GB
+   * RAM cost: 3 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Returns an array with the name of all Factions you currently have oustanding invitations from.
@@ -1605,7 +1605,7 @@ export interface Singularity {
   /**
    * SF4.2 - Join a faction.
    * @remarks
-   * RAM cost: 3 GB
+   * RAM cost: 3 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will automatically accept an invitation from a faction and join it.
@@ -1618,7 +1618,7 @@ export interface Singularity {
   /**
    * SF4.2 - Work for a faction.
    * @remarks
-   * RAM cost: 3 GB
+   * RAM cost: 3 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will automatically set you to start working for the specified faction.
@@ -1661,7 +1661,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get faction reputation.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 1 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns the amount of reputation you have for the specified faction.
@@ -1674,7 +1674,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get faction favor.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 1 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns the amount of favor you have for the specified faction.
@@ -1687,7 +1687,7 @@ export interface Singularity {
   /**
    * SF4.2 - Get faction favor gain.
    * @remarks
-   * RAM cost: 0.75 GB
+   * RAM cost: 0.75 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns the amount of favor you will gain for the specified
@@ -1701,7 +1701,7 @@ export interface Singularity {
   /**
    * SF4.3 - Donate to a faction.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Attempts to donate money to the specified faction in exchange for reputation.
@@ -1716,7 +1716,7 @@ export interface Singularity {
   /**
    * SF4.3 - Create a program.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will automatically set you to start working on creating the
@@ -1756,7 +1756,7 @@ export interface Singularity {
   /**
    * SF4.3 - Commit a crime.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function is used to automatically attempt to commit crimes.
@@ -1783,7 +1783,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get chance to successfully commit a crime.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns your chance of success at commiting the specified crime.
@@ -1796,7 +1796,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get stats related to a crime.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Returns the stats of the crime.
@@ -1809,7 +1809,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get a list of owned augmentation.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns an array containing the names (as strings) of all Augmentations you have.
@@ -1822,7 +1822,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get a list of augmentation available from a faction.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Returns an array containing the names (as strings) of all Augmentations
@@ -1836,7 +1836,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get the pre-requisite of an augmentation.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns an array with the names of the prerequisite Augmentation(s) for the specified Augmentation.
@@ -1851,7 +1851,7 @@ export interface Singularity {
    * SF4.3 - Get the price and reputation of an augmentation.
    * @deprecated use getAugmentationPrice getAugmentationRepCost
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns an array with two elements that gives the cost for
@@ -1870,7 +1870,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get price of an augmentation.
    * @remarks
-   * RAM cost: 2.5 GB
+   * RAM cost: 2.5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @param augName - Name of Augmentation.
@@ -1881,7 +1881,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get reputation requirement of an augmentation.
    * @remarks
-   * RAM cost: 2.5 GB
+   * RAM cost: 2.5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @param augName - Name of Augmentation.
@@ -1892,7 +1892,7 @@ export interface Singularity {
   /**
    * SF4.3 - Purchase an augmentation
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will try to purchase the specified Augmentation through the given Faction.
@@ -1908,7 +1908,7 @@ export interface Singularity {
   /**
    * SF4.3 - Get the stats of an augmentation.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function returns augmentation stats.
@@ -1921,7 +1921,7 @@ export interface Singularity {
   /**
    * SF4.3 - Install your purchased augmentations.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will automatically install your Augmentations, resetting the game as usual.
@@ -1935,7 +1935,7 @@ export interface Singularity {
    * @deprecated use getPlayer
    *
    * @remarks
-   * RAM cost: 0.5 GB
+   * RAM cost: 0.5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @example
@@ -1952,7 +1952,7 @@ export interface Singularity {
    * @deprecated use getPlayer
    *
    * @remarks
-   * RAM cost: 0.5 GB
+   * RAM cost: 0.5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @returns Object with various information about your character.
@@ -1962,7 +1962,7 @@ export interface Singularity {
   /**
    * SF4.1 - Hospitalize the player.
    * @remarks
-   * RAM cost: 0.25 GB
+   * RAM cost: 0.25 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @returns The cost of the hospitalization.
@@ -1972,7 +1972,7 @@ export interface Singularity {
   /**
    * SF4.3 - Soft reset the game.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * This function will perform a reset even if you don’t have any augmentation installed.
@@ -1984,7 +1984,7 @@ export interface Singularity {
   /**
    * SF4.3 - Go to a location.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 5 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Move the player to a specific location.
@@ -1997,7 +1997,7 @@ export interface Singularity {
   /**
    * SF4.1 - Get the current server.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @returns Name of the current server.
@@ -2007,7 +2007,7 @@ export interface Singularity {
   /**
    * SF4.1 - Connect to a server.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * Run the connect HOSTNAME command in the terminal. Can only connect to neighbors.
@@ -2019,7 +2019,7 @@ export interface Singularity {
   /**
    * SF4.1 - Run the hack command in the terminal.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @returns Amount of money stolen by manual hacking.
@@ -2029,7 +2029,7 @@ export interface Singularity {
   /**
    * SF4.1 - Run the backdoor command in the terminal.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @returns True if the installation was successful.
@@ -2039,7 +2039,7 @@ export interface Singularity {
   /**
    * SF4.2 - Check if the player is focused.
    * @remarks
-   * RAM cost: 0.1 GB
+   * RAM cost: 0.1 GB * %SINGULARY_MULTIPLIER%
    *
    *
    * @returns True if the player is focused.
@@ -2049,7 +2049,7 @@ export interface Singularity {
   /**
    * SF4.2 - Set the players focus.
    * @remarks
-   * RAM cost: 0.1 GB
+   * RAM cost: 0.1 GB * %SINGULARY_MULTIPLIER%
    *
    * @returns True if the focus was changed.
    */

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -35,6 +35,7 @@ import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { PromptEvent } from "../../ui/React/PromptManager";
+import { SF4Cost } from "../../Netscript/RamCostGenerator";
 
 import libSource from "!!raw-loader!../NetscriptDefinitions.d.ts";
 
@@ -297,7 +298,9 @@ export function Root(props: IProps): React.ReactElement {
       l.language.tokenizer.root.unshift(["this", { token: "this" }]);
     })();
 
-    const source = (libSource + "").replace(/export /g, "");
+    const sf4Multiplier = SF4Cost(1)(props.player);
+    const source = (libSource + "").replace(/export /g, "").
+      replace(/%SINGULARY_MULTIPLIER%/, `${sf4Multiplier} (Singularity Multiplier)`);
     monaco.languages.typescript.javascriptDefaults.addExtraLib(source, "netscript.d.ts");
     monaco.languages.typescript.typescriptDefaults.addExtraLib(source, "netscript.d.ts");
     loadThemes(monaco);


### PR DESCRIPTION
Added tag %SINGULARITY_MULTIPLER% in the typing files, replaced by a value before being added to Monaco.

```sh
   * @remarks
   * RAM cost: 2 GB * %SINGULARY_MULTIPLIER%
   *
   * This function will automatically set you to start taking a course at a university.
```

![firefox_FBMNtiY7Vr](https://user-images.githubusercontent.com/1521080/148609542-6a55bda6-b8ae-4da5-9460-9183de01303e.png)
