### PR TITLE
Ensure that we leave focus when we call stopAction or cancel working

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -738,6 +738,7 @@ export function NetscriptSingularity(
       helper.checkSingularityAccess("stopAction");
       if (player.isWorking) {
         if (player.focus) {
+          player.stopFocusing();
           Router.toTerminal();
         }
         const txt = player.singularityStopWork();

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -729,6 +729,7 @@ export function finishWork(this: IPlayer, cancelled: boolean, sing = false): str
   }
 
   this.isWorking = false;
+  this.focus = false;
 
   this.resetWorkStatus();
   if (sing) {


### PR DESCRIPTION
When a job is cancelled, we did not correctly reset focus.  In addition, when stopAction was called we did not reset focus there as well.

#2577 - This is in response to this issue.