### PR TITLE
Add tooltips to unfocused work

### DIFF
--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -7,6 +7,7 @@ import createStyles from "@mui/styles/createStyles";
 import { numeralWrapper } from "../../ui/numeralFormat";
 import { Reputation } from "./Reputation";
 import { KillScriptsModal } from "./KillScriptsModal";
+import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFunctions";
 
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -90,12 +91,14 @@ function Work(): React.ReactElement {
       <>
         <TableRow>
           <TableCell component="th" scope="row" colSpan={2} classes={{ root: classes.cellNone }}>
-            <Typography>Work&nbsp;in&nbsp;progress:</Typography>
+            <Tooltip title={'You are ' + player.className}>
+              <Typography>Work&nbsp;in&nbsp;progress:</Typography>
+            </Tooltip>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell component="th" scope="row" colSpan={2} classes={{ root: classes.cellNone }}>
-            <Typography>{player.className}</Typography>
+            <Typography>{convertTimeMsToTimeElapsedString(player.timeWorked)}</Typography>
           </TableCell>
         </TableRow>
         <TableRow>
@@ -119,7 +122,9 @@ function Work(): React.ReactElement {
       <>
         <TableRow>
           <TableCell component="th" scope="row" colSpan={2} classes={{ root: classes.cellNone }}>
-            <Typography>Work&nbsp;in&nbsp;progress:</Typography>
+            <Tooltip title={`Coding ${player.createProgramName}`}>
+              <Typography>Work&nbsp;in&nbsp;progress:</Typography>
+            </Tooltip>
           </TableCell>
         </TableRow>
         <TableRow>
@@ -150,7 +155,9 @@ function Work(): React.ReactElement {
     <>
       <TableRow>
         <TableCell component="th" scope="row" colSpan={2} classes={{ root: classes.cellNone }}>
-          <Typography>Work&nbsp;in&nbsp;progress:</Typography>
+          <Tooltip title={player.workType}>
+            <Typography>Work&nbsp;in&nbsp;progress:</Typography>
+          </Tooltip>
         </TableCell>
       </TableRow>
       <TableRow>


### PR DESCRIPTION
Adds tooltips in the character overview HUD (attached to "`Work in progress:`") to indicate what type of work is being done:

---

![image](https://user-images.githubusercontent.com/60761231/149039206-789c4907-fad1-4c6f-820d-6ffe3fe5943d.png)  
![image](https://user-images.githubusercontent.com/60761231/149039237-662e51e2-d7c3-43d4-877d-93e7b5b0720b.png)  
![image](https://user-images.githubusercontent.com/60761231/149039334-ceb1af82-087a-4bbb-bd6d-c395476df8d5.png)  
![image](https://user-images.githubusercontent.com/60761231/149039462-76e6a348-d9f4-4dcb-8b7b-7b01f757208e.png) [^1]

---

Also changes unfocused classes so that they display the time elapsed, rather than the full `player.className`.

![image](https://user-images.githubusercontent.com/60761231/149039933-b6aaa6e7-29fd-419c-8bba-6dca6a81bc5c.png)
[^1]: This one is a bit redundant, but I added it for the sake of consistency