### PR TITLE
NetscriptDefinition.d.ts correcting based on code

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1901,7 +1901,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       const iport = helper.getValidPort("clearPort", port);
       return iport.clear();
     },
-    getPortHandle: function (port: any): any {
+    getPortHandle: function (port: any): IPort {
       updateDynamicRam("getPortHandle", getRamCost(Player, "getPortHandle"));
       const iport = helper.getValidPort("getPortHandle", port);
       return iport;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1,7 +1,7 @@
 /**
  * @public
  */
- interface Player {
+interface Player {
   hacking: number;
   hp: number;
   max_hp: number;
@@ -113,7 +113,7 @@ interface RunningScript {
  * Interface of a netscript port
  * @public
  */
- export interface IPort {
+export interface IPort {
   /** write data to the port and removes and returns first element if full */
   write: (value: any) => any;
   /** add data to port if not full.
@@ -5430,7 +5430,7 @@ export interface NS extends Singularity {
    * Get a handle to a Netscript Port.
    *
    * WARNING: Port Handles only work in NetscriptJS (Netscript 2.0). They will not work in Netscript 1.0.
-   * 
+   *
    * @see https://bitburner.readthedocs.io/en/latest/netscript/netscriptmisc.html#netscript-ports
    * @param port - Port number. Must be an integer between 1 and 20.
    * @returns Data in the specified port.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1,7 +1,7 @@
 /**
  * @public
  */
-interface Player {
+ interface Player {
   hacking: number;
   hp: number;
   max_hp: number;
@@ -107,6 +107,32 @@ interface RunningScript {
   ramUsage: number;
   server: string;
   threads: number;
+}
+
+/**
+ * Interface of a netscript port
+ * @public
+ */
+ export interface IPort {
+  /** write data to the port and removes and returns first element if full */
+  write: (value: any) => any;
+  /** add data to port if not full.
+   * @returns true if added and false if full and not added */
+  tryWrite: (value: any) => boolean;
+  /** reads and removes first element from port 
+   * if no data in port returns "NULL PORT DATA"
+   */
+  read: () => any;
+  /** reads first element without removing it from port
+   * if no data in port returns "NULL PORT DATA"
+   */
+  peek: () => any;
+  /** check if port is full */
+  full: () => boolean;
+  /** check if port is empty */
+  empty: () => boolean;
+  /** removes all data from port */
+  clear: () => void;
 }
 
 /**
@@ -5404,12 +5430,12 @@ export interface NS extends Singularity {
    * Get a handle to a Netscript Port.
    *
    * WARNING: Port Handles only work in NetscriptJS (Netscript 2.0). They will not work in Netscript 1.0.
-   *
+   * 
    * @see https://bitburner.readthedocs.io/en/latest/netscript/netscriptmisc.html#netscript-ports
    * @param port - Port number. Must be an integer between 1 and 20.
    * @returns Data in the specified port.
    */
-  getPortHandle(port: number): any[];
+  getPortHandle(port: number): IPort;
 
   /**
    * Delete a file.


### PR DESCRIPTION
I added the IPort interface to the definitions and also changed the return value of getPortHandle to IPort.

I based my changes on the following files:
definition:
https://github.com/danielyxie/bitburner/blob/dev/src/NetscriptPort.ts

code logic:
https://github.com/danielyxie/bitburner/blob/75283504fd70bbb943400056a43ba41aa68683e7/src/NetscriptFunctions.ts#L1906
https://github.com/danielyxie/bitburner/blob/75283504fd70bbb943400056a43ba41aa68683e7/src/NetscriptFunctions.ts#L445

Do not know if it should also be changed in de docs?
But they are auto generated so I do not know where it should be changed.

https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.ns.getporthandle.md

would also need a new file to contain the correct return type of a port