### PR TITLE
Check if running script is null before offlineProd

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -638,7 +638,14 @@ export function loadAllRunningScripts(player: IPlayer): void {
       server.runningScripts.length = 0;
     } else {
       for (let j = 0; j < server.runningScripts.length; ++j) {
+        const fileName = server.runningScripts[j].filename;
         createAndAddWorkerScript(player, server.runningScripts[j], server);
+
+        if (!server.runningScripts[j]) {
+          // createAndAddWorkerScript can modify the server.runningScripts array if a script is invalid
+          console.error(`createAndAddWorkerScript removed ${fileName} from ${server}`);
+          continue;
+        }
 
         // Offline production
         scriptCalculateOfflineProduction(server.runningScripts[j]);


### PR DESCRIPTION
This bypasses the error in #2466.

It does not really fix the issue since the script that ran before being made invalid will die on game load, but at least it prevents the recovery screen.