### PR TITLE
Fix #2446 - ns.purchaseAugment() can no longer buy NF from gang

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -166,6 +166,8 @@ export function NetscriptSingularity(
       let augs = [];
       if (player.hasGangWith(faction)) {
         for (const augName in Augmentations) {
+          if (augName === AugmentationNames.NeuroFluxGovernor) continue;
+          if (augName === AugmentationNames.TheRedPill && player.bitNodeN !== 2) continue;
           const tempAug = Augmentations[augName];
           if (!tempAug.isSpecial) {
             augs.push(augName);


### PR DESCRIPTION
Added the checks from AugmentationPage.tsx to the singularity purchaseAugment() function to disallow buying NF from player-run gang and disallow TRP from player-run gang outside BN2