### PR TITLE
Clear timers when unmounting CorruptableText

### DIFF
--- a/src/ui/React/CorruptableText.tsx
+++ b/src/ui/React/CorruptableText.tsx
@@ -25,20 +25,22 @@ export function CorruptableText(props: IProps): JSX.Element {
 
   useEffect(() => {
     let counter = 5;
-    const id = setInterval(() => {
+    const timers: number[] = [];
+    const intervalId = setInterval(() => {
       counter--;
       if (counter > 0) return;
       counter = Math.random() * 5;
       const index = Math.random() * content.length;
       const letter = content.charAt(index);
       setContent((content) => replace(content, index, randomize(letter)));
-      setTimeout(() => {
+      timers.push(window.setTimeout(() => {
         setContent((content) => replace(content, index, letter));
-      }, 500);
+      }, 500));
     }, 20);
 
     return () => {
-      clearInterval(id);
+      clearInterval(intervalId);
+      timers.forEach((timerId) => clearTimeout(timerId));
     };
   }, []);
 


### PR DESCRIPTION
The interval was cleared, but not the setTimeout to replace the character. Prefixes setTimeout with window otherwise Typescript thinks it's a NodeJS.Timer object.

Fixes this warning that can occur intermittently:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
CorruptableText@webpack-internal:///432:24:39
```