### PR TITLE
Fix stale faction data after work

### DIFF
--- a/src/Bladeburner/ui/Stats.tsx
+++ b/src/Bladeburner/ui/Stats.tsx
@@ -40,7 +40,7 @@ export function Stats(props: IProps): React.ReactElement {
       joinFaction(faction);
     }
 
-    props.router.toFaction(faction);
+    props.router.toFaction(faction?.name);
   }
 
   return (

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -38,7 +38,7 @@ export function FactionsRoot(props: IProps): React.ReactElement {
   }, []);
 
   function openFaction(faction: Faction): void {
-    props.router.toFaction(faction);
+    props.router.toFaction(faction?.name);
   }
 
   function acceptInvitation(event: React.MouseEvent<HTMLButtonElement, MouseEvent>, faction: string): void {

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -165,7 +165,7 @@ export function SpecialLocation(props: IProps): React.ReactElement {
       applyAugmentation({ name: AugmentationNames.StaneksGift1, level: 1 });
     }
 
-    router.toFaction(faction);
+    router.toFaction(faction?.name);
   }
 
   function renderCotMG(): React.ReactElement {

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -317,9 +317,12 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     toCorporation: () => setCurrentPage(Page.Corporation),
     toCreateProgram: () => setCurrentPage(Page.CreateProgram),
     toDevMenu: () => setCurrentPage(Page.DevMenu),
-    toFaction: (faction?: Faction) => {
-      setCurrentPage(Page.Faction, faction);
-      if (faction) setFaction(faction);
+    toFaction: (factionName?: string) => {
+      setCurrentPage(Page.Faction, factionName);
+      if (factionName) {
+        const faction = Factions[factionName];
+        setFaction(faction);
+      }
     },
     toFactions: () => setCurrentPage(Page.Factions),
     toGameOptions: () => setCurrentPage(Page.Options),

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -1,4 +1,3 @@
-import { Faction } from "../Faction/Faction";
 import { Location } from "../Locations/Location";
 
 /**
@@ -65,7 +64,7 @@ export interface IRouter {
   toCorporation(): void;
   toCreateProgram(): void;
   toDevMenu(): void;
-  toFaction(faction?: Faction): void; // faction name
+  toFaction(factionName?: string): void; // faction name
   toFactions(): void;
   toGameOptions(): void;
   toGang(): void;

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -37,11 +37,11 @@ export function WorkInProgressRoot(): React.ReactElement {
   if (player.workType == CONSTANTS.WorkTypeFaction) {
     function cancel(): void {
       player.finishFactionWork(true);
-      router.toPreviousPage(() => router.toFaction(faction));
+      router.toPreviousPage(() => router.toFaction(faction.name));
     }
     function unfocus(): void {
       player.stopFocusing();
-      router.toPreviousPage(() => router.toFaction(faction));
+      router.toPreviousPage(() => router.toFaction(faction.name));
     }
     return (
       <Grid container direction="column" justifyContent="center" alignItems="center" style={{ minHeight: "100vh" }}>


### PR DESCRIPTION
Fixes #2569

Change the toFaction router action to work with a faction?.name instead of the full object.

Before that, we were keeping the previous page data and refreshing the page with that stale copy.