### PR TITLE
fix: dev menu achievement name & visibility

### DIFF
--- a/src/Achievements/AchievementData.json
+++ b/src/Achievements/AchievementData.json
@@ -479,7 +479,7 @@
     },
     "DEVMENU": {
       "ID": "DEVMENU",
-      "Name": "Exploit: edit",
+      "Name": "Exploit: you're not meant to access this",
       "Description": "Open the dev menu."
     }
   }

--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -724,6 +724,7 @@ export const achievements: IMap<Achievement> = {
   DEVMENU: {
     ...achievementData["DEVMENU"],
     Icon: "SF-1",
+    Secret: true,
     Condition: () => Player.exploits.includes(Exploit.YoureNotMeantToAccessThis),
   },
 };


### PR DESCRIPTION
Fixed dev menu exploit achievement name and set it as a secret achievement.