### PR TITLE
Update toast signature

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -3982,7 +3982,7 @@ export declare interface NS extends Singularity {
      * Queue a toast (bottom-right notification).
      * @param msg - Message in the toast.
      * @param variant - Type of toast, must be one of success, info, warning, error. Defaults to success.
-     * @param duration - Duration of toast in ms. Can also be null to create a persistent toast. Defaults to 2000
+     * @param duration - Duration of toast in ms. Can also be `null` to create a persistent toast. Defaults to 2000
      */
     toast(msg: any, variant?: string, duration?: number | null): void;
 

--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -3982,9 +3982,9 @@ export declare interface NS extends Singularity {
      * Queue a toast (bottom-right notification).
      * @param msg - Message in the toast.
      * @param variant - Type of toast, must be one of success, info, warning, error. Defaults to success.
-     * @param duration - Duration of toast in ms, defaults to 2000
+     * @param duration - Duration of toast in ms. Can also be null to create a persistent toast. Defaults to 2000
      */
-    toast(msg: any, variant?: string, duration?: number): void;
+    toast(msg: any, variant?: string, duration?: number | null): void;
 
     /**
      * Download a file from the internet.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5670,9 +5670,9 @@ export interface NS extends Singularity {
    * Queue a toast (bottom-right notification).
    * @param msg - Message in the toast.
    * @param variant - Type of toast, must be one of success, info, warning, error. Defaults to success.
-   * @param duration - Duration of toast in ms, defaults to 2000
+   * @param duration - Duration of toast in ms. Can also be null to create a persistent toast. Defaults to 2000
    */
-  toast(msg: any, variant?: string, duration?: number): void;
+  toast(msg: any, variant?: string, duration?: number | null): void;
 
   /**
    * Download a file from the internet.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5670,7 +5670,7 @@ export interface NS extends Singularity {
    * Queue a toast (bottom-right notification).
    * @param msg - Message in the toast.
    * @param variant - Type of toast, must be one of success, info, warning, error. Defaults to success.
-   * @param duration - Duration of toast in ms. Can also be null to create a persistent toast. Defaults to 2000
+   * @param duration - Duration of toast in ms. Can also be `null` to create a persistent toast. Defaults to 2000
    */
   toast(msg: any, variant?: string, duration?: number | null): void;
 


### PR DESCRIPTION
Indicates that toasts can be made persistent by passing a `null` duration ([notistack docs](https://iamhosseindhv.com/notistack/api#mutual)).