### PR TITLE
MISC: Add an event log to persist certain game events

### DIFF
--- a/src/Augmentation/AugmentationHelpers.tsx
+++ b/src/Augmentation/AugmentationHelpers.tsx
@@ -22,6 +22,7 @@ import {
   initUnstableCircadianModulator,
 } from "./AugmentationCreator";
 import { Router } from "../ui/GameRoot";
+import { EventLog, LogCategories, LogTypes } from "../EventLog/EventLog";
 
 export function AddToAugmentations(aug: Augmentation): void {
   const name = aug.name;
@@ -166,6 +167,7 @@ function installAugmentations(force?: boolean): boolean {
       break;
     }
   }
+  const nbAugmentations = Player.queuedAugmentations.length;
   for (let i = 0; i < Player.queuedAugmentations.length; ++i) {
     const ownedAug = Player.queuedAugmentations[i];
     const aug = Augmentations[ownedAug.name];
@@ -185,12 +187,17 @@ function installAugmentations(force?: boolean): boolean {
   }
   Player.queuedAugmentations = [];
   if (!force) {
-    dialogBoxCreate(
+    const message =
       "You slowly drift to sleep as scientists put you under in order " +
-        "to install the following Augmentations:<br>" +
-        augmentationList +
-        "<br>You wake up in your home...you feel different...",
-    );
+      "to install the following Augmentations:<br>" +
+      augmentationList +
+      "<br>You wake up in your home...you feel different...";
+    dialogBoxCreate(message);
+    EventLog.addItem(`Installed ${nbAugmentations} augmentations.`, {
+      type: LogTypes.Success,
+      category: LogCategories.Prestige,
+      description: message,
+    });
   }
   prestigeAugmentation();
   Router.toTerminal();

--- a/src/Bladeburner/ui/BladeburnerCinematic.tsx
+++ b/src/Bladeburner/ui/BladeburnerCinematic.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FactionNames } from "../../Faction/data/FactionNames";
+import { EventLog, LogCategories, LogTypes } from "../../EventLog/EventLog";
 import { use } from "../../ui/Context";
 import { CinematicText } from "../../ui/React/CinematicText";
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
@@ -33,10 +34,11 @@ export function BladeburnerCinematic(): React.ReactElement {
       ]}
       onDone={() => {
         router.toTerminal();
-        dialogBoxCreate(
+        const message =
           `Visit the National Security Agency (NSA) to apply for their ${FactionNames.Bladeburners} ` +
-            "division! You will need 100 of each combat stat before doing this.",
-        );
+          "division! You will need 100 of each combat stat before doing this.";
+        dialogBoxCreate(message);
+        EventLog.addItem(message, { type: LogTypes.Info, category: LogCategories.Prestige });
       }}
     />
   );

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -13,6 +13,7 @@ import { IPlayer } from "../PersonObjects/IPlayer";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { Reviver, Generic_toJSON, Generic_fromJSON } from "../utils/JSONReviver";
 import { isString } from "../utils/helpers/isString";
+import { EventLog, LogCategories, LogTypes } from "../EventLog/EventLog";
 
 interface IParams {
   name?: string;
@@ -112,11 +113,16 @@ export class Corporation {
           (this.avgProfit * (CorporationConstants.AvgProfitLength - 1) + profit) / CorporationConstants.AvgProfitLength;
         const cycleProfit = profit * (marketCycles * CorporationConstants.SecsPerMarketCycle);
         if (isNaN(this.funds) || this.funds === Infinity || this.funds === -Infinity) {
-          dialogBoxCreate(
+          const message =
             "There was an error calculating your Corporations funds and they got reset to 0. " +
-              "This is a bug. Please report to game developer.<br><br>" +
-              "(Your funds have been set to $150b for the inconvenience)",
-          );
+            "This is a bug. Please report to game developer.<br><br>" +
+            "(Your funds have been set to $150b for the inconvenience)";
+          dialogBoxCreate(message);
+          EventLog.addItem("Error calculating your Corporations funds", {
+            type: LogTypes.Error,
+            category: LogCategories.GameError,
+            description: `${message}`,
+          });
           this.funds = 150e9;
         }
 

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -15,6 +15,7 @@ import { Warehouse } from "./Warehouse";
 import { ICorporation } from "./ICorporation";
 import { IIndustry } from "./IIndustry";
 import { IndustryUpgrade, IndustryUpgrades } from "./IndustryUpgrades";
+import { EventLog, LogCategories, LogTypes } from "../EventLog/EventLog";
 
 interface IParams {
   name?: string;
@@ -394,10 +395,12 @@ export class Industry implements IIndustry {
     //Then calculate salaries and processs the markets
     if (state === "START") {
       if (isNaN(this.thisCycleRevenue) || isNaN(this.thisCycleExpenses)) {
-        console.error("NaN in Corporation's computed revenue/expenses");
-        dialogBoxCreate(
-          "Something went wrong when compting Corporation's revenue/expenses. This is a bug. Please report to game developer",
-        );
+        const err = "NaN in Corporation's computed revenue/expenses";
+        console.error(err);
+        const message =
+          "Something went wrong when compting Corporation's revenue/expenses. This is a bug. Please report to game developer";
+        dialogBoxCreate(message);
+        EventLog.addItem(message, { type: LogTypes.Error, category: LogCategories.GameError, description: err });
         this.thisCycleRevenue = 0;
         this.thisCycleExpenses = 0;
       }

--- a/src/DevMenu.tsx
+++ b/src/DevMenu.tsx
@@ -24,6 +24,7 @@ import { Stanek } from "./DevMenu/ui/Stanek";
 import { TimeSkip } from "./DevMenu/ui/TimeSkip";
 import { Achievements } from "./DevMenu/ui/Achievements";
 import { Entropy } from "./DevMenu/ui/Entropy";
+import { EventLogDev } from "./DevMenu/ui/EventLogDev";
 import Typography from "@mui/material/Typography";
 import { Exploit } from "./Exploits/Exploit";
 
@@ -65,6 +66,7 @@ export function DevMenuRoot(props: IProps): React.ReactElement {
       <TimeSkip player={props.player} engine={props.engine} />
       <Achievements player={props.player} engine={props.engine} />
       <Entropy player={props.player} engine={props.engine} />
+      <EventLogDev />
     </>
   );
 }

--- a/src/DevMenu/ui/EventLogDev.tsx
+++ b/src/DevMenu/ui/EventLogDev.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+
+import { EventLogObject as EventLog, getDummyData } from "../../EventLog/EventLog";
+
+export function EventLogDev(): React.ReactElement {
+  function wipeLogs(): void {
+    EventLog.clear();
+  }
+
+  function addDummy(): void {
+    EventLog.setEntries(getDummyData());
+  }
+
+  function addSpam(): void {
+    let n = 1;
+    setInterval(() => {
+      EventLog.addItem(`Entry #${n}`);
+      n++;
+    }, 2000);
+  }
+
+  return (
+    <Accordion TransitionProps={{ unmountOnExit: true }}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography>Event Log</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <table>
+          <tbody>
+            <tr>
+              <td></td>
+              <td>
+                <Typography>Achievements:</Typography>
+              </td>
+              <td>
+                <ButtonGroup>
+                  <Button onClick={wipeLogs}>Wipe All</Button>
+                  <Button onClick={addDummy}>Set Dummy</Button>
+                  <Button onClick={addSpam}>Spam Events</Button>
+                </ButtonGroup>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/src/EventLog/EventLog.tsx
+++ b/src/EventLog/EventLog.tsx
@@ -1,0 +1,270 @@
+import React from "react";
+import { ISelfInitializer, ISelfLoading } from "../types";
+
+import { Settings } from "../Settings/Settings";
+import { SourceFiles } from "../SourceFile/SourceFiles";
+import { Router } from "../ui/GameRoot";
+import { achievements } from "../Achievements/Achievements";
+
+import ErrorIcon from "@mui/icons-material/Error";
+import WarningIcon from "@mui/icons-material/Warning";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import InfoIcon from "@mui/icons-material/Info";
+
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents"; // Achievements
+import StarsIcon from "@mui/icons-material/Stars"; // Prestige
+import CodeIcon from "@mui/icons-material/Code"; // ScriptError
+import WorkIcon from "@mui/icons-material/Work"; // Jobs
+import GroupsIcon from "@mui/icons-material/Groups"; // Gangs
+import BugReportIcon from "@mui/icons-material/BugReport"; // Game Error
+
+export enum LogTypes {
+  Info,
+  Error,
+  Warning,
+  Success,
+}
+
+export enum LogCategories {
+  Misc,
+  ScriptError,
+  Achievement,
+  GameError,
+  Prestige,
+  Gangs,
+  Jobs,
+}
+
+export interface LogEntryOptions {
+  description?: string;
+  type?: LogTypes;
+  category?: LogCategories;
+  linkIdentifier?: any;
+}
+
+export interface LogEntry {
+  message: string;
+  timestamp: number;
+  description?: string;
+  type: LogTypes;
+  category: LogCategories;
+  seen?: boolean;
+  linkIdentifier?: any;
+}
+
+export interface DetailedLogEntry extends Omit<LogEntry, "description"> {
+  icon: React.ReactNode;
+  description?: React.ReactNode | string | undefined;
+  logKey: string;
+  actionHandler: (key?: any) => void;
+}
+
+export interface IEventLog {
+  addItem(message: string, options?: LogEntryOptions): void;
+  getEntries: () => LogEntry[];
+  getDetailedEntries: () => DetailedLogEntry[];
+  getEventLogUpdatedOn(): number;
+  getNumberUnseen(): number;
+  markAsSeen(): void;
+}
+
+class EventLogManager implements IEventLog, ISelfInitializer, ISelfLoading {
+  private logEntries: LogEntry[];
+  private eventLogUpdatedOn: number;
+
+  constructor() {
+    this.logEntries = [];
+    this.eventLogUpdatedOn = new Date().getTime();
+  }
+
+  addItem(message: string, options?: LogEntryOptions): void {
+    const e: LogEntry = {
+      timestamp: new Date().getTime(),
+      message: message,
+      category: options?.category ?? LogCategories.Misc,
+      type: options?.type ?? LogTypes.Error,
+      description: options?.description,
+      linkIdentifier: options?.linkIdentifier,
+    };
+    try {
+      this.logEntries = [e, ...this.logEntries].slice(0, Settings.MaxEventLogCapacity);
+      this.eventLogUpdatedOn = new Date().getTime();
+    } catch (ex) {
+      console.error(ex);
+    }
+  }
+
+  getEntries(): LogEntry[] {
+    return this.logEntries;
+  }
+
+  getDetailedEntries(): DetailedLogEntry[] {
+    return this.getEntries().map((log) => {
+      const icon = getLogIcon(log);
+      const actionHandler = getLogAction(log);
+      const detailed: DetailedLogEntry = {
+        ...log,
+        icon,
+        actionHandler,
+        description: getLogDescription(log),
+        logKey: `log_${log.timestamp}_${log.category}_${log.type}`,
+      };
+      return detailed;
+    });
+  }
+
+  getEventLogUpdatedOn(): number {
+    return this.eventLogUpdatedOn;
+  }
+
+  clear(): void {
+    this.logEntries = [];
+    this.eventLogUpdatedOn = new Date().getTime();
+  }
+
+  setEntries(entries: LogEntry[]): void {
+    this.logEntries = entries;
+  }
+
+  private getUnseen(): LogEntry[] {
+    return this.logEntries.filter((e) => !e.seen);
+  }
+
+  getNumberUnseen(): number {
+    return this.getUnseen().length;
+  }
+
+  markAsSeen(): void {
+    this.getUnseen().forEach((e) => (e.seen = true));
+  }
+
+  init(): void {
+    Object.assign(this, new EventLogManager());
+  }
+
+  load(saveString: string): void {
+    const save = JSON.parse(saveString);
+    Object.assign(this, save);
+  }
+}
+
+function getLogIcon(log: LogEntry): React.ReactNode {
+  let color = Settings.theme.primary;
+  let IconComponent;
+  switch (log.type) {
+    case LogTypes.Error:
+      color = Settings.theme.error;
+      IconComponent = ErrorIcon;
+      break;
+    case LogTypes.Success:
+      color = Settings.theme.success;
+      IconComponent = CheckCircleIcon;
+      break;
+    case LogTypes.Warning:
+      color = Settings.theme.warning;
+      IconComponent = WarningIcon;
+      break;
+    case LogTypes.Info:
+      color = Settings.theme.info;
+      IconComponent = InfoIcon;
+      break;
+  }
+
+  switch (log.category) {
+    case LogCategories.Achievement:
+      IconComponent = EmojiEventsIcon;
+      break;
+    case LogCategories.ScriptError:
+      IconComponent = CodeIcon;
+      break;
+    case LogCategories.GameError:
+      IconComponent = BugReportIcon;
+      break;
+    case LogCategories.Prestige:
+      IconComponent = StarsIcon;
+      break;
+    case LogCategories.Gangs:
+      IconComponent = GroupsIcon;
+      break;
+    case LogCategories.Jobs:
+      IconComponent = WorkIcon;
+      break;
+  }
+
+  return <IconComponent sx={{ color: color }} />;
+}
+
+function getLogAction(log: LogEntry): () => void | null {
+  let handler;
+  switch (log.category) {
+    case LogCategories.Achievement:
+      handler = () => Router.toAchievements();
+      break;
+  }
+  return handler as () => void | null;
+}
+
+function getLogDescription(log: LogEntry): React.ReactNode | string | undefined {
+  if (log.description) return log.description;
+  if (!log.linkIdentifier) return;
+  switch (log.category) {
+    case LogCategories.Achievement:
+      return achievements[log.linkIdentifier]?.Description;
+    case LogCategories.Prestige:
+      if (log.linkIdentifier.startsWith("SourceFile")) {
+        return SourceFiles[log.linkIdentifier]?.info;
+      }
+  }
+  return;
+}
+
+export const getDummyData = (): LogEntry[] => [
+  {
+    timestamp: new Date().getTime(),
+    type: LogTypes.Error,
+    category: LogCategories.ScriptError,
+    message: "Oh No! This is bad!",
+    description: `
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut iaculis libero. Ut feugiat, nisl vitae ornare hendrerit, turpis ante mollis sapien, vitae facilisis ipsum ex non ante. Nam ac neque purus. Fusce vulputate faucibus purus vitae bibendum. Vestibulum ut justo nec nisl dapibus maximus. Sed sit amet ultricies felis, at pretium sem. Nam molestie lobortis dolor et convallis. Nulla suscipit ante magna, a dapibus purus tincidunt efficitur. Cras hendrerit nunc eu dictum aliquam. In in consectetur massa. Curabitur eu eros lobortis, eleifend tellus iaculis, malesuada ipsum. Mauris egestas efficitur leo, eu dictum ante suscipit sit amet. Nulla efficitur fringilla massa, nec rutrum sapien mollis id. Vivamus quis faucibus odio.
+      <br />
+      <br />
+      <br />
+      <strong style="color: red">Lorem Ipsum</strong> dolor sit amet.
+    `,
+  },
+  {
+    timestamp: new Date().getTime() - 2344,
+    type: LogTypes.Success,
+    category: LogCategories.Achievement,
+    message: "Yay! You got an achievement!",
+    description: "You're so cool! Good job!",
+  },
+  {
+    timestamp: new Date().getTime() - 98273,
+    type: LogTypes.Error,
+    category: LogCategories.Misc,
+    message: "This is a miscellaneous error.",
+  },
+  {
+    timestamp: new Date().getTime() - 9283498,
+    type: LogTypes.Warning,
+    category: LogCategories.Misc,
+    message: "WARNING WARNING SOMETHING OCCURED",
+  },
+  {
+    timestamp: new Date().getTime() - 832748234,
+    type: LogTypes.Success,
+    category: LogCategories.Misc,
+    message: "Oh Yes! Sucess!",
+  },
+  {
+    timestamp: new Date().getTime() - 2938849389,
+    type: LogTypes.Info,
+    category: LogCategories.Misc,
+    message: "Boring information goes here.",
+  },
+];
+
+const instance = new EventLogManager();
+export const EventLog = instance as IEventLog;
+export const EventLogObject = instance;

--- a/src/EventLog/EventLogRoot.tsx
+++ b/src/EventLog/EventLogRoot.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+
+import Typography from "@mui/material/Typography";
+import { Box, Tooltip } from "@mui/material";
+
+import { EventLog } from "./EventLog";
+import { LogsList } from "./LogsList";
+import { RelativeTime } from "../ui/React/RelativeTime";
+import { OptionSwitch } from "../ui/React/OptionSwitch";
+
+export function EventLogRoot(): React.ReactElement {
+  const [updatedOn, setUpdatedOn] = useState(EventLog.getEventLogUpdatedOn());
+  const [refresh, setRefresh] = useState(true);
+  const items = EventLog.getDetailedEntries();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const logUpdate = EventLog.getEventLogUpdatedOn();
+      if (refresh && updatedOn !== logUpdate) setUpdatedOn(logUpdate);
+    }, 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [updatedOn, refresh]);
+
+  useEffect(() => {
+    EventLog.markAsSeen();
+  }, [updatedOn]);
+
+  return (
+    <Box sx={{ px: 1 }}>
+      <Tooltip
+        title={
+          <>
+            Last updated <RelativeTime initial={updatedOn} />
+          </>
+        }
+      >
+        <Typography variant="h4">Recent Game Logs</Typography>
+      </Tooltip>
+      <Box>
+        <Box sx={{ pb: 1 }}>
+          <OptionSwitch
+            checked={refresh}
+            onValueChanged={(newValue) => setRefresh(newValue)}
+            text="Auto-refresh"
+            tooltip={<>Enable or Disable auto-refresh</>}
+          />
+        </Box>
+        <LogsList logs={items} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/EventLog/LogItem.tsx
+++ b/src/EventLog/LogItem.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import Typography from "@mui/material/Typography";
+import { ListItem, ListItemIcon, ListItemText, Tooltip, Collapse, IconButton, Link } from "@mui/material";
+
+import makeStyles from "@mui/styles/makeStyles";
+import createStyles from "@mui/styles/createStyles";
+import { Settings } from "../Settings/Settings";
+
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+
+import { RelativeTime } from "../ui/React/RelativeTime";
+import { LogTypes, LogCategories, DetailedLogEntry } from "./EventLog";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    entry: {
+      "& p": {
+        color: Settings.theme.primary,
+        fontSize: "1rem",
+      },
+    },
+  }),
+);
+
+export function LogItem(log: DetailedLogEntry): React.ReactElement {
+  const classes = useStyles();
+  const [collapsed, setCollapsed] = useState(true);
+  const descriptionSectionButton = !log.description ? (
+    <></>
+  ) : (
+    <IconButton edge="end" onClick={() => setCollapsed(!collapsed)}>
+      {collapsed ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
+    </IconButton>
+  );
+  let iconTooltip = `${LogTypes[log.type]}`;
+  if (log.category !== LogCategories.Misc) iconTooltip += ` - ${LogCategories[log.category]}`;
+  return (
+    <>
+      <ListItem
+        sx={{ borderBottom: collapsed ? `1px solid ${Settings.theme.well}` : "" }}
+        secondaryAction={descriptionSectionButton}
+      >
+        <Tooltip title={iconTooltip}>
+          <ListItemIcon>{log.icon}</ListItemIcon>
+        </Tooltip>
+        <ListItemText
+          className={classes.entry}
+          secondary={
+            <RelativeTime sx={{ color: Settings.theme.secondarydark, fontSize: "0.8rem" }} initial={log.timestamp} />
+          }
+        >
+          <Typography>
+            {log.actionHandler ? (
+              <Link sx={{ cursor: "pointer" }} onClick={log.actionHandler}>
+                {log.message}
+              </Link>
+            ) : (
+              <>{log.message}</>
+            )}
+          </Typography>
+        </ListItemText>
+      </ListItem>
+      {log.description && (
+        <Collapse in={!collapsed} timeout="auto" unmountOnExit>
+          <ListItem sx={{ borderBottom: `1px solid ${Settings.theme.well}` }}>
+            <ListItemText>
+              {typeof log.description === "object" ? (
+                <>{log.description}</>
+              ) : (
+                <span dangerouslySetInnerHTML={{ __html: log.description.toString() }} />
+              )}
+            </ListItemText>
+          </ListItem>
+        </Collapse>
+      )}
+    </>
+  );
+}

--- a/src/EventLog/LogsList.tsx
+++ b/src/EventLog/LogsList.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { List, ListItem, ListItemText } from "@mui/material";
+import { Theme } from "@mui/material/styles";
+import makeStyles from "@mui/styles/makeStyles";
+import createStyles from "@mui/styles/createStyles";
+
+import { Settings } from "../Settings/Settings";
+import { LogItem } from "./LogItem";
+import { DetailedLogEntry } from "./EventLog";
+
+interface IProps {
+  logs: DetailedLogEntry[];
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    list: {
+      padding: theme.spacing(0),
+      width: "100%",
+      maxWidth: "500px",
+      border: `1px solid ${Settings.theme.welllight}`,
+    },
+  }),
+);
+
+export function LogsList({ logs }: IProps): React.ReactElement {
+  const classes = useStyles();
+  const items = logs.map((log) => {
+    return <LogItem key={log.logKey} {...log} />;
+  });
+  return (
+    <List dense className={classes.list}>
+      {items.length > 0 ? (
+        items
+      ) : (
+        <ListItem>
+          <ListItemText>No events occured yet...</ListItemText>
+        </ListItem>
+      )}
+    </List>
+  );
+}

--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -26,6 +26,7 @@ import { WorkerScript } from "../Netscript/WorkerScript";
 import { IPlayer } from "../PersonObjects/IPlayer";
 import { PowerMultiplier } from "./data/power";
 import { IGang } from "./IGang";
+import { EventLog, LogCategories, LogTypes } from "../EventLog/EventLog";
 
 export class Gang implements IGang {
   facName: string;
@@ -346,7 +347,10 @@ export class Gang implements IGang {
 
     // Notify of death
     if (this.notifyMemberDeath) {
-      dialogBoxCreate(`${member.name} was killed in a gang clash! You lost ${lostRespect} respect`);
+      const killed = `${member.name} was killed in a gang clash!`;
+      const loss = `You lost ${lostRespect} respect`;
+      dialogBoxCreate(`${killed} ${loss}`);
+      EventLog.addItem(killed, { type: LogTypes.Warning, category: LogCategories.Gangs, description: loss });
     }
   }
 

--- a/src/Gang/ui/GangMemberList.tsx
+++ b/src/Gang/ui/GangMemberList.tsx
@@ -45,7 +45,7 @@ export function GangMemberList(): React.ReactElement {
       />
       <OptionSwitch
         checked={ascendOnly}
-        onChange={(newValue) => setAscendOnly(newValue)}
+        onValueChanged={(newValue: boolean) => setAscendOnly(newValue)}
         text="Show only ascendable"
         tooltip={<>Filter the members list by whether or not the member can be ascended.</>}
       />

--- a/src/Hacknet/HacknetNode.ts
+++ b/src/Hacknet/HacknetNode.ts
@@ -19,6 +19,7 @@ import { HacknetNodeConstants } from "./data/Constants";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { Generic_fromJSON, Generic_toJSON, Reviver } from "../utils/JSONReviver";
 import { ObjectValidator, minMax } from "../utils/Validator";
+import { EventLog, LogCategories, LogTypes } from "../EventLog/EventLog";
 
 export class HacknetNode implements IHacknetNode {
   static validationData: ObjectValidator<HacknetNode> = {
@@ -116,7 +117,9 @@ export class HacknetNode implements IHacknetNode {
     this.moneyGainRatePerSecond = calculateMoneyGainRate(this.level, this.ram, this.cores, prodMult);
     if (isNaN(this.moneyGainRatePerSecond)) {
       this.moneyGainRatePerSecond = 0;
-      dialogBoxCreate("Error in calculating Hacknet Node production. Please report to game developer");
+      const message = "Error in calculating Hacknet Node production. Please report to game developer";
+      dialogBoxCreate(message);
+      EventLog.addItem(message, { type: LogTypes.Error, category: LogCategories.GameError });
     }
   }
 

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -14,6 +14,7 @@ import { compareArrays } from "../utils/helpers/compareArrays";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { AddRecentScript } from "./RecentScripts";
 import { Player } from "../Player";
+import { EventLog, LogCategories, LogTypes } from "../EventLog/EventLog";
 
 export function killWorkerScript(runningScriptObj: RunningScript, hostname: string, rerenderUi?: boolean): boolean;
 export function killWorkerScript(workerScript: WorkerScript): boolean;
@@ -73,9 +74,14 @@ function stopAndCleanUpWorkerScript(workerScript: WorkerScript, rerenderUi = tru
     try {
       workerScript.atExit();
     } catch (e: any) {
-      dialogBoxCreate(
-        `Error trying to call atExit for script ${workerScript.name} on ${workerScript.hostname} ${workerScript.scriptRef.args} ${e}`,
-      );
+      const message = `Error trying to call atExit for script ${workerScript.name} on ${workerScript.hostname} ${workerScript.scriptRef.args} ${e}`;
+      dialogBoxCreate(message);
+
+      EventLog.addItem("Error calling atExit", {
+        type: LogTypes.Error,
+        category: LogCategories.ScriptError,
+        description: message,
+      });
     }
     workerScript.atExit = undefined;
   }

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -66,6 +66,7 @@ import { SnackbarEvents, ToastVariant } from "../../ui/React/Snackbar";
 import { calculateClassEarnings } from "../formulas/work";
 import { achievements } from "../../Achievements/Achievements";
 import { FactionNames } from "../../Faction/data/FactionNames";
+import { EventLog, LogTypes, LogCategories } from "../../EventLog/EventLog";
 
 export function init(this: IPlayer): void {
   /* Initialize Player's home computer */
@@ -1318,7 +1319,11 @@ export function finishCreateProgramWork(this: IPlayer, cancelled: boolean): stri
   if (!cancelled) {
     //Complete case
     this.gainIntelligenceExp((CONSTANTS.IntelligenceProgramBaseExpGain * this.timeWorked) / 1000);
-    dialogBoxCreate(`You've finished creating ${programName}!<br>The new program can be found on your home computer.`);
+
+    const message = `You've finished creating ${programName}!`;
+    const details = "The new program can be found on your home computer.";
+    dialogBoxCreate(`${message}<br>${details}`);
+    EventLog.addItem(message, { type: LogTypes.Info, category: LogCategories.Misc, description: details });
 
     if (!this.getHomeComputer().programs.includes(programName)) {
       this.getHomeComputer().programs.push(programName);
@@ -1824,7 +1829,13 @@ export function applyForJob(this: IPlayer, entryPosType: CompanyPosition, sing =
   this.companyName = this.location;
 
   if (!sing) {
-    dialogBoxCreate("Congratulations! You were offered a new job at " + this.companyName + " as a " + pos.name + "!");
+    const message = "Congratulations! You were offered a new job at " + this.companyName + " as a " + pos.name + "!";
+    dialogBoxCreate(message);
+    EventLog.addItem(`Promotion to ${pos.name} at "${this.companyName}"`, {
+      type: LogTypes.Info,
+      category: LogCategories.Jobs,
+      description: message,
+    });
   }
   return true;
 }
@@ -2716,6 +2727,12 @@ export function giveAchievement(this: IPlayer, achievementId: string): void {
   if (!this.achievements.map((a) => a.ID).includes(achievementId)) {
     this.achievements.push({ ID: achievementId, unlockedOn: new Date().getTime() });
     SnackbarEvents.emit(`Unlocked Achievement: "${achievement.Name}"`, ToastVariant.SUCCESS, 2000);
+    EventLog.addItem(`Unlocked Achievement: "${achievement.Name}"`, {
+      type: LogTypes.Success,
+      category: LogCategories.Achievement,
+      description: achievement.Description,
+      linkIdentifier: achievement.ID,
+    });
   }
 }
 

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -32,6 +32,7 @@ import { ProgramsSeen } from "./Programs/ui/ProgramsRoot";
 import { InvitationsSeen } from "./Faction/ui/FactionsRoot";
 import { CONSTANTS } from "./Constants";
 import { LogBoxClearEvents } from "./ui/React/LogBoxManager";
+import { EventLog, LogCategories, LogTypes } from "./EventLog/EventLog";
 
 const BitNode8StartingMoney = 250e6;
 
@@ -254,10 +255,15 @@ export function prestigeSourceFile(flume: boolean): void {
   // BitNode 3: Corporatocracy
   if (Player.bitNodeN === 3) {
     homeComp.messages.push(LiteratureNames.CorporationManagementHandbook);
-    dialogBoxCreate(
+    const message =
       "You received a copy of the Corporation Management Handbook on your home computer. " +
-        "Read it if you need help getting started with Corporations!",
-    );
+      "Read it if you need help getting started with Corporations!";
+    dialogBoxCreate(message);
+    EventLog.addItem("Corporation Management Handbook", {
+      type: LogTypes.Info,
+      category: LogCategories.Prestige,
+      description: message,
+    });
   }
 
   // BitNode 8: Ghost of Wall Street
@@ -271,11 +277,15 @@ export function prestigeSourceFile(flume: boolean): void {
 
   // Bit Node 10: Digital Carbon
   if (Player.bitNodeN === 10) {
-    dialogBoxCreate("Visit VitaLife in New Tokyo if you'd like to purchase a new sleeve!");
+    const message = "Visit VitaLife in New Tokyo if you'd like to purchase a new sleeve!";
+    dialogBoxCreate(message);
+    EventLog.addItem(message, { type: LogTypes.Info, category: LogCategories.Prestige });
   }
 
   if (Player.bitNodeN === 13) {
-    dialogBoxCreate(`Trouble is brewing in ${CityName.Chongqing}`);
+    const message = `Trouble is brewing in ${CityName.Chongqing}`;
+    dialogBoxCreate(message);
+    EventLog.addItem(message, { type: LogTypes.Info, category: LogCategories.Prestige });
   }
 
   // Reset Stock market, gang, and corporation

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -2,6 +2,7 @@
  * Implementation for what happens when you destroy a BitNode
  */
 import React from "react";
+import { EventLog, LogCategories, LogTypes } from "./EventLog/EventLog";
 import { Player } from "./Player";
 import { prestigeSourceFile } from "./Prestige";
 import { PlayerOwnedSourceFile } from "./SourceFile/PlayerOwnedSourceFile";
@@ -32,18 +33,27 @@ function giveSourceFile(bitNodeNumber: number): void {
 
   if (alreadyOwned && ownedSourceFile) {
     if (ownedSourceFile.lvl >= 3 && ownedSourceFile.n !== 12) {
-      dialogBoxCreate(
-        `The Source-File for the BitNode you just destroyed, ${sourceFile.name}, is already at max level!`,
-      );
+      const message = `The Source-File for the BitNode you just destroyed, ${sourceFile.name}, is already at max level!`;
+      dialogBoxCreate(message);
+      EventLog.addItem(message, {
+        type: LogTypes.Warning,
+        category: LogCategories.Prestige,
+        linkIdentifier: sourceFileKey,
+      });
     } else {
       ++ownedSourceFile.lvl;
-      dialogBoxCreate(
+      const message =
         sourceFile.name +
-          " was upgraded to level " +
-          ownedSourceFile.lvl +
-          " for " +
-          "destroying its corresponding BitNode!",
-      );
+        " was upgraded to level " +
+        ownedSourceFile.lvl +
+        " for " +
+        "destroying its corresponding BitNode!";
+      dialogBoxCreate(message);
+      EventLog.addItem(`${sourceFile.name} was upgraded to level ${ownedSourceFile.lvl}`, {
+        type: LogTypes.Success,
+        category: LogCategories.Prestige,
+        linkIdentifier: sourceFileKey,
+      });
     }
   } else {
     const playerSrcFile = new PlayerOwnedSourceFile(bitNodeNumber, 1);
@@ -52,7 +62,7 @@ function giveSourceFile(bitNodeNumber: number): void {
       // Artificial Intelligence
       Player.intelligence = 1;
     }
-    dialogBoxCreate(
+    const message = (
       <>
         You received a Source-File for destroying a BitNode!
         <br />
@@ -61,8 +71,14 @@ function giveSourceFile(bitNodeNumber: number): void {
         <br />
         <br />
         {sourceFile.info}
-      </>,
+      </>
     );
+    dialogBoxCreate(message);
+    EventLog.addItem(`You received ${sourceFile.name} for destroying a BitNode!`, {
+      type: LogTypes.Success,
+      category: LogCategories.Prestige,
+      linkIdentifier: sourceFileKey,
+    });
   }
 }
 

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -24,6 +24,7 @@ import { LocationName } from "./Locations/data/LocationNames";
 import { SxProps } from "@mui/system";
 import { PlayerObject } from "./PersonObjects/Player/PlayerObject";
 import { pushGameSaved } from "./Electron";
+import { EventLogObject as EventLog } from "./EventLog/EventLog";
 
 /* SaveObject.js
  *  Defines the object used to save/load games
@@ -72,6 +73,8 @@ class BitburnerSaveObject {
   AllGangsSave = "";
   LastExportBonus = "";
   StaneksGiftSave = "";
+  EventLogSave = "";
+  SaveTimestamp = "";
 
   getSaveString(excludeRunningScripts = false): string {
     this.PlayerSave = JSON.stringify(Player);
@@ -86,6 +89,8 @@ class BitburnerSaveObject {
     this.VersionSave = JSON.stringify(CONSTANTS.VersionNumber);
     this.LastExportBonus = JSON.stringify(ExportBonus.LastExportBonus);
     this.StaneksGiftSave = JSON.stringify(staneksGift);
+    this.EventLogSave = JSON.stringify(EventLog);
+    this.SaveTimestamp = new Date().getTime().toString();
 
     if (Player.inGang()) {
       this.AllGangsSave = JSON.stringify(AllGangs);
@@ -473,6 +478,14 @@ function loadGame(saveString: string): boolean {
       loadAllGangs(saveObj.AllGangsSave);
     } catch (e) {
       console.error("ERROR: Failed to parse AllGangsSave: " + e);
+    }
+  }
+  if (saveObj.hasOwnProperty("EventLogSave")) {
+    try {
+      EventLog.load(saveObj.EventLogSave);
+    } catch (e) {
+      console.error("ERROR: Failed to parse Event Logs. Re-initing default values");
+      EventLog.init();
     }
   }
   if (saveObj.hasOwnProperty("VersionSave")) {

--- a/src/ScriptEditor/ui/ThemeEditorModal.tsx
+++ b/src/ScriptEditor/ui/ThemeEditorModal.tsx
@@ -101,7 +101,7 @@ export function ThemeEditorModal(props: IProps): React.ReactElement {
       <Paper sx={{ p: 1, my: 1 }}>
         <OptionSwitch
           checked={themeCopy.base === "vs"}
-          onChange={(val) => {
+          onValueChanged={(val) => {
             setThemeCopy(_.set(themeCopy, "base", val ? "vs" : "vs-dark"));
             rerender();
           }}

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -85,6 +85,11 @@ interface IDefaultSettings {
   MaxTerminalCapacity: number;
 
   /**
+   * Limit the number of event log entries kept in memory
+   */
+  MaxEventLogCapacity: number;
+
+  /**
    * Save the game when you save any file.
    */
   SaveGameOnFileSave: boolean;
@@ -206,6 +211,7 @@ export const defaultSettings: IDefaultSettings = {
   MaxLogCapacity: 50,
   MaxPortCapacity: 50,
   MaxTerminalCapacity: 500,
+  MaxEventLogCapacity: 100,
   SaveGameOnFileSave: true,
   SuppressBuyAugmentationConfirmation: false,
   SuppressFactionInvites: false,
@@ -246,6 +252,7 @@ export const Settings: ISettings & ISelfInitializer & ISelfLoading = {
   MaxLogCapacity: defaultSettings.MaxLogCapacity,
   MaxPortCapacity: defaultSettings.MaxPortCapacity,
   MaxTerminalCapacity: defaultSettings.MaxTerminalCapacity,
+  MaxEventLogCapacity: defaultSettings.MaxEventLogCapacity,
   OwnedAugmentationsOrder: OwnedAugmentationsOrderSetting.AcquirementTime,
   PurchaseAugmentationsOrder: PurchaseAugmentationsOrderSetting.Default,
   SaveGameOnFileSave: defaultSettings.SaveGameOnFileSave,

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -39,6 +39,7 @@ import HelpIcon from "@mui/icons-material/Help"; // Tutorial
 import SettingsIcon from "@mui/icons-material/Settings"; // options
 import DeveloperBoardIcon from "@mui/icons-material/DeveloperBoard"; // Dev
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents"; // Achievements
+import FeedIcon from "@mui/icons-material/Feed"; // Logs
 import AccountBoxIcon from "@mui/icons-material/AccountBox";
 import PublicIcon from "@mui/icons-material/Public";
 import LiveHelpIcon from "@mui/icons-material/LiveHelp";
@@ -55,6 +56,7 @@ import { AugmentationNames } from "../../Augmentation/data/AugmentationNames";
 
 import { ProgramsSeen } from "../../Programs/ui/ProgramsRoot";
 import { InvitationsSeen } from "../../Faction/ui/FactionsRoot";
+import { EventLog } from "../../EventLog/EventLog";
 import { hash } from "../../hash/hash";
 
 const openedMixin = (theme: Theme): CSSObject => ({
@@ -164,6 +166,8 @@ export function SidebarRoot(props: IProps): React.ReactElement {
   const canBladeburner = !!(props.player.bladeburner as any);
   const canStaneksGift = props.player.augmentations.some((aug) => aug.name === AugmentationNames.StaneksGift1);
 
+  const unseenEvents = EventLog.getNumberUnseen();
+
   function clickTerminal(): void {
     props.router.toTerminal();
     if (flashTerminal) iTutorialNextStep();
@@ -255,6 +259,10 @@ export function SidebarRoot(props: IProps): React.ReactElement {
 
   function clickAchievements(): void {
     props.router.toAchievements();
+  }
+
+  function clickLogs(): void {
+    props.router.toEventLog();
   }
 
   useEffect(() => {
@@ -799,6 +807,26 @@ export function SidebarRoot(props: IProps): React.ReactElement {
               <Typography color={flashTutorial ? "error" : props.page !== Page.Tutorial ? "secondary" : "primary"}>
                 Tutorial
               </Typography>
+            </ListItemText>
+          </ListItem>
+          <ListItem
+            button
+            key={"Logs"}
+            className={clsx({
+              [classes.active]: props.page === Page.Achievements,
+            })}
+            onClick={clickLogs}
+          >
+            <ListItemIcon>
+              <Badge
+                badgeContent={unseenEvents !== 0 ? unseenEvents : undefined}
+                color={props.page !== Page.EventLog ? "primary" : "secondary"}
+              >
+                <FeedIcon color={props.page !== Page.EventLog ? "secondary" : "primary"} />
+              </Badge>
+            </ListItemIcon>
+            <ListItemText>
+              <Typography color={props.page !== Page.EventLog ? "secondary" : "primary"}>Event Log</Typography>
             </ListItemText>
           </ListItem>
           <ListItem

--- a/src/UncaughtPromiseHandler.ts
+++ b/src/UncaughtPromiseHandler.ts
@@ -1,4 +1,5 @@
 import { ScriptDeath } from "./Netscript/ScriptDeath";
+import { EventLog, LogCategories, LogTypes } from "./EventLog/EventLog";
 import { isScriptErrorMessage } from "./NetscriptEvaluator";
 import { dialogBoxCreate } from "./ui/React/DialogBox";
 
@@ -14,11 +15,21 @@ export function setupUncaughtPromiseHandler(): void {
       msg += "<br>";
       msg += errorMsg;
       dialogBoxCreate(msg);
+      EventLog.addItem(`UNCAUGHT PROMISE ERROR in ${scriptName}@${hostname}`, {
+        type: LogTypes.Warning,
+        category: LogCategories.ScriptError,
+        description: msg,
+      });
     } else if (e.reason instanceof ScriptDeath) {
       const msg =
         `UNCAUGHT PROMISE ERROR<br>You forgot to await a promise<br>${e.reason.name}@${e.reason.hostname} (PID - ${e.reason.pid})<br>` +
         `Maybe hack / grow / weaken ?`;
       dialogBoxCreate(msg);
+      EventLog.addItem(`UNCAUGHT PROMISE ERROR in ${e.reason.name}@${e.reason.hostname}`, {
+        type: LogTypes.Warning,
+        category: LogCategories.ScriptError,
+        description: msg,
+      });
     }
   });
 }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -88,6 +88,7 @@ import _wrap from "lodash/wrap";
 import _functions from "lodash/functions";
 import { Apr1 } from "./Apr1";
 import { EventLogRoot } from "../EventLog/EventLogRoot";
+import { EventLog, LogCategories, LogTypes } from "../EventLog/EventLog";
 
 const htmlLocation = location;
 
@@ -316,6 +317,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
   function softReset(): void {
     dialogBoxCreate("Soft Reset!");
     installAugmentations(true);
+    EventLog.addItem(`Your run has been soft-reset.`, { type: LogTypes.Info, category: LogCategories.Misc });
     resetErrorBoundary();
     Router.toTerminal();
   }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -87,6 +87,7 @@ import { BypassWrapper } from "./React/BypassWrapper";
 import _wrap from "lodash/wrap";
 import _functions from "lodash/functions";
 import { Apr1 } from "./Apr1";
+import { EventLogRoot } from "../EventLog/EventLogRoot";
 
 const htmlLocation = location;
 
@@ -150,6 +151,7 @@ export let Router: IRouter = {
   toAchievements: uninitialized,
   toThemeBrowser: uninitialized,
   toImportSave: uninitialized,
+  toEventLog: uninitialized,
 };
 
 function determineStartPage(player: IPlayer): Page {
@@ -282,6 +284,9 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       setImportString(base64save);
       setImportAutomatic(automatic);
       setPage(Page.ImportSave);
+    },
+    toEventLog: () => {
+      setPage(Page.EventLog);
     },
   };
 
@@ -502,6 +507,9 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     }
     case Page.ThemeBrowser: {
       mainPage = <ThemeBrowser router={Router} />;
+    }
+    case Page.EventLog: {
+      mainPage = <EventLogRoot />;
       break;
     }
     case Page.ImportSave: {

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -213,7 +213,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SuppressMessages}
-                onChange={(newValue) => (Settings.SuppressMessages = newValue)}
+                onValueChanged={(newValue) => (Settings.SuppressMessages = newValue)}
                 text="Suppress story messages"
                 tooltip={
                   <>
@@ -227,7 +227,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SuppressFactionInvites}
-                onChange={(newValue) => (Settings.SuppressFactionInvites = newValue)}
+                onValueChanged={(newValue) => (Settings.SuppressFactionInvites = newValue)}
                 text="Suppress faction invites"
                 tooltip={
                   <>
@@ -240,7 +240,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SuppressTravelConfirmation}
-                onChange={(newValue) => (Settings.SuppressTravelConfirmation = newValue)}
+                onValueChanged={(newValue) => (Settings.SuppressTravelConfirmation = newValue)}
                 text="Suppress travel confirmations"
                 tooltip={
                   <>
@@ -253,7 +253,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SuppressBuyAugmentationConfirmation}
-                onChange={(newValue) => (Settings.SuppressBuyAugmentationConfirmation = newValue)}
+                onValueChanged={(newValue) => (Settings.SuppressBuyAugmentationConfirmation = newValue)}
                 text="Suppress augmentations confirmation"
                 tooltip={<>If this is set, the confirmation message before buying augmentation will not show up.</>}
               />
@@ -261,7 +261,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SuppressTIXPopup}
-                onChange={(newValue) => (Settings.SuppressTIXPopup = newValue)}
+                onValueChanged={(newValue) => (Settings.SuppressTIXPopup = newValue)}
                 text="Suppress TIX messages"
                 tooltip={<>If this is set, the stock market will never create any popup.</>}
               />
@@ -270,7 +270,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
               <ListItem>
                 <OptionSwitch
                   checked={Settings.SuppressBladeburnerPopup}
-                  onChange={(newValue) => (Settings.SuppressBladeburnerPopup = newValue)}
+                  onValueChanged={(newValue) => (Settings.SuppressBladeburnerPopup = newValue)}
                   text="Suppress bladeburner popup"
                   tooltip={
                     <>
@@ -284,7 +284,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SuppressSavedGameToast}
-                onChange={(newValue) => (Settings.SuppressSavedGameToast = newValue)}
+                onValueChanged={(newValue) => (Settings.SuppressSavedGameToast = newValue)}
                 text="Suppress Auto-Save Game Toast"
                 tooltip={<>If this is set, there will be no "Game Saved!" toast appearing after an auto-save.</>}
               />
@@ -292,7 +292,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SuppressAutosaveDisabledWarnings}
-                onChange={(newValue) => (Settings.SuppressAutosaveDisabledWarnings = newValue)}
+                onValueChanged={(newValue) => (Settings.SuppressAutosaveDisabledWarnings = newValue)}
                 text="Suppress Auto-Save Disabled Warning"
                 tooltip={<>If this is set, there will be no warning triggered when auto-save is disabled (at 0).</>}
               />
@@ -300,7 +300,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.DisableHotkeys}
-                onChange={(newValue) => (Settings.DisableHotkeys = newValue)}
+                onValueChanged={(newValue) => (Settings.DisableHotkeys = newValue)}
                 text="Disable hotkeys"
                 tooltip={
                   <>
@@ -314,7 +314,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.DisableASCIIArt}
-                onChange={(newValue) => (Settings.DisableASCIIArt = newValue)}
+                onValueChanged={(newValue) => (Settings.DisableASCIIArt = newValue)}
                 text="Disable ascii art"
                 tooltip={<>If this is set all ASCII art will be disabled.</>}
               />
@@ -322,7 +322,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.DisableTextEffects}
-                onChange={(newValue) => (Settings.DisableTextEffects = newValue)}
+                onValueChanged={(newValue) => (Settings.DisableTextEffects = newValue)}
                 text="Disable text effects"
                 tooltip={
                   <>
@@ -335,7 +335,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.DisableOverviewProgressBars}
-                onChange={(newValue) => (Settings.DisableOverviewProgressBars = newValue)}
+                onValueChanged={(newValue) => (Settings.DisableOverviewProgressBars = newValue)}
                 text="Disable Overview Progress Bars"
                 tooltip={<>If this is set, the progress bars in the character overview will be hidden.</>}
               />
@@ -343,7 +343,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.EnableBashHotkeys}
-                onChange={(newValue) => (Settings.EnableBashHotkeys = newValue)}
+                onValueChanged={(newValue) => (Settings.EnableBashHotkeys = newValue)}
                 text="Enable bash hotkeys"
                 tooltip={
                   <>
@@ -357,7 +357,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.UseIEC60027_2}
-                onChange={(newValue) => (Settings.UseIEC60027_2 = newValue)}
+                onValueChanged={(newValue) => (Settings.UseIEC60027_2 = newValue)}
                 text="Use GiB instead of GB"
                 tooltip={
                   <>
@@ -369,7 +369,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.ExcludeRunningScriptsFromSave}
-                onChange={(newValue) => (Settings.ExcludeRunningScriptsFromSave = newValue)}
+                onValueChanged={(newValue) => (Settings.ExcludeRunningScriptsFromSave = newValue)}
                 text="Exclude Running Scripts from Save"
                 tooltip={
                   <>
@@ -414,7 +414,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
             <ListItem>
               <OptionSwitch
                 checked={Settings.SaveGameOnFileSave}
-                onChange={(newValue) => (Settings.SaveGameOnFileSave = newValue)}
+                onValueChanged={(newValue) => (Settings.SaveGameOnFileSave = newValue)}
                 text="Save game on file save"
                 tooltip={<>Save your game any time a file is saved in the script editor.</>}
               />

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -6,7 +6,6 @@ import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
 import Typography from "@mui/material/Typography";
-import Slider from "@mui/material/Slider";
 import Grid from "@mui/material/Grid";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
@@ -39,6 +38,7 @@ import { formatTime } from "../../utils/helpers/formatTime";
 import { OptionSwitch } from "./OptionSwitch";
 import { ImportData, saveObject } from "../../SaveObject";
 import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFunctions";
+import { OptionSlider } from "./OptionSlider";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -63,47 +63,11 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
   const classes = useStyles();
   const importInput = useRef<HTMLInputElement>(null);
 
-  const [execTime, setExecTime] = useState(Settings.CodeInstructionRunTime);
-  const [recentScriptsSize, setRecentScriptsSize] = useState(Settings.MaxRecentScriptsCapacity);
-  const [logSize, setLogSize] = useState(Settings.MaxLogCapacity);
-  const [portSize, setPortSize] = useState(Settings.MaxPortCapacity);
-  const [terminalSize, setTerminalSize] = useState(Settings.MaxTerminalCapacity);
-  const [autosaveInterval, setAutosaveInterval] = useState(Settings.AutosaveInterval);
   const [timestampFormat, setTimestampFormat] = useState(Settings.TimestampsFormat);
   const [locale, setLocale] = useState(Settings.Locale);
   const [diagnosticOpen, setDiagnosticOpen] = useState(false);
   const [importSaveOpen, setImportSaveOpen] = useState(false);
   const [importData, setImportData] = useState<ImportData | null>(null);
-
-  function handleExecTimeChange(event: any, newValue: number | number[]): void {
-    setExecTime(newValue as number);
-    Settings.CodeInstructionRunTime = newValue as number;
-  }
-
-  function handleRecentScriptsSizeChange(event: any, newValue: number | number[]): void {
-    setRecentScriptsSize(newValue as number);
-    Settings.MaxRecentScriptsCapacity = newValue as number;
-  }
-
-  function handleLogSizeChange(event: any, newValue: number | number[]): void {
-    setLogSize(newValue as number);
-    Settings.MaxLogCapacity = newValue as number;
-  }
-
-  function handlePortSizeChange(event: any, newValue: number | number[]): void {
-    setPortSize(newValue as number);
-    Settings.MaxPortCapacity = newValue as number;
-  }
-
-  function handleTerminalSizeChange(event: any, newValue: number | number[]): void {
-    setTerminalSize(newValue as number);
-    Settings.MaxTerminalCapacity = newValue as number;
-  }
-
-  function handleAutosaveIntervalChange(event: any, newValue: number | number[]): void {
-    setAutosaveInterval(newValue as number);
-    Settings.AutosaveInterval = newValue as number;
-  }
 
   function handleLocaleChange(event: SelectChangeEvent<string>): void {
     setLocale(event.target.value as string);
@@ -164,112 +128,85 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
           <List>
             <ListItem>
               <Box display="grid" sx={{ width: "fit-content", gridTemplateColumns: "1fr 3.5fr", gap: 1 }}>
-                <Tooltip
-                  title={
-                    <Typography>
-                      The minimum number of milliseconds it takes to execute an operation in Netscript. Setting this too
-                      low can result in poor performance if you have many scripts running.
-                    </Typography>
-                  }
-                >
-                  <Typography>.script exec time (ms)</Typography>
-                </Tooltip>
-                <Slider
-                  value={execTime}
-                  onChange={handleExecTimeChange}
-                  step={1}
+                <OptionSlider
                   min={5}
                   max={100}
-                  valueLabelDisplay="auto"
-                />
-                <Tooltip
-                  title={
-                    <Typography>
-                      The maximum number of recently killed script entries being tracked. Setting this too high can
-                      cause the game to use a lot of memory.
-                    </Typography>
+                  text=".script exec time (ms)"
+                  value={Settings.CodeInstructionRunTime}
+                  onValueChanged={(newValue) => (Settings.CodeInstructionRunTime = newValue)}
+                  tooltip={
+                    <>
+                      The minimum number of milliseconds it takes to execute an operation in Netscript. Setting this too
+                      low can result in poor performance if you have many scripts running.
+                    </>
                   }
-                >
-                  <Typography>Recently killed scripts size</Typography>
-                </Tooltip>
-                <Slider
-                  value={recentScriptsSize}
-                  onChange={handleRecentScriptsSizeChange}
+                />
+                <OptionSlider
+                  value={Settings.MaxRecentScriptsCapacity}
+                  onValueChanged={(newValue) => (Settings.MaxRecentScriptsCapacity = newValue)}
                   step={25}
                   min={0}
                   max={500}
                   valueLabelDisplay="auto"
+                  text="Recently killed scripts size"
+                  tooltip={
+                    <>
+                      The maximum number of recently killed script entries being tracked. Setting this too high can
+                      cause the game to use a lot of memory.
+                    </>
+                  }
                 />
-                <Tooltip
-                  title={
-                    <Typography>
+                <OptionSlider
+                  min={20}
+                  max={500}
+                  step={20}
+                  text="Netscript log size"
+                  value={Settings.MaxLogCapacity}
+                  onValueChanged={(newValue) => (Settings.MaxLogCapacity = newValue)}
+                  tooltip={
+                    <>
                       The maximum number of lines a script's logs can hold. Setting this too high can cause the game to
                       use a lot of memory if you have many scripts running.
-                    </Typography>
+                    </>
                   }
-                >
-                  <Typography>Netscript log size</Typography>
-                </Tooltip>
-                <Slider
-                  value={logSize}
-                  onChange={handleLogSizeChange}
-                  step={20}
-                  min={20}
-                  max={500}
-                  valueLabelDisplay="auto"
                 />
-                <Tooltip
-                  title={
-                    <Typography>
-                      The maximum number of entries that can be written to a port using Netscript's write() function.
-                      Setting this too high can cause the game to use a lot of memory.
-                    </Typography>
-                  }
-                >
-                  <Typography>Netscript port size</Typography>
-                </Tooltip>
-                <Slider
-                  value={portSize}
-                  onChange={handlePortSizeChange}
-                  step={1}
+                <OptionSlider
                   min={20}
                   max={100}
-                  valueLabelDisplay="auto"
-                />
-                <Tooltip
-                  title={
-                    <Typography>
-                      The maximum number of entries that can be written to the terminal. Setting this too high can cause
-                      the game to use a lot of memory.
-                    </Typography>
+                  text="Netscript port size"
+                  value={Settings.MaxPortCapacity}
+                  onValueChanged={(newValue) => (Settings.MaxPortCapacity = newValue)}
+                  tooltip={
+                    <>
+                      The maximum number of entries that can be written to a port using Netscript's write() function.
+                      Setting this too high can cause the game to use a lot of memory.
+                    </>
                   }
-                >
-                  <Typography>Terminal capacity</Typography>
-                </Tooltip>
-                <Slider
-                  value={terminalSize}
-                  onChange={handleTerminalSizeChange}
-                  step={50}
+                />
+                <OptionSlider
                   min={50}
                   max={500}
-                  valueLabelDisplay="auto"
+                  step={50}
                   marks
-                />
-                <Tooltip
-                  title={
-                    <Typography>The time (in seconds) between each autosave. Set to 0 to disable autosave.</Typography>
+                  text="Terminal capacity"
+                  value={Settings.MaxTerminalCapacity}
+                  onValueChanged={(newValue) => (Settings.MaxTerminalCapacity = newValue)}
+                  tooltip={
+                    <>
+                      The maximum number of entries that can be written to the terminal. Setting this too high can cause
+                      the game to use a lot of memory.
+                    </>
                   }
-                >
-                  <Typography>Autosave interval (s)</Typography>
-                </Tooltip>
-                <Slider
-                  value={autosaveInterval}
-                  onChange={handleAutosaveIntervalChange}
-                  step={30}
+                />
+                <OptionSlider
                   min={0}
                   max={600}
-                  valueLabelDisplay="auto"
+                  step={30}
                   marks
+                  text="Autosave interval (s)"
+                  value={Settings.AutosaveInterval}
+                  onValueChanged={(newValue) => (Settings.AutosaveInterval = newValue)}
+                  tooltip={<>The time (in seconds) between each autosave. Set to 0 to disable autosave.</>}
                 />
               </Box>
             </ListItem>

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -199,6 +199,16 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
                   }
                 />
                 <OptionSlider
+                  min={25}
+                  max={500}
+                  step={25}
+                  marks
+                  text="Events capacity"
+                  value={Settings.MaxEventLogCapacity}
+                  onValueChanged={(newValue) => (Settings.MaxEventLogCapacity = newValue)}
+                  tooltip={<>The maximum number of entries to save in the event log.</>}
+                />
+                <OptionSlider
                   min={0}
                   max={600}
                   step={30}

--- a/src/ui/React/OptionSlider.tsx
+++ b/src/ui/React/OptionSlider.tsx
@@ -1,0 +1,31 @@
+import { Tooltip, Typography, Slider, SliderProps } from "@mui/material";
+import React, { useEffect, useState } from "react";
+
+interface IProps extends SliderProps {
+  value: number;
+  onValueChanged: (newValue: number, error?: string) => void;
+  text: React.ReactNode;
+  tooltip: React.ReactNode;
+  step?: number;
+  min: number;
+  max: number;
+}
+
+export function OptionSlider({ value, onValueChanged, text, tooltip, ...otherProps }: IProps): React.ReactElement {
+  const [sliderValue, setSliderValue] = useState(value);
+
+  function handleSliderChange(event: any, newValue: number | number[]): void {
+    setSliderValue(newValue as number);
+  }
+
+  useEffect(() => onValueChanged(sliderValue), [sliderValue]);
+
+  return (
+    <>
+      <Tooltip title={<Typography>{tooltip}</Typography>}>
+        <Typography>{text}</Typography>
+      </Tooltip>
+      <Slider value={sliderValue} onChange={handleSliderChange} valueLabelDisplay="auto" {...otherProps} />
+    </>
+  );
+}

--- a/src/ui/React/OptionSwitch.tsx
+++ b/src/ui/React/OptionSwitch.tsx
@@ -1,25 +1,25 @@
-import { FormControlLabel, Switch, Tooltip, Typography } from "@mui/material";
+import { FormControlLabel, Switch, SwitchProps, Tooltip, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
 
-interface IProps {
+interface IProps extends SwitchProps {
   checked: boolean;
-  onChange: (newValue: boolean, error?: string) => void;
+  onValueChanged: (newValue: boolean, error?: string) => void;
   text: React.ReactNode;
   tooltip: React.ReactNode;
 }
 
-export function OptionSwitch({ checked, onChange, text, tooltip }: IProps): React.ReactElement {
+export function OptionSwitch({ checked, onValueChanged, text, tooltip, ...otherProps }: IProps): React.ReactElement {
   const [value, setValue] = useState(checked);
 
   function handleSwitchChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setValue(event.target.checked);
   }
 
-  useEffect(() => onChange(value), [value]);
+  useEffect(() => onValueChanged(value), [value]);
 
   return (
     <FormControlLabel
-      control={<Switch checked={value} onChange={handleSwitchChange} />}
+      control={<Switch checked={value} onChange={handleSwitchChange} {...otherProps} />}
       label={
         <Tooltip title={<Typography>{tooltip}</Typography>}>
           <Typography>{text}</Typography>

--- a/src/ui/React/RelativeTime.tsx
+++ b/src/ui/React/RelativeTime.tsx
@@ -1,0 +1,74 @@
+import { Tooltip, Typography, TypographyProps } from "@mui/material";
+import React, { useEffect, useState } from "react";
+
+const rtf = new Intl.RelativeTimeFormat("en", {
+  localeMatcher: "best fit", // other values: "lookup"
+  numeric: "always", // other values: "auto"
+  style: "long", // other values: "short" or "narrow"
+});
+
+type UnitsMs = {
+  [key: string]: number;
+};
+
+// in miliseconds
+const units: UnitsMs = {
+  year: 24 * 60 * 60 * 1000 * 365,
+  month: (24 * 60 * 60 * 1000 * 365) / 12,
+  day: 24 * 60 * 60 * 1000,
+  hour: 60 * 60 * 1000,
+  minute: 60 * 1000,
+  second: 1000,
+};
+
+// https://stackoverflow.com/a/53800501
+export const getRelativeTime = (d1: number, d2 = new Date().getTime()): string => {
+  const elapsed: number = d1 - d2;
+
+  // "Math.abs" accounts for both "past" & "future" scenarios
+  for (const u in units) {
+    if (Math.abs(elapsed) > units[u] || u == "second") {
+      return rtf.format(Math.round(elapsed / units[u]), u as Intl.RelativeTimeFormatUnit);
+    }
+  }
+
+  return "n/a";
+};
+
+interface IProps extends TypographyProps {
+  initial: number;
+  hideTooltip?: boolean;
+  refresh?: boolean;
+}
+
+export function RelativeTime({
+  initial,
+  hideTooltip = false,
+  refresh = true,
+  ...otherProps
+}: IProps): React.ReactElement {
+  const current = new Date().getTime();
+  const [relativeTime, setRelativeTime] = useState<string>(getRelativeTime(initial, current));
+
+  useEffect(() => {
+    if (!refresh) return;
+    const interval = setInterval(() => {
+      setRelativeTime(getRelativeTime(initial, new Date().getTime()));
+    }, 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (hideTooltip) {
+    return <span>{relativeTime}</span>;
+  }
+
+  return (
+    <Tooltip title={new Date(initial).toLocaleString()}>
+      <Typography component="span" {...otherProps}>
+        {relativeTime}
+      </Typography>
+    </Tooltip>
+  );
+}

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -39,6 +39,7 @@ export enum Page {
   Achievements,
   ThemeBrowser,
   ImportSave,
+  EventLog,
 }
 
 export interface ScriptEditorRouteOptions {
@@ -88,4 +89,5 @@ export interface IRouter {
   toAchievements(): void;
   toThemeBrowser(): void;
   toImportSave(base64Save: string, automatic?: boolean): void;
+  toEventLog(): void;
 }


### PR DESCRIPTION
## Add an event log to persist certain game events

Allows errors & noteworthy events to be logged so that they are not lost
if missed by the player when AFK or when clicking away by mistake.

- Add an Event Log page listing the last events, auto-refreshed
- Add setting to select maximum event log capacity
- Refactor Options Sliders into its reusable component (OptionSlider)
- Some events may have an action to link to, like achievements
- Events can be tied to a unique key to grab dynamic data when loading the list
- Add a dev page to create dummy events, spam create & clear events
- Adds a flag to indicate if events have been seen with a counter in the
sidebar
- Log some events when certain actions are done or errors are thrown
  - When a player receives an achievement
  - When a player augments
  - When a player completes a BitNode
  - When a player gets promoted
  - When a gang member dies
  - When the player get errors trying to run bad scripts

### Testing

* Tested saving & triggering events around the game. 
* Tested with dummy events (dev menu).
* Tested on browser & electron.
* Tested with saves that had no events.
* Tested with bigger & smaller max log capacity.
* Tested extra metadata displayed for certain event types (like achievements)

### Screenshots

![firefox_AjxP9YC84O](https://user-images.githubusercontent.com/1521080/149418265-dd86af3c-1f46-44a2-aa65-a7d50c2b914c.png)

![firefox_6GXa1f1zXD](https://user-images.githubusercontent.com/1521080/149418274-352fdbc3-b170-4411-a656-4f0ea1416219.png)

![firefox_AgfjrY5YOn](https://user-images.githubusercontent.com/1521080/149418284-e3401646-83a5-4be9-804c-4a2a9486b67c.png)

![firefox_BQWgFlngQu](https://user-images.githubusercontent.com/1521080/149418280-eae6c86d-db5f-4de8-9c86-a81f8dc6fbca.png)

![firefox_tEILIK4woV](https://user-images.githubusercontent.com/1521080/149418291-11481dd0-85c4-468b-aa40-62eb77110ff0.png)


