### PR TITLE
Fix navigation issue (duplicate previous pages in history)

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { cloneDeep } from "lodash";
+import { cloneDeep, isEqual } from "lodash";
 import { IPlayer } from "../PersonObjects/IPlayer";
 import { IEngine } from "../IEngine";
 import { ITerminal } from "../Terminal/ITerminal";
@@ -251,11 +251,16 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
   }
 
   function setCurrentPage(page: Page, ...args: any): void {
-    const history = [
-        { page, args: cloneDeep(args) },
+    const newPage = { page, args: cloneDeep(args) };
+    const previousPage = pageHistory[0];
+    const isDifferentThenPrevious = page !== previousPage?.page || !isEqual([...args], previousPage?.args);
+    if (isDifferentThenPrevious) {
+      const history = [
+        newPage,
         ...pageHistory
       ].slice(0, 20);
-    setPageHistory(history)
+      setPageHistory(history)
+    }
     setPage(page)
   }
 


### PR DESCRIPTION
Multiple .toWork calls were made so the history contained multiple entries, making going back a pain (multi clicks).

Now compares the previous page to make sure it's different before adding it to the array.