### PR TITLE
Handle greenworks.init() errors gracefully

### DIFF
--- a/electron/achievements.js
+++ b/electron/achievements.js
@@ -3,6 +3,9 @@ const greenworks = require("./greenworks");
 const log = require("electron-log");
 
 function enableAchievementsInterval(window) {
+  // If the Steam API could not be initialized on game start, we'll abort this.
+  if (global.greenworksError) return;
+
    // This is backward but the game fills in an array called `document.achievements` and we retrieve it from
   // here. Hey if it works it works.
   const steamAchievements = greenworks.getAchievementNames();


### PR DESCRIPTION
Since we are only using it to track achievements, we can still launch
the game if it fails to initialize, we just have to not run the
achievements interval.

Adds a dialog that tells the user to fix the issue & restart the game to
enable achievements.

![bitburner_4YscZ9NbTD](https://user-images.githubusercontent.com/1521080/149506166-1a5f1614-2e7c-4798-b4b0-c0ddfeb46b05.png)

Could help with #2605 and maybe #1873 if the root cause is greenworks.
