### PR TITLE
Fix 'Small town' achievement condition to match description text

### DIFF
--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -223,7 +223,7 @@ const achievements: Achievement[] = [
       for (const d of Player.corporation.divisions) {
         for (const o of Object.values(d.offices)) {
           if (o === 0) continue;
-          if (o.employees.length > 3000) return true;
+          if (o.employees.length >= 3000) return true;
         }
       }
       return false;


### PR DESCRIPTION
Achievement description says "Have a division with 3000 employee.", but code checked for over 3000.