### PR TITLE
Fix root min-height being over 100vh with padding

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -101,6 +101,7 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "block",
       padding: "8px",
       minHeight: "100vh",
+      boxSizing: 'border-box',
     },
   }),
 );


### PR DESCRIPTION
It was causing a very small scrollable content.

See Factions page or any like that.