### PR TITLE
Fix invalid sleeve's augmentation data (null ref)

### DIFF
--- a/src/PersonObjects/Sleeve/ui/SleeveAugmentationsModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveAugmentationsModal.tsx
@@ -89,6 +89,13 @@ export function SleeveAugmentationsModal(props: IProps): React.ReactElement {
             <Typography>Owned Augmentations:</Typography>
             {ownedAugNames.map((augName) => {
               const aug = Augmentations[augName];
+              if (!aug) {
+                return (
+                  <Paper key={augName}>
+                    <Typography color="error">INVALID: {augName}</Typography>
+                  </Paper>
+                )
+              }
               let tooltip = <></>;
               if (typeof aug.info === "string") {
                 tooltip = (


### PR DESCRIPTION
I had an invalid sleeve augmentation name in my save which caused the
sleeve page to crash.

![firefox_0e1CEhAM0F](https://user-images.githubusercontent.com/1521080/148643146-6d98832e-c4a5-4f89-bd72-ca5d7fb254b4.png)

