### PR TITLE
Fix faction reputation gain

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -319,8 +319,8 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     toCreateProgram: () => setCurrentPage(Page.CreateProgram),
     toDevMenu: () => setCurrentPage(Page.DevMenu),
     toFaction: (faction?: Faction) => {
+      if (faction) setFaction(Factions[faction.name]);
       setCurrentPage(Page.Faction, faction);
-      if (faction) setFaction(faction);
     },
     toFactions: () => setCurrentPage(Page.Factions),
     toGameOptions: () => setCurrentPage(Page.Options),


### PR DESCRIPTION
Ensure that faction state is updated whenever `router.toFaction` is called in order to ensure that the faction page is up to date.

Fixes #2569