### PR TITLE
(Breaking change) Parallelize favor gain

### DIFF
--- a/src/Company/Company.ts
+++ b/src/Company/Company.ts
@@ -1,7 +1,7 @@
 import { CompanyPosition } from "./CompanyPosition";
 import * as posNames from "./data/companypositionnames";
+import { favorToRep, repToFavor } from "./formulas/favor";
 
-import { CONSTANTS } from "../Constants";
 import { IMap } from "../types";
 
 import { Generic_fromJSON, Generic_toJSON, Reviver } from "../utils/JSONReviver";
@@ -137,39 +137,17 @@ export class Company {
     if (this.favor == null) {
       this.favor = 0;
     }
-    if (this.rolloverRep == null) {
-      this.rolloverRep = 0;
-    }
-    const res = this.getFavorGain();
-    if (res.length != 2) {
-      console.error("Invalid result from getFavorGain() function");
-      return;
-    }
-
-    this.favor += res[0];
-    this.rolloverRep = res[1];
+    this.favor += this.getFavorGain();
   }
 
-  getFavorGain(): number[] {
+  getFavorGain(): number {
     if (this.favor == null) {
       this.favor = 0;
     }
-    if (this.rolloverRep == null) {
-      this.rolloverRep = 0;
-    }
-    let favorGain = 0,
-      rep = this.playerReputation + this.rolloverRep;
-    let reqdRep = CONSTANTS.CompanyReputationToFavorBase * Math.pow(CONSTANTS.CompanyReputationToFavorMult, this.favor);
-    while (rep > 0) {
-      if (rep >= reqdRep) {
-        ++favorGain;
-        rep -= reqdRep;
-      } else {
-        break;
-      }
-      reqdRep *= CONSTANTS.FactionReputationToFavorMult;
-    }
-    return [favorGain, rep];
+    const storedRep = Math.max(0, favorToRep(this.favor));
+    const totalRep = storedRep + this.playerReputation;
+    const newFavor = repToFavor(totalRep);
+    return newFavor - this.favor;
   }
 
   /**

--- a/src/Company/Company.ts
+++ b/src/Company/Company.ts
@@ -71,7 +71,6 @@ export class Company {
   isPlayerEmployed: boolean;
   playerReputation: number;
   favor: number;
-  rolloverRep: number;
 
   constructor(p: IConstructorParams = DefaultConstructorParams) {
     this.name = p.name;
@@ -84,7 +83,6 @@ export class Company {
     this.isPlayerEmployed = false;
     this.playerReputation = 1;
     this.favor = 0;
-    this.rolloverRep = 0;
     this.isMegacorp = false;
     if (p.isMegacorp) this.isMegacorp = true;
   }

--- a/src/Company/formulas/favor.ts
+++ b/src/Company/formulas/favor.ts
@@ -1,0 +1,14 @@
+// The initial formulas was sum 0 to f of 500*1.02^f.
+// see https://en.wikipedia.org/wiki/Geometric_series#Closed-form_formula
+// for information on how to calculate this
+
+export function favorToRep(f: number): number {
+    const raw = 25000 * (Math.pow(1.02, f) - 1);
+    return Math.round(raw * 10000) / 10000; // round to make things easier.
+  }
+  
+  export function repToFavor(r: number): number {
+    const raw = Math.log(r / 25000 + 1) / Math.log(1.02);
+    return Math.round(raw * 10000) / 10000; // round to make things easier.
+  }
+  

--- a/src/Company/formulas/favor.ts
+++ b/src/Company/formulas/favor.ts
@@ -3,12 +3,11 @@
 // for information on how to calculate this
 
 export function favorToRep(f: number): number {
-    const raw = 25000 * (Math.pow(1.02, f) - 1);
-    return Math.round(raw * 10000) / 10000; // round to make things easier.
-  }
-  
-  export function repToFavor(r: number): number {
-    const raw = Math.log(r / 25000 + 1) / Math.log(1.02);
-    return Math.round(raw * 10000) / 10000; // round to make things easier.
-  }
-  
+  const raw = 25000 * (Math.pow(1.02, f) - 1);
+  return Math.round(raw * 10000) / 10000; // round to make things easier.
+}
+
+export function repToFavor(r: number): number {
+  const raw = Math.log(r / 25000 + 1) / Math.log(1.02);
+  return Math.round(raw * 10000) / 10000; // round to make things easier.
+}

--- a/src/Locations/ui/CompanyLocation.tsx
+++ b/src/Locations/ui/CompanyLocation.tsx
@@ -198,7 +198,7 @@ export function CompanyLocation(props: IProps): React.ReactElement {
             <Tooltip
               title={
                 <>
-                  You will have <Favor favor={company.favor + favorGain[0]} /> company favor upon resetting after
+                  You will have <Favor favor={company.favor + favorGain} /> company favor upon resetting after
                   installing Augmentations
                 </>
               }


### PR DESCRIPTION
Updates the favor gain formula for `Company` so that it mirrors that of `Faction`.

Also introduces a fix and breaking change to `Singularity.getCompanyFavorGain()`, which previously returned a `number[]` of `[favorGain, rep]`, and now returns a single `number`, representing the favor gained.

Copies the formulas directory and `favor.ts` from `src/Faction/formulas`