### PR TITLE
Ignore trailing whitespace for dirty file asterisk

### DIFF
--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -118,7 +118,7 @@ export class Script {
    */
   saveScript(player: IPlayer, filename: string, code: string, hostname: string, otherScripts: Script[]): void {
     // Update code and filename
-    this.code = code.replace(/^\s+|\s+$/g, "");
+    this.code = Script.formatCode(this.code);
 
     this.filename = filename;
     this.server = hostname;
@@ -157,6 +157,15 @@ export class Script {
     // Rehash the code to ensure that hash is set properly.
     s.rehash();
     return s;
+  }
+
+  /**
+   * Formats code: Removes the starting & trailing whitespace
+   * @param {string} code - The code to format
+   * @returns The formatted code
+   */
+   static formatCode(code: string): string {
+    return code.replace(/^\s+|\s+$/g, "");
   }
 }
 

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -686,7 +686,9 @@ export function Root(props: IProps): React.ReactElement {
     const serverScript = server.scripts.find((s) => s.filename === openScript.fileName);
     if (serverScript === undefined) return " *";
 
-    return serverScript.code !== openScript.code ? " *" : "";
+    // The server code is stored with its starting & trailing whitespace removed
+    const openScriptFormatted = Script.formatCode(openScript.code);
+    return serverScript.code !== openScriptFormatted ? " *" : "";
   }
 
   // Toolbars are roughly 112px:


### PR DESCRIPTION
Saved scripts is stored on servers with its trailing newline removed, so
comparison would fail and show the file as dirty if it ended with one.

![Discord_dFwIBBukp8](https://user-images.githubusercontent.com/1521080/149499852-2afe0672-3d85-4546-9d39-28cb9db3d9b0.png)

Fixes  #2290

