### PR TITLE
Fix steam achievement spam

### DIFF
--- a/electron/achievements.js
+++ b/electron/achievements.js
@@ -2,19 +2,25 @@
 const greenworks = require("./greenworks");
 const log = require("electron-log");
 
-function enableAchievementsInterval(window) {
+async function enableAchievementsInterval(window) {
   // If the Steam API could not be initialized on game start, we'll abort this.
   if (global.greenworksError) return;
 
    // This is backward but the game fills in an array called `document.achievements` and we retrieve it from
   // here. Hey if it works it works.
   const steamAchievements = greenworks.getAchievementNames();
+  log.info(`All Steam achievements ${JSON.stringify(steamAchievements)}`);
+  const playerAchieved = (await Promise.all(steamAchievements.map(name => new Promise((resolve, reject) => { greenworks.getAchievement(name, (playerHas) => resolve(playerHas ? name : ""), reject); })))).filter(name => !!name);
+  log.info(`Player has Steam achievements ${JSON.stringify(playerAchieved)}`);
   const intervalID = setInterval(async () => {
     try {
       const playerAchievements = await window.webContents.executeJavaScript("document.achievements");
       for (const ach of playerAchievements) {
-        if (!steamAchievements.includes(ach)) continue;
+        if (!steamAchievements.includes(ach)) continue; // Don't try activating achievements that don't exist Steam-side
+        if (playerAchieved.includes(ach)) continue;     // Don't spam achievements that have already been recorded
+        log.info(`Granting Steam achievement ${ach}`);
         greenworks.activateAchievement(ach, () => undefined);
+        playerAchieved.push(ach);
       }
     } catch (error) {
       log.error(error);

--- a/electron/achievements.js
+++ b/electron/achievements.js
@@ -10,7 +10,7 @@ async function enableAchievementsInterval(window) {
   // here. Hey if it works it works.
   const steamAchievements = greenworks.getAchievementNames();
   log.info(`All Steam achievements ${JSON.stringify(steamAchievements)}`);
-  const playerAchieved = (await Promise.all(steamAchievements.map(name => new Promise((resolve, reject) => { greenworks.getAchievement(name, (playerHas) => resolve(playerHas ? name : ""), reject); })))).filter(name => !!name);
+  const playerAchieved = (await Promise.all(steamAchievements.map(checkSteamAchievement))).filter(name => !!name);
   log.info(`Player has Steam achievements ${JSON.stringify(playerAchieved)}`);
   const intervalID = setInterval(async () => {
     try {
@@ -32,6 +32,15 @@ async function enableAchievementsInterval(window) {
     }
   }, 1000);
   window.achievementsIntervalID = intervalID;
+}
+
+function checkSteamAchievement(name) {
+  return new Promise((resolve) => {
+    greenworks.getAchievement(name, playerHas => resolve(playerHas ? name : ""), err => {
+      log.warn(`Failed to get Steam achievement ${name} status: ${err}`);
+      resolve("");
+    });
+  });
 }
 
 function disableAchievementsInterval(window) {

--- a/electron/achievements.js
+++ b/electron/achievements.js
@@ -9,9 +9,9 @@ async function enableAchievementsInterval(window) {
    // This is backward but the game fills in an array called `document.achievements` and we retrieve it from
   // here. Hey if it works it works.
   const steamAchievements = greenworks.getAchievementNames();
-  log.info(`All Steam achievements ${JSON.stringify(steamAchievements)}`);
+  log.debug(`All Steam achievements ${JSON.stringify(steamAchievements)}`);
   const playerAchieved = (await Promise.all(steamAchievements.map(checkSteamAchievement))).filter(name => !!name);
-  log.info(`Player has Steam achievements ${JSON.stringify(playerAchieved)}`);
+  log.debug(`Player has Steam achievements ${JSON.stringify(playerAchieved)}`);
   const intervalID = setInterval(async () => {
     try {
       const playerAchievements = await window.webContents.executeJavaScript("document.achievements");


### PR DESCRIPTION
Fix Steam version trying to record every achievement the player has once per second. Every duplicate achievement attempt causes Steam to record a log entry on disk, and also correlated with growing memory use in the Steam process.

The log problem can be witnessed from Steam log file `.../Steam/logs/stats_log.txt`, which fills very fast with entries like
```
[2022-01-12 19:48:55] [AppID 1812820] CAPIJobStoreUserStats::BInit() - no upload needed
[2022-01-12 19:48:55] [AppID 1812820] CAPIJobStoreUserStats::BInit() - no upload needed
[2022-01-12 19:48:58] [AppID 1812820] CAPIJobStoreUserStats::BInit() - no upload needed
```
Every attempt to record an achievement the player already has generates one such log entry.