### PR TITLE
Add an uncaught errors handler

### DIFF
--- a/src/DevMenu/ui/General.tsx
+++ b/src/DevMenu/ui/General.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
@@ -17,6 +17,8 @@ interface IProps {
 }
 
 export function General(props: IProps): React.ReactElement {
+  const [error, setError] = useState(false);
+
   function addMoney(n: number) {
     return function () {
       props.player.gainMoney(n, "other");
@@ -42,6 +44,10 @@ export function General(props: IProps): React.ReactElement {
   function hackW0r1dD43m0n(): void {
     props.router.toBitVerse(false, false);
   }
+
+  useEffect(() => {
+    if (error) throw new Error('Oh no! This is an error.');
+  }, [error]);
 
   return (
     <Accordion TransitionProps={{ unmountOnExit: true }}>
@@ -81,6 +87,7 @@ export function General(props: IProps): React.ReactElement {
         <Button onClick={b1tflum3}>Run b1t_flum3.exe</Button>
         <Button onClick={quickHackW0r1dD43m0n}>Quick w0rld_d34m0n</Button>
         <Button onClick={hackW0r1dD43m0n}>Hack w0rld_d34m0n</Button>
+        <Button onClick={() => setError(true)}>Throw Error</Button>
       </AccordionDetails>
     </Accordion>
   );

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -77,6 +77,7 @@ import { enterBitNode } from "../RedPill";
 import { Context } from "./Context";
 import { RecoveryMode, RecoveryRoot } from "./React/RecoveryRoot";
 import { AchievementsRoot } from "../Achievements/AchievementsRoot";
+import { ErrorBoundary } from "./React/ErrorBoundary";
 
 const htmlLocation = location;
 
@@ -571,40 +572,43 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
   }
 
   return (
-    <Context.Player.Provider value={player}>
-      <Context.Router.Provider value={Router}>
-        <SnackbarProvider>
-          <Overview mode={ITutorial.isRunning ? "tutorial" : "overview"}>
-            {!ITutorial.isRunning ? (
-              <CharacterOverview
-                save={() => saveObject.saveGame()}
-                killScripts={killAllScripts}
-                router={Router}
-                allowBackButton={withSidebar} />
+    <ErrorBoundary
+      router={Router}>
+      <Context.Player.Provider value={player}>
+        <Context.Router.Provider value={Router}>
+          <SnackbarProvider>
+            <Overview mode={ITutorial.isRunning ? "tutorial" : "overview"}>
+              {!ITutorial.isRunning ? (
+                <CharacterOverview
+                  save={() => saveObject.saveGame()}
+                  killScripts={killAllScripts}
+                  router={Router}
+                  allowBackButton={withSidebar} />
+              ) : (
+                <InteractiveTutorialRoot />
+              )}
+            </Overview>
+            {withSidebar ? (
+              <Box display="flex" flexDirection="row" width="100%">
+                <SidebarRoot player={player} router={Router} page={page} />
+                <Box className={classes.root}>{mainPage}</Box>
+              </Box>
             ) : (
-              <InteractiveTutorialRoot />
-            )}
-          </Overview>
-          {withSidebar ? (
-            <Box display="flex" flexDirection="row" width="100%">
-              <SidebarRoot player={player} router={Router} page={page} />
               <Box className={classes.root}>{mainPage}</Box>
-            </Box>
-          ) : (
-            <Box className={classes.root}>{mainPage}</Box>
-          )}
-          <Unclickable />
-          {withPopups && (
-            <>
-              <LogBoxManager />
-              <AlertManager />
-              <PromptManager />
-              <InvitationModal />
-              <Snackbar />
-            </>
-          )}
-        </SnackbarProvider>
-      </Context.Router.Provider>
-    </Context.Player.Provider>
+            )}
+            <Unclickable />
+            {withPopups && (
+              <>
+                <LogBoxManager />
+                <AlertManager />
+                <PromptManager />
+                <InvitationModal />
+                <Snackbar />
+              </>
+            )}
+          </SnackbarProvider>
+        </Context.Router.Provider>
+      </Context.Player.Provider>
+    </ErrorBoundary>
   );
 }

--- a/src/ui/React/DeleteGameButton.tsx
+++ b/src/ui/React/DeleteGameButton.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { deleteGame } from "../../db";
+import { ConfirmationModal } from "./ConfirmationModal";
+import Button from "@mui/material/Button";
+import { Tooltip } from '@mui/material';
+
+import DeleteIcon from '@mui/icons-material/Delete';
+
+interface IProps {
+  color?: "primary" | "warning" | "error";
+}
+
+export function DeleteGameButton({ color = "primary" }: IProps): React.ReactElement {
+  const [modalOpened, setModalOpened] = useState(false);
+
+  return (<>
+    <Tooltip title="This will permanently delete your local save game. Did you export it before?">
+      <Button startIcon={<DeleteIcon />} color={color} onClick={() => setModalOpened(true)}>Delete Save</Button>
+    </Tooltip>
+    <ConfirmationModal
+      onConfirm={() => {
+        setModalOpened(false);
+        deleteGame()
+          .then(() => setTimeout(() => location.reload(), 1000))
+          .catch((r) => console.error(`Could not delete game: ${r}`));
+      }}
+      open={modalOpened}
+      onClose={() => setModalOpened(false)}
+      confirmationText={"Really delete your game? (It's permanent!)"}
+    />
+  </>)
+}

--- a/src/ui/React/ErrorBoundary.tsx
+++ b/src/ui/React/ErrorBoundary.tsx
@@ -1,0 +1,307 @@
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Tooltip,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+  Link,
+  Grid,
+  FormControl,
+  InputLabel,
+  FilledInput,
+} from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
+import createStyles from "@mui/styles/createStyles";
+import withStyles from "@mui/styles/withStyles";
+import { Theme } from "@mui/material/styles";
+import ReportIcon from "@mui/icons-material/Report";
+import DownloadIcon from "@mui/icons-material/Download";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import GitHubIcon from "@mui/icons-material/GitHub";
+
+import { Settings } from "../../Settings/Settings";
+import { DeleteGameButton } from "./DeleteGameButton";
+import { CONSTANTS } from "../../Constants";
+import { hash } from "../../hash/hash";
+import { IRouter, Page } from "../Router";
+import { download } from "../../SaveObject";
+import { load } from "../../db";
+
+interface IProps {
+  children: React.ReactNode;
+  router: IRouter;
+}
+
+interface IState {
+  hasError: boolean;
+  page?: string;
+  error?: Error;
+  errorInfo?: React.ErrorInfo;
+}
+
+interface Error {
+  stack?: string;
+}
+
+interface ErrorPage {
+  error?: Error;
+  errorInfo?: React.ErrorInfo;
+  page?: string;
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      display: "block",
+      padding: "8px",
+      minHeight: "100vh",
+    },
+
+    preBox: {
+      marginRight: theme.spacing(1),
+      border: `1px solid ${Settings.theme.secondary}`,
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+
+      "& pre": {
+        padding: theme.spacing(1),
+        margin: theme.spacing(0),
+        whiteSpace: 'normal',
+
+        "& p": {
+          fontSize: "0.75rem",
+        },
+      },
+    },
+
+    specsTable: {
+      marginLeft: theme.spacing(1),
+      "& .MuiTableCell-body": {
+        borderBottom: `1px solid ${Settings.theme.welllight}`,
+      },
+      "& p": {
+        fontSize: "0.85rem",
+      },
+    },
+  }),
+);
+
+function ErrorPage({ error, errorInfo, page }: ErrorPage): React.ReactElement {
+  const classes = useStyles();
+  const [saveString, setSaveString] = useState<string | undefined>("n/a");
+  const stackLinePattern = /(.*)@(.*\/\/\/[0-9]*):([0-9]*):([0-9]*)/;
+  const stack = errorInfo?.componentStack
+    ?.split("\n")
+    ?.map((line) => line.trim())
+    .filter((line) => line !== "")
+    .map((line) => {
+      const matches = line.match(stackLinePattern);
+      const entry: any = {
+        stack: line,
+        file: (matches && matches[1]) ?? "",
+        source: (matches && matches[2]) ?? "",
+        row: (matches && matches[3]) ?? "",
+        col: (matches && matches[4]) ?? "",
+      };
+      return entry;
+    });
+
+  const runtime = navigator.userAgent.toLowerCase().indexOf(" electron/") > -1 ? "Steam" : "Browser";
+  const runtimeVersion = `v${CONSTANTS.VersionString} (${hash()}) - ${runtime} in "${page}"`;
+  const features = `lang=${navigator.language} cookiesEnabled=${navigator.cookieEnabled.toString()} doNotTrack=${
+    navigator.doNotTrack
+  } indexedDb=${(!!window.indexedDB).toString()}`;
+  const issueTitle = `\`${runtime}\` - Game Crash with \`${error?.toString()}\` in \`${page}\``;
+  const log = `
+# ${issueTitle}
+
+## How did this happen?
+
+**Please fill this information with details if any.**
+
+---
+
+### Environment
+
+* **Error**: \`${error?.toString()}\`
+* **Runtime**: \`${runtimeVersion}\`
+* **UserAgent**: \`${navigator.userAgent}\`
+* **Features**: \`${features}\`
+* **Source**: \`${(error as any).fileName}\`
+
+### Stack Trace
+
+\`\`\`
+${errorInfo?.componentStack.toString().trim()}
+\`\`\`
+
+### Save
+\`\`\`
+*Add your save string here if possible (if not too big)*
+\`\`\`
+  `.trim();
+
+  const githubUrl = `https://github.com/danielyxie/bitburner/issues/new?title=${encodeURIComponent(
+    issueTitle,
+  )}&body=${encodeURIComponent(log)}`;
+
+  useEffect(() => {
+    load().then((saveString) => setSaveString(saveString));
+  }, []);
+
+  if (!error || !errorInfo) return <></>;
+
+  return (
+    <Box display="flex" flexDirection="row" width="100%">
+      <Box className={classes.root}>
+        <Typography variant="h4" color="error" sx={{ mb: 1 }}>
+          <ReportIcon sx={{ mr: 1 }} />
+          <strong>{(error as any).name}</strong>: {(error as any).message}
+        </Typography>
+        <Typography variant="body1" sx={{ mt: 2 }}>
+          The game crashed unexpectedly. The best way to report this to us is through{" "}
+          <Link href={githubUrl} target="_blank">
+            submitting an issue on the game's GitHub repository
+          </Link>
+          . If you need quick support, the{" "}
+          <Link href="https://discord.gg/TFc3hKD" target="_blank">
+            Discord
+          </Link>{" "}
+          is also a good place to get help. You may copy the "Bug Report" text below. You may also choose to include the
+          "Save String" in your report. Most information will be pre-filled in the Submit Issue link.
+        </Typography>
+        <ButtonGroup sx={{ my: 2}}>
+          <Tooltip title="Submitting an issue to GitHub really help us improve the game!">
+            <Button component={Link} href={githubUrl} target={"_blank"} startIcon={<GitHubIcon />} color="primary">
+              Submit Issue to GitHub
+            </Button>
+          </Tooltip>
+          <Tooltip title="Reload the current page">
+            <Button startIcon={<RefreshIcon />} color="secondary" onClick={() => window.location.reload()}>
+              Reload Game
+            </Button>
+          </Tooltip>
+          <Tooltip title="Export your local save game to a file.">
+            <Button
+              startIcon={<DownloadIcon />}
+              color="secondary"
+              disabled={!saveString && saveString !== "n/a"}
+              onClick={() => {
+                if (!saveString) return;
+                const epochTime = Math.round(Date.now() / 1000);
+                const filename = `bitburnerSave_recovery_${epochTime}.json`;
+                download(filename, saveString);
+              }}
+            >
+              Export Save
+            </Button>
+          </Tooltip>
+          <DeleteGameButton color="error" />
+        </ButtonGroup>
+        <Box sx={{ my: 2 }}>
+          <Grid container>
+            <Grid item xs={8}>
+              <FormControl fullWidth variant="outlined" sx={{ pr: 1 }}>
+                <InputLabel>Bug Report Text</InputLabel>
+                <FilledInput multiline rows={8} value={log} />
+              </FormControl>
+            </Grid>
+            <Grid item xs={4}>
+              <FormControl fullWidth variant="outlined" sx={{ pl: 1 }}>
+                <InputLabel>Save String</InputLabel>
+                <FilledInput multiline rows={8} value={saveString} />
+              </FormControl>
+            </Grid>
+          </Grid>
+        </Box>
+        <Typography variant="body1" color="primary" sx={{ my: 2 }}>
+          Thrown at {(error as any).fileName}
+        </Typography>
+        <Grid container>
+          <Grid item xs={8}>
+            <Box className={classes.preBox}>
+              <pre>
+                {stack?.map((e, index) =>
+                  (e.file ? (
+                    <Typography color="secondary" sx={{ display: "block" }} key={index}>
+                      &#x21B3; <strong>{e.file}</strong> in {e.source}{" "}
+                      <em>
+                        (ln:{e.row}, col:{e.col})
+                      </em>
+                    </Typography>
+                  ) : (
+                    <Typography color="secondary" sx={{ display: "block" }} key={index}>
+                      &#x21B3; {e.stack}
+                    </Typography>
+                  )),
+                )}
+              </pre>
+            </Box>
+          </Grid>
+          <Grid item xs={4}>
+            <Table className={classes.specsTable}>
+              <TableBody>
+                <TableRow>
+                  <TableCell>
+                    <Typography>Runtime</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography>{runtimeVersion}</Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>
+                    <Typography>User Agent</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography>{navigator.userAgent}</Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>
+                    <Typography>Features</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography>{features}</Typography>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Grid>
+        </Grid>
+      </Box>
+    </Box>
+  );
+}
+
+// We can't use functional components to handle the componentDidCatch function
+// https://blog.openreplay.com/catching-errors-in-react-with-error-boundaries
+class ErrorBoundaryBase extends React.Component<IProps, IState> {
+  state: IState = { hasError: false };
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    this.setState({
+      errorInfo,
+      page: Page[this.props.router.page()],
+    });
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return <ErrorPage error={this.state.error} errorInfo={this.state.errorInfo} page={this.state.page} />;
+    }
+    return this.props.children;
+  }
+
+  static getDerivedStateFromError(error: Error): IState {
+    return { hasError: true, error };
+  }
+}
+
+export const ErrorBoundary = withStyles({}, { withTheme: true })(ErrorBoundaryBase);

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -21,6 +21,7 @@ import TextField from "@mui/material/TextField";
 
 import DownloadIcon from "@mui/icons-material/Download";
 import UploadIcon from "@mui/icons-material/Upload";
+import SaveIcon from '@mui/icons-material/Save';
 
 import { FileDiagnosticModal } from "../../Diagnostic/FileDiagnosticModal";
 import { dialogBoxCreate } from "./DialogBox";
@@ -31,9 +32,10 @@ import { StyleEditorModal } from "./StyleEditorModal";
 import { SnackbarEvents } from "./Snackbar";
 
 import { Settings } from "../../Settings/Settings";
-import { save, deleteGame } from "../../db";
+import { save } from "../../db";
 import { formatTime } from "../../utils/helpers/formatTime";
 import { OptionSwitch } from "./OptionSwitch";
+import { DeleteGameButton } from "./DeleteGameButton";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -71,7 +73,6 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
   const [timestampFormat, setTimestampFormat] = useState(Settings.TimestampsFormat);
   const [locale, setLocale] = useState(Settings.Locale);
   const [diagnosticOpen, setDiagnosticOpen] = useState(false);
-  const [deleteGameOpen, setDeleteOpen] = useState(false);
   const [themeEditorOpen, setThemeEditorOpen] = useState(false);
   const [styleEditorOpen, setStyleEditorOpen] = useState(false);
   const [softResetOpen, setSoftResetOpen] = useState(false);
@@ -523,8 +524,8 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
         </Grid>
         <Grid item xs={12} sm={6}>
           <Box>
-            <Button onClick={() => props.save()}>Save Game</Button>
-            <Button onClick={() => setDeleteOpen(true)}>Delete Game</Button>
+            <Button startIcon={<SaveIcon />} onClick={() => props.save()}>Save Game</Button>
+            <DeleteGameButton />
           </Box>
           <Box>
             <Tooltip title={<Typography>Export your game to a text file.</Typography>}>
@@ -632,17 +633,6 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
         </Grid>
       </Grid>
       <FileDiagnosticModal open={diagnosticOpen} onClose={() => setDiagnosticOpen(false)} />
-      <ConfirmationModal
-        onConfirm={() => {
-          setDeleteOpen(false);
-          deleteGame()
-            .then(() => setTimeout(() => location.reload(), 1000))
-            .catch((r) => console.error(`Could not delete game: ${r}`));
-        }}
-        open={deleteGameOpen}
-        onClose={() => setDeleteOpen(false)}
-        confirmationText={"Really delete your game? (It's permanent!)"}
-      />
       <ThemeEditorModal open={themeEditorOpen} onClose={() => setThemeEditorOpen(false)} />
       <StyleEditorModal open={styleEditorOpen} onClose={() => setStyleEditorOpen(false)} />
     </div>


### PR DESCRIPTION
- Handles uncaught errors and shows a page with details about the error & environment.
- Includes a link to open a new GitHub issue using the information from the page.
- Also adds a button to throw a new Error in the general dev menu.
- Refactored the Delete Game Button into its own component.

Current template looks like the content of this issue #2538

---

The examples in these screenshot are using `throw new Error("Oh no! This is an error.");`

![firefox_Z1ewLNDmxg](https://user-images.githubusercontent.com/1521080/148837939-db14a865-1440-48cd-aa91-4c44176ab20a.png)

![firefox_G1BpZqFsIV](https://user-images.githubusercontent.com/1521080/148837937-9ff57448-8892-48f1-aaf7-e499c54ff0f2.png)

![firefox_v9SYQcm6dV](https://user-images.githubusercontent.com/1521080/148837935-f621da85-da5e-4f29-b63f-69d1616b013b.png)

![firefox_qaNwbUDFUM](https://user-images.githubusercontent.com/1521080/148837932-1f628f1b-f9a1-40f8-9d81-2092e434fb45.png)




