### PR TITLE
Add pointer cursors to the Bitnode portals in the Bitverse

### DIFF
--- a/src/BitNode/ui/BitverseRoot.tsx
+++ b/src/BitNode/ui/BitverseRoot.tsx
@@ -15,24 +15,28 @@ const useStyles = makeStyles(() =>
   createStyles({
     level0: {
       color: "red",
+      cursor: "pointer",
       "&:hover": {
         color: "#fff",
       },
     },
     level1: {
       color: "yellow",
+      cursor: "pointer",
       "&:hover": {
         color: "#fff",
       },
     },
     level2: {
       color: "#48d1cc",
+      cursor: "pointer",
       "&:hover": {
         color: "#fff",
       },
     },
     level3: {
       color: "blue",
+      cursor: "pointer",
       "&:hover": {
         color: "#fff",
       },


### PR DESCRIPTION
As it is now, the pointer in the Bitverse stays the text cursor when you hover over the portals (the colored Os).

![NVIDIA_Share_25cWIv2PK7](https://user-images.githubusercontent.com/38111803/148824796-e12feda5-e7d4-4e87-a221-fae1aab5632f.png)

This creates a bit of a mismatch between the signals to the user - as the pointer cursor is the universal sign that you can click on something, the text cursor doesn't convey that. Meanwhile, the portals changing colors themselves convey to the user that they can be clicked on, creating a cognitive dissonance between whether you can or can't click on the portals (in the moment - with more thought it's obvious you can, but your immediate feeling is that you aren't sure.)

This PR adds the `cursor: pointer;` CSS property to those portals, so the cursor turns into, well, a pointer when you hover over them.

![NVIDIA_Share_DjdHmioUFD](https://user-images.githubusercontent.com/38111803/148824913-41f43d73-75ed-4667-b9c1-cf61c118611b.png)

This makes the Bitverse a bit nicer to use and removes that cognitive dissonance.