### PR TITLE
Analyze now outputs if a server has a backdoor installed or not

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -315,6 +315,7 @@ export class Terminal implements ITerminal {
       this.print("Root Access: " + (hasAdminRights ? "YES" : "NO"));
       this.print("Can run scripts on this host: " + (hasAdminRights ? "YES" : "NO"));
       if (currServ instanceof Server) {
+        this.print("Backdoor: " + (currServ.backdoorInstalled ? "YES" : "NO"));
         const hackingSkill = currServ.requiredHackingSkill;
         this.print("Required hacking skill for hack() and backdoor: " + (!isHacknet ? hackingSkill : "N/A"));
         const security = currServ.hackDifficulty;


### PR DESCRIPTION
Currently you have no way to determine if a server has a backdoor installed.  This adds a new output to analyze so that it reports that information.

This is in response to #2562 