### PR TITLE
MISC: FIX #2557 Refactor directories to be more flexible.

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -266,7 +266,7 @@ export const achievements: IMap<Achievement> = {
     ...achievementData["NS2"],
     Icon: "ns2",
     Condition: () =>
-      Player.getHomeComputer().scripts.some((s) => s.filename.endsWith(".js") || s.filename.endsWith(".ns")),
+      Player.getHomeComputer().getAllScriptFilenames().some((filename) => filename.endsWith(".js") || filename.endsWith(".ns")),
   },
   FROZE: {
     ...achievementData["FROZE"],
@@ -309,7 +309,7 @@ export const achievements: IMap<Achievement> = {
   SCRIPTS_30: {
     ...achievementData["SCRIPTS_30"],
     Icon: "folders",
-    Condition: () => Player.getHomeComputer().scripts.length >= 30,
+    Condition: () => Player.getHomeComputer().getAllScriptFilenames().length >= 30,
   },
   KARMA_1000000: {
     ...achievementData["KARMA_1000000"],
@@ -334,7 +334,7 @@ export const achievements: IMap<Achievement> = {
   SCRIPT_32GB: {
     ...achievementData["SCRIPT_32GB"],
     Icon: "bigcost",
-    Condition: () => Player.getHomeComputer().scripts.some((s) => s.ramUsage >= 32),
+    Condition: () => Player.getHomeComputer().getAllScriptFiles().some((s) => s.ramUsage >= 32),
   },
   FIRST_HACKNET_NODE: {
     ...achievementData["FIRST_HACKNET_NODE"],

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -112,7 +112,7 @@ export const CONSTANTS: {
   LatestUpdate: string;
 } = {
   VersionString: "1.3.0",
-  VersionNumber: 9,
+  VersionNumber: 11,
 
   // Speed (in ms) at which the main loop is updated
   _idleSpeed: 200,

--- a/src/Diagnostic/FileDiagnosticModal.tsx
+++ b/src/Diagnostic/FileDiagnosticModal.tsx
@@ -24,11 +24,11 @@ function ServerAccordion(props: IServerProps): React.ReactElement {
   const server = GetServer(props.hostname);
   if (server === null) throw new Error(`server '${props.hostname}' should not be null`);
   let totalSize = 0;
-  for (const f of server.scripts) {
+  for (const f of server.getAllScriptFiles()) {
     totalSize += f.code.length;
   }
 
-  for (const f of server.textFiles) {
+  for (const f of server.getAllTextFiles()) {
     totalSize += f.text.length;
   }
 
@@ -43,12 +43,12 @@ function ServerAccordion(props: IServerProps): React.ReactElement {
 
   const files: File[] = [];
 
-  for (const f of server.scripts) {
+  for (const f of server.getAllScriptFiles()) {
     files.push({ name: f.filename, size: f.code.length });
   }
 
-  for (const f of server.textFiles) {
-    files.push({ name: f.fn, size: f.text.length });
+  for (const f of server.getAllTextFiles()) {
+    files.push({ name: f.filename, size: f.text.length });
   }
 
   files.sort((a: File, b: File): number => b.size - a.size);

--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -1,6 +1,5 @@
 import { Player } from "./Player";
 import { isScriptFilename } from "./Script/isScriptFilename";
-import { Script } from "./Script/Script";
 import { removeLeadingSlash } from "./Terminal/DirectoryHelpers";
 import { Terminal } from "./Terminal";
 import { SnackbarEvents } from "./ui/React/Snackbar";
@@ -28,18 +27,14 @@ function initWebserver(): void {
     const home = GetServer("home");
     if (home === null) return "'home' server not found.";
     if (isScriptFilename(filename)) {
-      //If the current script already exists on the server, overwrite it
-      for (let i = 0; i < home.scripts.length; i++) {
-        if (filename == home.scripts[i].filename) {
-          home.scripts[i].saveScript(Player, filename, code, "home", home.scripts);
-          return "written";
-        }
+      const script = home.getScript(filename);
+      if (script === null) {
+        //If the current script does NOT exist, create a new one
+        home.writeToScriptFile(Player, filename, code);
+        return 'written';
       }
-
-      //If the current script does NOT exist, create a new one
-      const script = new Script();
-      script.saveScript(Player, filename, code, "home", home.scripts);
-      home.scripts.push(script);
+      //If the current script already exists on the server, overwrite it
+      script.saveScript(Player, filename, code, "home", home.getAllScriptFiles())
       return "written";
     }
 

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -127,16 +127,11 @@ export class WorkerScript {
     if (server == null) {
       throw new Error(`WorkerScript constructed with invalid server ip: ${this.hostname}`);
     }
-    let found = false;
-    for (let i = 0; i < server.scripts.length; ++i) {
-      if (server.scripts[i].filename === this.name) {
-        found = true;
-        this.code = server.scripts[i].code;
-      }
-    }
-    if (!found) {
+    const scriptFile = server.getScript(this.name);
+    if (scriptFile === null) {
       throw new Error(`WorkerScript constructed with invalid script filename: ${this.name}`);
     }
+    this.code = scriptFile.code;
     this.scriptRef = runningScriptObj;
     this.args = runningScriptObj.args.slice();
     this.env = new Environment(null);
@@ -161,34 +156,25 @@ export class WorkerScript {
    */
   getScript(): Script | null {
     const server = this.getServer();
-    for (let i = 0; i < server.scripts.length; ++i) {
-      if (server.scripts[i].filename === this.name) {
-        return server.scripts[i];
-      }
+    const script = server.getScript(this.name);
+    if (script === null) {
+      console.error(
+        "Failed to find underlying Script object in WorkerScript.getScript(). This probably means somethings wrong",
+      );
     }
-
-    console.error(
-      "Failed to find underlying Script object in WorkerScript.getScript(). This probably means somethings wrong",
-    );
-    return null;
+    return script;
   }
 
   /**
    * Returns the script with the specified filename on the specified server,
    * or null if it cannot be found
    */
-  getScriptOnServer(fn: string, server: BaseServer): Script | null {
+  getScriptOnServer(filename: string, server: BaseServer): Script | null {
     if (server == null) {
       server = this.getServer();
     }
 
-    for (let i = 0; i < server.scripts.length; ++i) {
-      if (server.scripts[i].filename === fn) {
-        return server.scripts[i];
-      }
-    }
-
-    return null;
+    return server.getScript(filename);
   }
 
   shouldLog(fn: string): boolean {

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -76,7 +76,7 @@ export function NetscriptSingularity(
     //Run a script after reset
     if (cbScript && isString(cbScript)) {
       const home = player.getHomeComputer();
-      for (const script of home.scripts) {
+      for (const script of home.getAllScriptFiles()) {
         if (script.filename === cbScript) {
           const ramUsage = script.ramUsage;
           const ramAvailable = home.maxRam - home.ramUsed;

--- a/src/Script/RunningScriptHelpers.ts
+++ b/src/Script/RunningScriptHelpers.ts
@@ -10,13 +10,10 @@ export function getRamUsageFromRunningScript(script: RunningScript): number {
   if (server == null) {
     return 0;
   }
-  for (let i = 0; i < server.scripts.length; ++i) {
-    if (server.scripts[i].filename === script.filename) {
-      // Cache the ram usage for the next call
-      script.ramUsage = server.scripts[i].ramUsage;
-      return script.ramUsage;
-    }
+  const scriptFile = server.getScript(script.filename);
+  if (scriptFile === null) {
+    return 0;
   }
-
-  return 0;
+  script.ramUsage = scriptFile.ramUsage;
+  return script.ramUsage;
 }

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -112,8 +112,9 @@ export function prestigeHomeComputer(player: IPlayer, homeComp: Server): void {
   }
 
   //Update RAM usage on all scripts
-  homeComp.scripts.forEach(function (script) {
-    script.updateRamUsage(player, homeComp.scripts);
+  const homeCompScripts = homeComp.getAllScriptFiles();
+  homeCompScripts.forEach(function (script) {
+    script.updateRamUsage(player, homeCompScripts);
   });
 
   homeComp.messages.length = 0; //Remove .lit and .msg files

--- a/src/Terminal/DirectoryServerHelpers.ts
+++ b/src/Terminal/DirectoryServerHelpers.ts
@@ -27,9 +27,9 @@ export function getSubdirectories(serv: BaseServer, dir: string): string[] {
   }
 
   function processFile(fn: string): void {
-    if (t_dir === "/" && isInRootDirectory(fn)) {
+    if (t_dir === "" && isInRootDirectory(fn)) {
       const subdir = getFirstParentDirectory(fn);
-      if (subdir !== "/" && !res.includes(subdir)) {
+      if (subdir !== "" && !res.includes(subdir)) {
         res.push(subdir);
       }
     } else if (fn.startsWith(t_dir)) {
@@ -41,12 +41,12 @@ export function getSubdirectories(serv: BaseServer, dir: string): string[] {
     }
   }
 
-  for (const script of serv.scripts) {
-    processFile(script.filename);
+  for (const filename of serv.getAllScriptFilenames()) {
+    processFile('/'+filename);
   }
 
-  for (const txt of serv.textFiles) {
-    processFile(txt.fn);
+  for (const filename of serv.getAllTextFilenames()) {
+    processFile('/'+filename);
   }
 
   return res;

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -402,25 +402,13 @@ export class Terminal implements ITerminal {
   getScript(player: IPlayer, filename: string): Script | null {
     const s = player.getCurrentServer();
     const filepath = this.getFilepath(filename);
-    for (const script of s.scripts) {
-      if (filepath === script.filename) {
-        return script;
-      }
-    }
-
-    return null;
+    return s.getScript(filepath);
   }
 
   getTextFile(player: IPlayer, filename: string): TextFile | null {
     const s = player.getCurrentServer();
     const filepath = this.getFilepath(filename);
-    for (const txt of s.textFiles) {
-      if (filepath === txt.fn) {
-        return txt;
-      }
-    }
-
-    return null;
+    return s.getFile(filepath);
   }
 
   getLitFile(player: IPlayer, filename: string): string | null {

--- a/src/Terminal/commands/cd.ts
+++ b/src/Terminal/commands/cd.ts
@@ -32,8 +32,8 @@ export function cd(
 
       const server = player.getCurrentServer();
       if (
-        !server.scripts.some((script) => script.filename.startsWith(evaledDir + "")) &&
-        !server.textFiles.some((file) => file.fn.startsWith(evaledDir + ""))
+        !server.getAllScriptFilenames().some((filename) => filename.startsWith(evaledDir + "")) &&
+        !server.getAllTextFilenames().some((filename) => filename.startsWith(evaledDir + ""))
       ) {
         terminal.error("Invalid path. Failed to change directories");
         return;

--- a/src/Terminal/commands/cp.ts
+++ b/src/Terminal/commands/cp.ts
@@ -5,13 +5,13 @@ import { BaseServer } from "../../Server/BaseServer";
 import { isScriptFilename } from "../../Script/isScriptFilename";
 import { getDestinationFilepath, areFilesEqual } from "../DirectoryHelpers";
 
-export function cp(
+export async function cp(
   terminal: ITerminal,
   router: IRouter,
   player: IPlayer,
   server: BaseServer,
   args: (string | number | boolean)[],
-): void {
+): Promise<void> {
   try {
     if (args.length !== 2) {
       terminal.error("Incorrect usage of cp command. Usage: cp [src] [dst]");
@@ -50,13 +50,7 @@ export function cp(
 
     // Scp for txt files
     if (src.endsWith(".txt")) {
-      let txtFile = null;
-      for (let i = 0; i < server.textFiles.length; ++i) {
-        if (areFilesEqual(server.textFiles[i].fn, src)) {
-          txtFile = server.textFiles[i];
-          break;
-        }
-      }
+      const txtFile = server.getFile(src);
 
       if (txtFile === null) {
         return terminal.error("No such file exists!");
@@ -77,19 +71,13 @@ export function cp(
     }
 
     // Get the current script
-    let sourceScript = null;
-    for (let i = 0; i < server.scripts.length; ++i) {
-      if (areFilesEqual(server.scripts[i].filename, src)) {
-        sourceScript = server.scripts[i];
-        break;
-      }
-    }
+    const sourceScript = server.getScript(src);
     if (sourceScript == null) {
       terminal.error("cp failed. No such script exists");
       return;
     }
 
-    const sRes = server.writeToScriptFile(player, dst, sourceScript.code);
+    const sRes = await server.writeToScriptFile(player, dst, sourceScript.code);
     if (!sRes.success) {
       terminal.error(`cp failed`);
       return;

--- a/src/Terminal/commands/download.ts
+++ b/src/Terminal/commands/download.ts
@@ -35,14 +35,14 @@ export function download(
       // In the case of script files, we pull from the server.scripts array
       if (!matchEnding || isScriptFilename(matchEnding))
         zipFiles(
-          server.scripts.map((s) => s.filename),
-          server.scripts.map((s) => s.code),
+          server.getAllScriptFiles().map((s) => s.filename),
+          server.getAllScriptFiles().map((s) => s.code),
         );
       // In the case of text files, we pull from the server.scripts array
       if (!matchEnding || matchEnding.endsWith(".txt"))
         zipFiles(
-          server.textFiles.map((s) => s.fn),
-          server.textFiles.map((s) => s.text),
+          server.getAllTextFiles().map((s) => s.filename),
+          server.getAllTextFiles().map((s) => s.text),
         );
       // Return an error if no files matched, rather than an empty zip folder
       if (Object.keys(zip.files).length == 0) return terminal.error(`No files match the pattern ${fn}`);

--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -100,8 +100,8 @@ export function ls(
   // Get all of the programs and scripts on the machine into one temporary array
   const s = player.getCurrentServer();
   for (const program of s.programs) handleFn(program, allPrograms);
-  for (const script of s.scripts) handleFn(script.filename, allScripts);
-  for (const txt of s.textFiles) handleFn(txt.fn, allTextFiles);
+  for (const filename of s.getAllScriptFilenames()) handleFn(filename, allScripts);
+  for (const filename of s.getAllTextFilenames()) handleFn(filename, allTextFiles);
   for (const contract of s.contracts) handleFn(contract.fn, allContracts);
   for (const msgOrLit of s.messages) handleFn(msgOrLit, allMessages);
 

--- a/src/Terminal/commands/mv.ts
+++ b/src/Terminal/commands/mv.ts
@@ -94,7 +94,7 @@ export function mv(
         }
       }
 
-      textFile.fn = destPath;
+      textFile.filename = destPath;
     }
   } catch (e) {
     terminal.error(e + "");

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -46,53 +46,50 @@ export function runScript(
   }
 
   // Check if the script exists and if it does run it
-  for (let i = 0; i < server.scripts.length; i++) {
-    if (server.scripts[i].filename !== scriptName) {
-      continue;
-    }
-    // Check for admin rights and that there is enough RAM availble to run
-    const script = server.scripts[i];
-    script.server = player.getCurrentServer().hostname;
-    const ramUsage = script.ramUsage * numThreads;
-    const ramAvailable = server.maxRam - server.ramUsed;
+  const script = server.getScript(scriptName);
+  if (script === null) {
+    terminal.error("No such script");
+    return;
+  }
+  // Check for admin rights and that there is enough RAM availble to run
+  script.server = player.getCurrentServer().hostname;
+  const ramUsage = script.ramUsage * numThreads;
+  const ramAvailable = server.maxRam - server.ramUsed;
 
-    if (!server.hasAdminRights) {
-      terminal.error("Need root access to run script");
-      return;
-    }
-
-    if (ramUsage > ramAvailable) {
-      terminal.error(
-        "This machine does not have enough RAM to run this script with " +
-          numThreads +
-          " threads. Script requires " +
-          numeralWrapper.formatRAM(ramUsage) +
-          " of RAM",
-      );
-      return;
-    }
-
-    // Able to run script
-    const runningScript = new RunningScript(script, args);
-    runningScript.threads = numThreads;
-
-    const success = startWorkerScript(player, runningScript, server);
-    if (!success) {
-      terminal.error(`Failed to start script`);
-      return;
-    }
-
-    terminal.print(
-      `Running script with ${numThreads} thread(s), pid ${runningScript.pid} and args: ${JSON.stringify(args)}.`,
-    );
-    if (runningScript.filename.endsWith(".ns")) {
-      terminal.warn(".ns files are deprecated, please rename everything to .js");
-    }
-    if (tailFlag) {
-      LogBoxEvents.emit(runningScript);
-    }
+  if (!server.hasAdminRights) {
+    terminal.error("Need root access to run script");
     return;
   }
 
-  terminal.error("No such script");
+  if (ramUsage > ramAvailable) {
+    terminal.error(
+      "This machine does not have enough RAM to run this script with " +
+        numThreads +
+        " threads. Script requires " +
+        numeralWrapper.formatRAM(ramUsage) +
+        " of RAM",
+    );
+    return;
+  }
+
+  // Able to run script
+  const runningScript = new RunningScript(script, args);
+  runningScript.threads = numThreads;
+
+  const success = startWorkerScript(player, runningScript, server);
+  if (!success) {
+    terminal.error(`Failed to start script`);
+    return;
+  }
+
+  terminal.print(
+    `Running script with ${numThreads} thread(s), pid ${runningScript.pid} and args: ${JSON.stringify(args)}.`,
+  );
+  if (runningScript.filename.endsWith(".ns")) {
+    terminal.warn(".ns files are deprecated, please rename everything to .js");
+  }
+  if (tailFlag) {
+    LogBoxEvents.emit(runningScript);
+  }
+  return;
 }

--- a/src/Terminal/commands/wget.ts
+++ b/src/Terminal/commands/wget.ts
@@ -23,10 +23,10 @@ export function wget(
   }
   $.get(
     url,
-    function (data: any) {
+    async function (data: any) {
       let res;
       if (isScriptFilename(target)) {
-        res = server.writeToScriptFile(player, target, data);
+        res = await server.writeToScriptFile(player, target, data);
       } else {
         res = server.writeToTextFile(target, data);
       }

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -70,7 +70,7 @@ const Engine: {
   };
   decrementAllCounters: (numCycles?: number) => void;
   checkCounters: () => void;
-  load: (saveString: string) => void;
+  load: (saveString: string) => Promise<void>;
   start: () => void;
 } = {
   // Time variables (milliseconds unix epoch time)
@@ -244,11 +244,11 @@ const Engine: {
     }
   },
 
-  load: function (saveString) {
+  load: async function (saveString) {
     startExploits();
     setupUncaughtPromiseHandler();
     // Load game from save or create new game
-    if (loadGame(saveString)) {
+    if (await loadGame(saveString)) {
       ThemeEvents.emit();
 
       initBitNodeMultipliers(Player);

--- a/src/ui/LoadingScreen.tsx
+++ b/src/ui/LoadingScreen.tsx
@@ -40,9 +40,9 @@ export function LoadingScreen(): React.ReactElement {
   useEffect(() => {
     async function doLoad(): Promise<void> {
       await load()
-        .then((saveString) => {
+        .then(async (saveString) => {
           try {
-            Engine.load(saveString);
+            await Engine.load(saveString);
           } catch (err: any) {
             ActivateRecoveryMode();
             setLoaded(true);
@@ -51,9 +51,9 @@ export function LoadingScreen(): React.ReactElement {
 
           setLoaded(true);
         })
-        .catch((reason) => {
+        .catch(async (reason) => {
           console.error(reason);
-          Engine.load("");
+          await Engine.load("");
           setLoaded(true);
         });
     }

--- a/src/utils/helpers/sanitizeFilename.ts
+++ b/src/utils/helpers/sanitizeFilename.ts
@@ -5,7 +5,7 @@ export function sanitizeFilename(filename: string): string {
   return filename;
 }
 
-const filenameRegex = /\/?[a-zA-Z0-9\-_]{1,}(\/[a-zA-Z0-9\-_]{1,})*\.(js|script|txt)/;
+const filenameRegex = /^\/?[a-zA-Z0-9\-_]{1,}(\/[a-zA-Z0-9\-_]{1,})*\.(js|script|txt)$/;
 
 export function isValidFilename(filename: string): boolean {
   const match = filename.match(filenameRegex);

--- a/src/utils/helpers/sanitizeFilename.ts
+++ b/src/utils/helpers/sanitizeFilename.ts
@@ -1,0 +1,35 @@
+export function sanitizeFilename(filename: string): string {
+  filename = filename.replace(/\/{2,}/g, '/');
+  // filename = filename.replace(/^\//, '');
+  filename = filename.replace(/\.ns$/, '.js');
+  return filename;
+}
+
+const filenameRegex = /\/?[a-zA-Z0-9\-_]{1,}(\/[a-zA-Z0-9\-_]{1,})*\.(js|script|txt)/;
+
+export function isValidFilename(filename: string): boolean {
+  const match = filename.match(filenameRegex);
+  return match !== null;
+}
+
+export function generateRecoveryFilename(): string {
+  const buf = new Uint16Array(8);
+  window.crypto.getRandomValues(buf);
+  const u16hex = (val: number): string => { return val.toString(16).padStart(4, '0'); };
+  // not actually a valid uuid but enough for this purpose
+  const chunks: string[] = [
+    u16hex(buf[0]),
+    u16hex(buf[1]),
+    '-',
+    u16hex(buf[2]),
+    '-',
+    u16hex(buf[3]),
+    '-',
+    u16hex(buf[4]),
+    '-',
+    u16hex(buf[5]),
+    u16hex(buf[6]),
+    u16hex(buf[7])
+  ];
+  return `/_recovered/${chunks.join('')}`
+}


### PR DESCRIPTION
regarding #2557

- [x]  Every file in the game should match `[a-zA-Z0-9\-_](/[a-zA-Z0-9\-_])*\.(js|script|txt)`. 
       Note the lack is leading slash in ALL files. Foldered or not.
       regex is slightly modified to actually match full filename
       actual regex is `/^\/?[a-zA-Z0-9\-_]{1,}(\/[a-zA-Z0-9\-_]{1,})*\.(js|script|txt)$/`
- [ ] Make a function to sanitize filename (convert // to /, remove leading slash, etc, take a look at electron.tsx)
        doesnt currently handle leading slash as i was unable to get other code to handle no leading slash
- [x] Make another function that validates a filename (to catch weird extension and other invalid characters like spaces)
- [x] Write a save file migration that sanitizes all txt and scripts.
- [x] Make the txt and scripts array on server private, will narrow down everything that uses them.
- [x] Write a function called like BaseServer.prototype.findFile so that nothing needs read access to the private arrays

basicly everything is implemented except for removal of leading slash on filenames in sub-directorys, i was unable to make enough sense of how the terminal handles autocomplete to make that work, but the code to sanitize them is present, just commented out