### PR TITLE
Apply bitnode multiplier before capping at 1 in calculatePercentMoneyHacked in hacking.ts

### DIFF
--- a/src/Hacking.ts
+++ b/src/Hacking.ts
@@ -49,7 +49,7 @@ export function calculatePercentMoneyHacked(server: Server, player: IPlayer): nu
 
   const difficultyMult = (100 - server.hackDifficulty) / 100;
   const skillMult = (player.hacking - (server.requiredHackingSkill - 1)) / player.hacking;
-  const percentMoneyHacked = (difficultyMult * skillMult * player.hacking_money_mult) / balanceFactor;
+  const percentMoneyHacked = (difficultyMult * skillMult * player.hacking_money_mult * BitNodeMultipliers.ScriptHackMoney) / balanceFactor;
   if (percentMoneyHacked < 0) {
     return 0;
   }
@@ -57,7 +57,7 @@ export function calculatePercentMoneyHacked(server: Server, player: IPlayer): nu
     return 1;
   }
 
-  return percentMoneyHacked * BitNodeMultipliers.ScriptHackMoney;
+  return percentMoneyHacked;
 }
 
 /**


### PR DESCRIPTION
It is entirely possible to hack more than the BN multiplier, which means this function is reporting the effects of the multiplier incorrectly. By moving the BN multiplier to before the caps are applied, the functionality is corrected.

(ie, hack % * BN multiplier, THEN cap to 1; not cap to 1, then BN multiply the 1)

TESTED: I'm currently running in BN 5 ( * BitNodeMultipliers.ScriptHackMoney = 0.15), and sent a 4b thread hack against several fully grown servers (Avail Money = 100% of Max Money). Each went down to 0% (not 85% as the current implementation would suggest) after the hack hit.

I've also tested and confirmed the proposed change's functionality in my current game through my custom formulas, but didn't do a full build or anything.