### PR TITLE
API: FIX #2391 atExit can now run netscript functions.

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -97,6 +97,11 @@ export class WorkerScript {
   running = false;
 
   /**
+   * Whether or not this workerScript is currently exiting
+   */
+  exiting = false;
+
+  /**
    * Reference to underlying RunningScript object
    */
   scriptRef: RunningScript;

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -68,6 +68,7 @@ function killWorkerScriptByPid(pid: number, rerenderUi = true): boolean {
 }
 
 function stopAndCleanUpWorkerScript(workerScript: WorkerScript, rerenderUi = true): void {
+  killNetscriptDelay(workerScript); // Run before atExit to avoid concurrence of calls
   if (workerScript.exiting == true) {
     dialogBoxCreate(
       `Error trying to call exit from inside the function of atExit in script ${workerScript.name} on ${workerScript.hostname} ${workerScript.scriptRef.args}`,
@@ -88,7 +89,6 @@ function stopAndCleanUpWorkerScript(workerScript: WorkerScript, rerenderUi = tru
     workerScript.exiting = false;
   }
   workerScript.env.stopFlag = true;
-  killNetscriptDelay(workerScript);
   removeWorkerScript(workerScript, rerenderUi);
 }
 

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -68,15 +68,24 @@ function killWorkerScriptByPid(pid: number, rerenderUi = true): boolean {
 }
 
 function stopAndCleanUpWorkerScript(workerScript: WorkerScript, rerenderUi = true): void {
-  if (typeof workerScript.atExit === "function") {
-    try {
-      workerScript.atExit();
-    } catch (e: any) {
-      dialogBoxCreate(
-        `Error trying to call atExit for script ${workerScript.name} on ${workerScript.hostname} ${workerScript.scriptRef.args} ${e}`,
-      );
+  if (workerScript.exiting == true) {
+    dialogBoxCreate(
+      `Error trying to call exit from inside the function of atExit in script ${workerScript.name} on ${workerScript.hostname} ${workerScript.scriptRef.args}`,
+    );
+  }
+  else {
+    workerScript.exiting = true;
+    if (typeof workerScript.atExit === "function") {
+      try {
+        workerScript.atExit();
+      } catch (e: any) {
+        dialogBoxCreate(
+          `Error trying to call atExit for script ${workerScript.name} on ${workerScript.hostname} ${workerScript.scriptRef.args} ${e}`,
+        );
+      }
+      workerScript.atExit = undefined;
     }
-    workerScript.atExit = undefined;
+    workerScript.exiting = false;
   }
   workerScript.env.stopFlag = true;
   killNetscriptDelay(workerScript);

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -88,7 +88,7 @@ function startNetscript2Script(player: IPlayer, workerScript: WorkerScript): Pro
         "Concurrent calls to Netscript functions are not allowed! " +
         "Did you forget to await hack(), grow(), or some other " +
         "promise-returning function? (Currently running: %s tried to run: %s)";
-      if (runningFn) {
+      if (runningFn && !(runningFn === "sleep" && workerScript.exiting)) {
         workerScript.errorMessage = makeRuntimeRejectMsg(workerScript, sprintf(msg, runningFn, propName));
         throw workerScript;
       }

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -92,7 +92,12 @@ function startNetscript2Script(player: IPlayer, workerScript: WorkerScript): Pro
         workerScript.errorMessage = makeRuntimeRejectMsg(workerScript, sprintf(msg, runningFn, propName));
         throw workerScript;
       }
-      runningFn = propName;
+
+      // If we register exit as running, Netscript functions cannot be called from atExit anymore, as it would be considered
+      // as a call concurrent to exit. As long as exit only kills the script, we do not need to register it.
+      if (propName !== "exit") {
+        runningFn = propName;
+      }
 
       // If the function throws an error, clear the runningFn flag first, and then re-throw it
       // This allows people to properly catch errors thrown by NS functions without getting


### PR DESCRIPTION
This PR aims to fix the issue presented in #2391, namely that `atExit` currently cannot work properly if its argument contains calls to ns.