### PR TITLE
Fix formatting for empty editor splash

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -846,7 +846,7 @@ export function Root(props: IProps): React.ReactElement {
         <span style={{ color: Settings.theme.primary, fontSize: "20px", textAlign: "center" }}>
           <Typography variant="h4">No open files</Typography>
           <Typography variant="h5">
-            Use `nano FILENAME` in
+            Use <code>nano FILENAME</code> in
             <br />
             the terminal to open files
           </Typography>


### PR DESCRIPTION
Updates the content of the empty editor splash page to properly render `nano FILENAME` inside of codeblocks

![image](https://user-images.githubusercontent.com/60761231/149198533-919f38ac-8afd-4e70-a8f7-8b287a38ee36.png)
