### PR TITLE
Make augment price multiplier prettier (was tested by Pigalot)

### DIFF
--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -15,6 +15,7 @@ import { hasAugmentationPrereqs } from "../FactionHelpers";
 import { use } from "../../ui/Context";
 import { Reputation } from "../../ui/React/Reputation";
 import { Favor } from "../../ui/React/Favor";
+import { numeralWrapper } from "../../ui/numeralFormat";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -203,7 +204,7 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
             </Typography>
           }
         >
-          <Typography>Price multiplier: x {mult.toFixed(3)}</Typography>
+          <Typography>Price multiplier: x {numeralWrapper.formatExp(mult)}</Typography>
         </Tooltip>
       </Box>
       <Button onClick={() => switchSortOrder(PurchaseAugmentationsOrderSetting.Cost)}>Sort by Cost</Button>


### PR DESCRIPTION
Just an attempt to make the augment price multiplier look nicer.
I haven't set up my dev environment yet, but I didn't want to lose my place, so not tested - sorry.
(Will test shortly and update the message if all looks good).

tested by Pigalot (discord reference for screenshots, etc.: https://discord.com/channels/415207508303544321/923707505698283560/930230679705378816)