### PR TITLE
Refactor netscriptDelay and script kill interaction

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -33,9 +33,9 @@ export class WorkerScript {
   delay: number | null = null;
 
   /**
-   * Holds the Promise resolve() function for when the script is "blocked" by an async op
+   * Holds the Promise reject() function while the script is "blocked" by an async op
    */
-  delayResolve?: () => void;
+  delayReject?: (reason?: any) => void;
 
   /**
    * Stores names of all functions that have logging disabled

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -138,8 +138,8 @@ function killNetscriptDelay(workerScript: WorkerScript): void {
   if (workerScript instanceof WorkerScript) {
     if (workerScript.delay) {
       clearTimeout(workerScript.delay);
-      if (workerScript.delayResolve) {
-        workerScript.delayResolve();
+      if (workerScript.delayReject) {
+        workerScript.delayReject(workerScript);
       }
     }
   }

--- a/src/NetscriptEvaluator.ts
+++ b/src/NetscriptEvaluator.ts
@@ -3,12 +3,17 @@ import { GetServer } from "./Server/AllServers";
 import { WorkerScript } from "./Netscript/WorkerScript";
 
 export function netscriptDelay(time: number, workerScript: WorkerScript): Promise<void> {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
     workerScript.delay = window.setTimeout(() => {
       workerScript.delay = null;
-      resolve();
+      workerScript.delayReject = undefined;
+
+      if (workerScript.env.stopFlag)
+        reject(workerScript);
+      else
+        resolve();
     }, time);
-    workerScript.delayResolve = resolve;
+    workerScript.delayReject = reject;
   });
 }
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -342,9 +342,6 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
     );
 
     return netscriptDelay(hackingTime * 1000, workerScript).then(function () {
-      if (workerScript.env.stopFlag) {
-        return Promise.reject(workerScript);
-      }
       const hackChance = calculateHackingChance(server, Player);
       const rand = Math.random();
       let expGainedOnSuccess = calculateHackingExpGain(server, Player) * threads;
@@ -614,9 +611,6 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
           )} (t=${numeralWrapper.formatThreads(threads)}).`,
       );
       return netscriptDelay(growTime * 1000, workerScript).then(function () {
-        if (workerScript.env.stopFlag) {
-          return Promise.reject(workerScript);
-        }
         const moneyBefore = server.moneyAvailable <= 0 ? 1 : server.moneyAvailable;
         processSingleServerGrowth(server, threads, Player, host.cpuCores);
         const moneyAfter = server.moneyAvailable;
@@ -685,7 +679,6 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
           )} (t=${numeralWrapper.formatThreads(threads)})`,
       );
       return netscriptDelay(weakenTime * 1000, workerScript).then(function () {
-        if (workerScript.env.stopFlag) return Promise.reject(workerScript);
         const host = GetServer(workerScript.hostname);
         if (host === null) {
           workerScript.log("weaken", () => "Server is null, did it die?");

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -311,9 +311,6 @@ export function NetscriptCorporation(
       const job = helper.string("assignJob", "job", ajob);
       const employee = getEmployee(divisionName, cityName, employeeName);
       return netscriptDelay(1000, workerScript).then(function () {
-        if (workerScript.env.stopFlag) {
-          return Promise.reject(workerScript);
-        }
         return Promise.resolve(AssignJob(employee, job));
       });
     },
@@ -344,9 +341,6 @@ export function NetscriptCorporation(
         (60 * 1000) / (player.hacking_speed_mult * calculateIntelligenceBonus(player.intelligence, 1)),
         workerScript,
       ).then(function () {
-        if (workerScript.env.stopFlag) {
-          return Promise.reject(workerScript);
-        }
         return Promise.resolve(ThrowParty(corporation, office, costPerEmployee));
       });
     },
@@ -359,9 +353,6 @@ export function NetscriptCorporation(
         (60 * 1000) / (player.hacking_speed_mult * calculateIntelligenceBonus(player.intelligence, 1)),
         workerScript,
       ).then(function () {
-        if (workerScript.env.stopFlag) {
-          return Promise.reject(workerScript);
-        }
         return Promise.resolve(BuyCoffee(corporation, getDivision(divisionName), getOffice(divisionName, cityName)));
       });
     },

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -611,9 +611,6 @@ export function NetscriptSingularity(
       );
 
       return netscriptDelay(installTime, workerScript).then(function () {
-        if (workerScript.env.stopFlag) {
-          return Promise.reject(workerScript);
-        }
         workerScript.log("installBackdoor", () => `Successfully installed backdoor on '${server.hostname}'`);
 
         server.backdoorInstalled = true;

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -38,9 +38,6 @@ export function NetscriptStanek(player: IPlayer, workerScript: WorkerScript, hel
       if (!fragment) throw helper.makeRuntimeErrorMsg("stanek.charge", `No fragment with root (${rootX}, ${rootY}).`);
       const time = staneksGift.inBonus() ? 200 : 1000;
       return netscriptDelay(time, workerScript).then(function () {
-        if (workerScript.env.stopFlag) {
-          return Promise.reject(workerScript);
-        }
         const charge = staneksGift.charge(player, fragment, workerScript.scriptRef.threads);
         workerScript.log("stanek.charge", () => `Charged fragment for ${charge} charge.`);
         return Promise.resolve();


### PR DESCRIPTION
`netscriptDelay`'s Promise is now rejected instead of resolved when a script blocked in delay is killed. Rejection value is the `WorkerScript` instance, following the standard pattern for handling exit from a Netscript function when the calling script is dead.

The purpose of this change is to ensure correct behaviour and reduce boilerplate in `netscriptDelay`-using functions. Prevents the repeat of bugs like happened with the corporation delayed functions (see PR #2406), and fixes a similar bug with `asleep` and `sleep`.

`asleep` and `sleep` old behaviour is to return instead of throw when the script is killed, which lets the user code continue execution until next time it calls a Netscript function that reacts to `stopFlag`.


Bunch of test scripts at https://github.com/Ornedan/bitburner-scripts/tree/main/netscriptdelay-check-stop-test. The current Bitburner test system doesn't seem to be set up to run NS1/2 files, so these are not included in the commits themselves.