### PR TITLE
Made hack log msg consitent with grow and weaken

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -335,7 +335,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
     workerScript.log(
       "hack",
       () =>
-        `Executing ${hostname} in ${convertTimeMsToTimeElapsedString(
+        `Executing on '${server.hostname}' in ${convertTimeMsToTimeElapsedString(
           hackingTime * 1000,
           true,
         )} (t=${numeralWrapper.formatThreads(threads)})`,


### PR DESCRIPTION
Changed hack log message from "executing target" to "executing on 'target'".
This makes it consistent with grow and weaken; and reads better as well.