### PR TITLE
Pass server to terminal actions that end later

### DIFF
--- a/src/Terminal/ITerminal.tsx
+++ b/src/Terminal/ITerminal.tsx
@@ -5,6 +5,7 @@ import { IPlayer } from "../PersonObjects/IPlayer";
 import { IRouter } from "../ui/Router";
 import { Settings } from "../Settings/Settings";
 import { formatTime } from "../utils/helpers/formatTime";
+import { BaseServer } from "../Server/BaseServer";
 
 export class Output {
   text: string;
@@ -43,11 +44,13 @@ export class TTimer {
   time: number;
   timeLeft: number;
   action: "h" | "b" | "a" | "g" | "w";
+  server?: BaseServer;
 
-  constructor(time: number, action: "h" | "b" | "a" | "g" | "w") {
+  constructor(time: number, action: "h" | "b" | "a" | "g" | "w", server?: BaseServer) {
     this.time = time;
     this.timeLeft = time;
     this.action = action;
+    this.server = server;
   }
 }
 
@@ -74,16 +77,16 @@ export interface ITerminal {
   warn(s: string): void;
 
   clear(): void;
-  startAnalyze(): void;
+  startAnalyze(player: IPlayer): void;
   startBackdoor(player: IPlayer): void;
   startHack(player: IPlayer): void;
   startGrow(player: IPlayer): void;
   startWeaken(player: IPlayer): void;
-  finishHack(router: IRouter, player: IPlayer, cancelled?: boolean): void;
-  finishGrow(player: IPlayer, cancelled?: boolean): void;
-  finishWeaken(player: IPlayer, cancelled?: boolean): void;
-  finishBackdoor(router: IRouter, player: IPlayer, cancelled?: boolean): void;
-  finishAnalyze(player: IPlayer, cancelled?: boolean): void;
+  finishHack(router: IRouter, player: IPlayer, server: BaseServer, cancelled?: boolean): void;
+  finishGrow(player: IPlayer, server: BaseServer, cancelled?: boolean): void;
+  finishWeaken(player: IPlayer, server: BaseServer, cancelled?: boolean): void;
+  finishBackdoor(router: IRouter, player: IPlayer, server: BaseServer, cancelled?: boolean): void;
+  finishAnalyze(player: IPlayer, server: BaseServer, cancelled?: boolean): void;
   finishAction(router: IRouter, player: IPlayer, cancelled?: boolean): void;
   getFilepath(filename: string): string;
   getFile(player: IPlayer, filename: string): Script | TextFile | string | null;

--- a/src/Terminal/commands/analyze.ts
+++ b/src/Terminal/commands/analyze.ts
@@ -14,5 +14,5 @@ export function analyze(
     terminal.error("Incorrect usage of analyze command. Usage: analyze");
     return;
   }
-  terminal.startAnalyze();
+  terminal.startAnalyze(player);
 }


### PR DESCRIPTION
Fixes #2410 

Adds the current server object to the finishAction handler so that if the player changes during the progress he'll hit the original server with the command. Handles the grow, weaken, hack, backdoor & analyze commands.

Before:
![firefox_DLMzt8D5f8](https://user-images.githubusercontent.com/1521080/148652011-0b3ea673-b528-4c4d-945c-6a90a2fab9d9.png)

After:
![firefox_asWcD7vrBW](https://user-images.githubusercontent.com/1521080/148652016-eaa69b6c-0db4-4e9d-bfe0-c5f42db7fb8e.png)

