### PR TITLE
Use wasted hashes on "Sell for Money"

### DIFF
--- a/src/Hacknet/HacknetHelpers.tsx
+++ b/src/Hacknet/HacknetHelpers.tsx
@@ -421,7 +421,21 @@ function processAllHacknetServerEarnings(player: IPlayer, numCycles: number): nu
     hashes += h;
   }
 
-  player.hashManager.storeHashes(hashes);
+  const wastedHashes = player.hashManager.storeHashes(hashes);
+  if (wastedHashes > 0) {
+    // Currently set to cap in at 1% of the capacity so it's probably still more efficient to run a script to use the hashes
+    const maxHashesToConvert = player.hashManager.capacity * 0.01;
+    const hashesToConvertToCash = Math.min(wastedHashes, maxHashesToConvert);
+
+    const upgrade = HashUpgrades["Sell for Money"];
+    if (upgrade === null) throw new Error("Could not get the hash upgrade");
+    if (!upgrade.cost) throw new Error("Upgrade is not properly configured");
+
+    const multiplier = Math.floor(hashesToConvertToCash / upgrade.cost);
+    if (multiplier > 0) {
+      player.gainMoney(upgrade.value * multiplier, "hacknet");
+    }
+  }
 
   return hashes;
 }

--- a/src/Hacknet/HashManager.ts
+++ b/src/Hacknet/HashManager.ts
@@ -113,9 +113,17 @@ export class HashManager {
     this.hashes += cost;
   }
 
-  storeHashes(numHashes: number): void {
+  /**
+   * Stores the given hashes, capping at capacity
+   * @param numHashes The number of hashes to increment
+   * @returns The number of wasted hashes (over capacity)
+   */
+  storeHashes(numHashes: number): number {
     this.hashes += numHashes;
+    let wastedHashes = this.hashes;
     this.hashes = Math.min(this.hashes, this.capacity);
+    wastedHashes -= this.hashes;
+    return wastedHashes;
   }
 
   updateCapacity(newCap: number): void {


### PR DESCRIPTION
Converts a portion of wasted hashes into money. 
Currently using the minimum value between the wasted hashes and 1% of the hash capacity, so that scripting the action would still be preferable.

Since the current cost of the action is 4 hashes, it won't trigger before 512 hash capacity.

Fixes #1893