### PR TITLE
Add toPreviousPage in router

### DIFF
--- a/src/Augmentation/AugmentationHelpers.tsx
+++ b/src/Augmentation/AugmentationHelpers.tsx
@@ -13,6 +13,7 @@ import { SourceFileFlags } from "../SourceFile/SourceFileFlags";
 
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { clearObject } from "../utils/helpers/clearObject";
+import { Router } from "../ui/GameRoot";
 
 import { WHRNG } from "../Casino/RNG";
 
@@ -2582,6 +2583,8 @@ function installAugmentations(): boolean {
     augmentationList += aug.name + level + "<br>";
   }
   Player.queuedAugmentations = [];
+  Router.clearHistory();
+
   dialogBoxCreate(
     "You slowly drift to sleep as scientists put you under in order " +
       "to install the following Augmentations:<br>" +

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -306,5 +306,7 @@ export function prestigeSourceFile(flume: boolean): void {
   // Gain int exp
   if (SourceFileFlags[5] !== 0 && !flume) Player.gainIntelligenceExp(300);
 
+  Router.clearHistory();
+
   resetPidCounter();
 }

--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -16,16 +16,21 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import SaveIcon from "@mui/icons-material/Save";
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ClearAllIcon from "@mui/icons-material/ClearAll";
 
 import { Settings } from "../../Settings/Settings";
 import { use } from "../Context";
 import { StatsProgressOverviewCell } from "./StatsProgressBar";
 import { BitNodeMultipliers } from "../../BitNode/BitNodeMultipliers";
+import { IRouter, Page } from "../Router";
+import { Box, Tooltip } from "@mui/material";
 
 interface IProps {
   save: () => void;
   killScripts: () => void;
+  router: IRouter;
+  allowBackButton: boolean;
 }
 
 function Intelligence(): React.ReactElement {
@@ -205,7 +210,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export { useStyles as characterOverviewStyles };
 
-export function CharacterOverview({ save, killScripts }: IProps): React.ReactElement {
+export function CharacterOverview({ save, killScripts, router, allowBackButton }: IProps): React.ReactElement {
   const [killOpen, setKillOpen] = useState(false);
   const player = use.Player();
 
@@ -243,6 +248,9 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
     player.charisma_exp,
     player.charisma_mult * BitNodeMultipliers.CharismaLevelMultiplier,
   );
+
+  const previousPageName = router.previousPage() < 0
+    ? '' : Page[router.previousPage() ?? 0].replace(/([a-z])([A-Z])/g, '$1 $2');
 
   return (
     <>
@@ -418,21 +426,33 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
           <Work />
           <Bladeburner />
-
-          <TableRow>
-            <TableCell align="center" classes={{ root: classes.cellNone }}>
-              <IconButton onClick={save}>
-                <SaveIcon color={Settings.AutosaveInterval !== 0 ? "primary" : "error"} />
-              </IconButton>
-            </TableCell>
-            <TableCell align="center" classes={{ root: classes.cellNone }}>
-              <IconButton onClick={() => setKillOpen(true)}>
-                <ClearAllIcon color="error" />
-              </IconButton>
-            </TableCell>
-          </TableRow>
         </TableBody>
       </Table>
+      <Box sx={{ display: 'flex', borderTop: `1px solid ${Settings.theme.welllight}` }}>
+        <Box sx={{ display: 'flex', flex: 1, justifyContent: 'flex-start', alignItems: 'center' }}>
+          <IconButton onClick={save}>
+            <Tooltip title="Save game">
+              <SaveIcon color={Settings.AutosaveInterval !== 0 ? "primary" : "error"} />
+            </Tooltip>
+          </IconButton>
+          {allowBackButton && (
+            <IconButton
+              disabled={!previousPageName}
+              onClick={() => router.toPreviousPage()}>
+              <Tooltip title={previousPageName ? `Go back to "${previousPageName}"` : ''}>
+                <ArrowBackIcon />
+              </Tooltip>
+            </IconButton>
+          )}
+        </Box>
+        <Box sx={{ display: 'flex', flex: 1, justifyContent: 'flex-end', alignItems: 'center' }}>
+          <IconButton onClick={() => setKillOpen(true)}>
+            <Tooltip title="Kill all running scripts">
+              <ClearAllIcon color="error" />
+            </Tooltip>
+          </IconButton>
+        </Box>
+      </Box>
       <KillScriptsModal open={killOpen} onClose={() => setKillOpen(false)} killScripts={killScripts} />
     </>
   );

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -53,6 +53,9 @@ export interface IRouter {
   // toRedPill(): void;
   // toworkInProgress(): void;
   page(): Page;
+  previousPage(): Page;
+  clearHistory(): void;
+  toPreviousPage(fallback?: (...args: any[]) => void): void;
   toActiveScripts(): void;
   toAugmentations(): void;
   toBitVerse(flume: boolean, quick: boolean): void;

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -36,12 +36,12 @@ export function WorkInProgressRoot(): React.ReactElement {
   const faction = Factions[player.currentWorkFactionName];
   if (player.workType == CONSTANTS.WorkTypeFaction) {
     function cancel(): void {
-      router.toFaction(faction);
       player.finishFactionWork(true);
+      router.toPreviousPage(() => router.toFaction(faction));
     }
     function unfocus(): void {
-      router.toFaction(faction);
       player.stopFocusing();
+      router.toPreviousPage(() => router.toFaction(faction));
     }
     return (
       <Grid container direction="column" justifyContent="center" alignItems="center" style={{ minHeight: "100vh" }}>
@@ -120,13 +120,12 @@ export function WorkInProgressRoot(): React.ReactElement {
   if (player.className !== "") {
     function cancel(): void {
       player.finishClass(true);
-      router.toCity();
+      router.toPreviousPage(() => router.toCity());
     }
 
     function unfocus(): void {
-      router.toFaction(faction);
-      router.toCity();
       player.stopFocusing();
+      router.toPreviousPage(() => router.toCity());
     }
 
     let stopText = "";
@@ -212,11 +211,11 @@ export function WorkInProgressRoot(): React.ReactElement {
 
     function cancel(): void {
       player.finishWork(true);
-      router.toJob();
+      router.toPreviousPage(() => router.toJob());
     }
     function unfocus(): void {
       player.stopFocusing();
-      router.toJob();
+      router.toPreviousPage(() => router.toJob());
     }
 
     const position = player.jobs[player.companyName];
@@ -304,11 +303,11 @@ export function WorkInProgressRoot(): React.ReactElement {
   if (player.workType == CONSTANTS.WorkTypeCompanyPartTime) {
     function cancel(): void {
       player.finishWorkPartTime(true);
-      router.toJob();
+      router.toPreviousPage(() => router.toJob());
     }
     function unfocus(): void {
       player.stopFocusing();
-      router.toJob();
+      router.toPreviousPage(() => router.toJob());
     }
     const comp = Companies[player.companyName];
     let companyRep = 0;
@@ -440,11 +439,11 @@ export function WorkInProgressRoot(): React.ReactElement {
   if (player.createProgramName !== "") {
     function cancel(): void {
       player.finishCreateProgramWork(true);
-      router.toTerminal();
+      router.toPreviousPage(() => router.toTerminal());
     }
     function unfocus(): void {
-      router.toTerminal();
       player.stopFocusing();
+      router.toPreviousPage(() => router.toTerminal());
     }
     return (
       <Grid container direction="column" justifyContent="center" alignItems="center" style={{ minHeight: "100vh" }}>


### PR DESCRIPTION
Allows the game to send us back to the previous page we were, fixes #2532.

- Allows the WorkInProgress cancel & unfocus to go back to the previous
page instead of a default one.
- Change layout of overview buttons
- Add a back button in the overview, only visible in pages with a
sidebar
- Clear the history on augmentation install & on prestige

---
![firefox_9aQPIFsE1n](https://user-images.githubusercontent.com/1521080/148949053-ab30e7ac-cf74-4241-bf45-86c09032ef84.png)

![firefox_B6xVvVijNw](https://user-images.githubusercontent.com/1521080/148949062-f09274fb-0b9a-4541-9ec3-c15dbddfd167.png)

