### PR TITLE
Add focus arg to Singularity functions

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -4520,9 +4520,10 @@ export declare interface Singularity {
      *
      * @param universityName - Name of university. You must be in the correct city for whatever university you specify.
      * @param courseName - Name of course.
+     * @param focus - Acquire player focus on this class. Optional. Defaults to true.
      * @returns True if actions is successfully started, false otherwise.
      */
-    universityCourse(universityName: string, courseName: string): boolean;
+    universityCourse(universityName: string, courseName: string, focus?: boolean): boolean;
 
     /**
      * SF4.1 - Workout at the gym.
@@ -4541,9 +4542,10 @@ export declare interface Singularity {
      *
      * @param gymName - Name of gym. You must be in the correct city for whatever gym you specify.
      * @param stat - The stat you want to train.
+     * @param focus - Acquire player focus on this gym workout. Optional. Defaults to true.
      * @returns True if actions is successfully started, false otherwise.
      */
-    gymWorkout(gymName: string, stat: string): boolean;
+    gymWorkout(gymName: string, stat: string, focus?: boolean): boolean;
 
     /**
      * SF4.1 - Travel to another city.
@@ -4954,9 +4956,10 @@ export declare interface Singularity {
      * ns.createProgram(“relaysmtp.exe”);
      * ```
      * @param program - Name of program to create.
+     * @param focus - Acquire player focus on this program creation. Optional. Defaults to true.
      * @returns True if you successfully start working on the specified program, and false otherwise.
      */
-    createProgram(program: string): boolean;
+    createProgram(program: string, focus?: boolean): boolean;
 
     /**
      * SF4.3 - Commit a crime.

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -267,9 +267,10 @@ export function NetscriptSingularity(
       player.gainIntelligenceExp(CONSTANTS.IntelligenceSingFnBaseExpGain / 500);
       return true;
     },
-    universityCourse: function (universityName: any, className: any): any {
+    universityCourse: function (universityName: any, className: any, focus = true): any {
       helper.updateDynamicRam("universityCourse", getRamCost(player, "universityCourse"));
       helper.checkSingularityAccess("universityCourse");
+      const wasFocusing = player.focus;
       if (player.isWorking) {
         const txt = player.singularityStopWork();
         workerScript.log("universityCourse", () => txt);
@@ -343,13 +344,21 @@ export function NetscriptSingularity(
           return false;
       }
       player.startClass(Router, costMult, expMult, task);
+      if (focus) {
+        player.startFocusing();
+        Router.toWork();
+      } else if (wasFocusing) {
+        player.stopFocusing();
+        Router.toTerminal();
+      }
       workerScript.log("universityCourse", () => `Started ${task} at ${universityName}`);
       return true;
     },
 
-    gymWorkout: function (gymName: any, stat: any): any {
+    gymWorkout: function (gymName: any, stat: any, focus = true): any {
       helper.updateDynamicRam("gymWorkout", getRamCost(player, "gymWorkout"));
       helper.checkSingularityAccess("gymWorkout");
+      const wasFocusing = player.focus;
       if (player.isWorking) {
         const txt = player.singularityStopWork();
         workerScript.log("gymWorkout", () => txt);
@@ -441,6 +450,13 @@ export function NetscriptSingularity(
         default:
           workerScript.log("gymWorkout", () => `Invalid stat: ${stat}.`);
           return false;
+      }
+      if (focus) {
+        player.startFocusing();
+        Router.toWork();
+      } else if (wasFocusing) {
+        player.stopFocusing();
+        Router.toTerminal();
       }
       workerScript.log("gymWorkout", () => `Started training ${stat} at ${gymName}`);
       return true;
@@ -1217,10 +1233,11 @@ export function NetscriptSingularity(
       );
       return true;
     },
-    createProgram: function (name: any): any {
+    createProgram: function (name: any, focus = true): any {
       helper.updateDynamicRam("createProgram", getRamCost(player, "createProgram"));
       helper.checkSingularityAccess("createProgram");
 
+      const wasFocusing = player.focus;
       if (player.isWorking) {
         const txt = player.singularityStopWork();
         workerScript.log("createProgram", () => txt);
@@ -1255,6 +1272,13 @@ export function NetscriptSingularity(
       }
 
       player.startCreateProgramWork(Router, p.name, create.time, create.level);
+      if (focus) {
+        player.startFocusing();
+        Router.toWork();
+      } else if (wasFocusing) {
+        player.stopFocusing();
+        Router.toTerminal();
+      }
       workerScript.log("createProgram", () => `Began creating program: '${name}'`);
       return true;
     },

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1341,9 +1341,10 @@ export interface Singularity {
    *
    * @param universityName - Name of university. You must be in the correct city for whatever university you specify.
    * @param courseName - Name of course.
+   * @param focus - Acquire player focus on this class. Optional. Defaults to true.
    * @returns True if actions is successfully started, false otherwise.
    */
-  universityCourse(universityName: string, courseName: string): boolean;
+  universityCourse(universityName: string, courseName: string, focus?: boolean): boolean;
 
   /**
    * Workout at the gym.
@@ -1362,9 +1363,10 @@ export interface Singularity {
    *
    * @param gymName - Name of gym. You must be in the correct city for whatever gym you specify.
    * @param stat - The stat you want to train.
+   * @param focus - Acquire player focus on this gym workout. Optional. Defaults to true.
    * @returns True if actions is successfully started, false otherwise.
    */
-  gymWorkout(gymName: string, stat: string): boolean;
+  gymWorkout(gymName: string, stat: string, focus?: boolean): boolean;
 
   /**
    * Travel to another city.
@@ -1775,9 +1777,10 @@ export interface Singularity {
    * ns.createProgram(“relaysmtp.exe”);
    * ```
    * @param program - Name of program to create.
+   * @param focus - Acquire player focus on this program creation. Optional. Defaults to true.
    * @returns True if you successfully start working on the specified program, and false otherwise.
    */
-  createProgram(program: string): boolean;
+  createProgram(program: string, focus?: boolean): boolean;
 
   /**
    * Commit a crime.


### PR DESCRIPTION
This PR adds an optional `focus` parameter (defaulting to `true`) to:
* `Singularity.createProgram`
* `Singularity.gymWorkout`
* `Singularity.universityCourse`

This reflects the recent changes to the game's UI, and mirrors the implementation used in `Singularity.workForFaction/Company`.

I have also updated the declaration files with proper documentation and parameters.