### PR TITLE
clarify error

### DIFF
--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -41,7 +41,7 @@ export function runScript(
 
   // Check if this script is already running
   if (findRunningScript(scriptName, args, server) != null) {
-    terminal.error("This script is already running. Cannot run multiple instances");
+    terminal.error("This script is already running with the same args. Cannot run multiple instances with the same args");
     return;
   }
 


### PR DESCRIPTION
The error message for running multiple instances of the same script with the same args should be updated to clarify that the args is the issue not just the multiple instances