### PR TITLE
Expand support for Export declarations with source parameters

### DIFF
--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -151,6 +151,24 @@ function _getScriptUrls(script: Script, scripts: Script[], seen: Script[]): Scri
           start: node.source.range[0] + 1,
           end: node.source.range[1] - 1
         });
+      },
+      ExportNamedDeclaration(node: any) {
+        if (node.source) {
+          importNodes.push({
+            filename: node.source.value,
+            start: node.source.range[0] + 1,
+            end: node.source.range[1] - 1
+          });
+        }
+      },
+      ExportAllDeclaration(node: any) {
+        if (node.source) {
+          importNodes.push({
+            filename: node.source.value,
+            start: node.source.range[0] + 1,
+            end: node.source.range[1] - 1
+          });
+        }
       }
     });
     // Sort the nodes from last start index to first. This replaces the last import with a blob first,


### PR DESCRIPTION
Resolves https://github.com/danielyxie/bitburner/issues/2497

Test code:
```js
// These will import correctly
export * as Class from "/class.js"
export { func } from "/source.js" 

// These should not be affected
const tconst = "123";
export { tconst };
export const tconst2 = "456";
function tfunc() {};
export { tfunc };
export function tfunc2() {};
```