### PR TITLE
Removing errant apostrophe

### DIFF
--- a/src/Corporation/ui/IndustryWarehouse.tsx
+++ b/src/Corporation/ui/IndustryWarehouse.tsx
@@ -149,7 +149,7 @@ function WarehouseRoot(props: IProps): React.ReactElement {
         </Button>
       </Box>
 
-      <Typography>This industry uses the following equation for it's production: </Typography>
+      <Typography>This industry uses the following equation for its production: </Typography>
       <br />
       <Typography>
         <IndustryProductEquation key={division.name} division={division} />


### PR DESCRIPTION
"It's" is short for "it is", not "something belonging to it".