### PR TITLE
ns.corporation.getDivision() should get data based on type

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -65,10 +65,10 @@ export function NetscriptCorporation(
     return corporation;
   }
 
-  function getDivision(divisionName: any): IIndustry {
+  function getDivision(divisionType: any): IIndustry {
     const corporation = getCorporation();
-    const division = corporation.divisions.find((div) => div.name === divisionName);
-    if (division === undefined) throw new Error(`No division named '${divisionName}'`);
+    const division = corporation.divisions.find((div) => div.type === divisionType);
+    if (division === undefined) throw new Error(`No division named '${divisionType}'`);
     return division;
   }
 


### PR DESCRIPTION
ns.corporation.getDivision() should get data based on the immutable value of 'type' as 'name' is defined during creation of the division.

This allows you to check via program to see if you have expanded into a division without the need of knowing what the names are, it can build the names from the static type values.

# Documentation

- DO NOT CHANGE any markdown/\*.md, these files are autogenerated from NetscriptDefinitions.d.ts and will be overwritten
- DO NOT re-generate the documentation, makes it harder to review.

# Bug fix

- Include how it was tested
- Include screenshot / gif (if possible)
