### PR TITLE
Change typescript definitions for sprintf/vsprintf

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -3916,7 +3916,7 @@ export declare interface NS extends Singularity {
      * @param args - Formating arguments.
      * @returns Formated text.
      */
-    sprintf(format: string, ...args: string[]): string;
+    sprintf(format: string, ...args: any[]): string;
 
     /**
      * Format a string with an array of arguments.
@@ -3928,7 +3928,7 @@ export declare interface NS extends Singularity {
      * @param args - Formating arguments.
      * @returns Formated text.
      */
-    vsprintf(format: string, args: string[]): string;
+    vsprintf(format: string, args: any[]): string;
 
     /**
      * Format a number

--- a/markdown/bitburner.ns.sprintf.md
+++ b/markdown/bitburner.ns.sprintf.md
@@ -9,15 +9,15 @@ Format a string.
 <b>Signature:</b>
 
 ```typescript
-sprintf(format: string, ...args: string[]): string;
+sprintf(format: string, ...args: any[]): string;
 ```
 
 ## Parameters
 
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  format | string | String to format. |
-|  args | string\[\] | Formating arguments. |
+| Parameter | Type    | Description          |
+| --------- | ------- | -------------------- |
+| format    | string  | String to format.    |
+| args      | any\[\] | Formating arguments. |
 
 <b>Returns:</b>
 
@@ -30,4 +30,3 @@ Formated text.
 RAM cost: 0 GB
 
 see: https://github.com/alexei/sprintf.js
-

--- a/markdown/bitburner.ns.vsprintf.md
+++ b/markdown/bitburner.ns.vsprintf.md
@@ -9,15 +9,15 @@ Format a string with an array of arguments.
 <b>Signature:</b>
 
 ```typescript
-vsprintf(format: string, args: string[]): string;
+vsprintf(format: string, args: any[]): string;
 ```
 
 ## Parameters
 
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  format | string | String to format. |
-|  args | string\[\] | Formating arguments. |
+| Parameter | Type    | Description          |
+| --------- | ------- | -------------------- |
+| format    | string  | String to format.    |
+| args      | any\[\] | Formating arguments. |
 
 <b>Returns:</b>
 
@@ -30,4 +30,3 @@ Formated text.
 RAM cost: 0 GB
 
 see: https://github.com/alexei/sprintf.js
-

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5630,7 +5630,7 @@ export interface NS extends Singularity {
    * @param args - Formating arguments.
    * @returns Formated text.
    */
-  sprintf(format: string, ...args: string[]): string;
+  sprintf(format: string, ...args: any[]): string;
 
   /**
    * Format a string with an array of arguments.
@@ -5642,7 +5642,7 @@ export interface NS extends Singularity {
    * @param args - Formating arguments.
    * @returns Formated text.
    */
-  vsprintf(format: string, args: string[]): string;
+  vsprintf(format: string, args: any[]): string;
 
   /**
    * Format a number


### PR DESCRIPTION
According to https://www.npmjs.com/package/@types/sprintf-js -> [sprintf](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/sprintf-js/index.d.ts#L84) and [vsprintf](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/sprintf-js/index.d.ts#L164) `args` argument doesn't have to be strings.

This PR aims to fix the definition provided in-game to match the one provided by library.