### PR TITLE
Overview skill hooks breaking change + improve tooltips

### DIFF
--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -26,6 +26,7 @@ import { BitNodeMultipliers } from "../../BitNode/BitNodeMultipliers";
 
 import { Box, Tooltip } from "@mui/material";
 import { CONSTANTS } from "../../Constants";
+import { ISkillProgress } from "src/PersonObjects/formulas/skill";
 
 interface IProps {
   save: () => void;
@@ -37,19 +38,24 @@ function Intelligence(): React.ReactElement {
   const classes = useStyles();
   if (player.intelligence === 0) return <></>;
   return (
-    <TableRow>
-      <TableCell component="th" scope="row" classes={{ root: classes.cell }}>
-        <Typography classes={{ root: classes.int }}>Int&nbsp;</Typography>
-      </TableCell>
-      <TableCell align="right" classes={{ root: classes.cell }}>
-        <Typography classes={{ root: classes.int }}>{numeralWrapper.formatSkill(player.intelligence)}</Typography>
-      </TableCell>
-      <TableCell align="right" classes={{ root: classes.cell }}>
-        <Typography id="overview-int-hook" classes={{ root: classes.int }}>
-          {/*Hook for player scripts*/}
-        </Typography>
-      </TableCell>
-    </TableRow>
+    <>
+      <TableRow>
+        <TableCell component="th" scope="row" classes={{ root: classes.cell }}>
+          <Typography classes={{ root: classes.int }}>Int&nbsp;</Typography>
+        </TableCell>
+        <TableCell align="right" classes={{ root: classes.cell }}>
+          <Typography classes={{ root: classes.int }}>{numeralWrapper.formatSkill(player.intelligence)}</Typography>
+        </TableCell>
+      </TableRow>
+
+      <TableRow>
+        <TableCell align="right" classes={{ root: classes.cell }}>
+          <Typography id="overview-int-hook" classes={{ root: classes.int }}>
+            {/*Hook for player scripts*/}
+          </Typography>
+        </TableCell>
+      </TableRow>
+    </>
   );
 }
 
@@ -275,6 +281,24 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
     player.charisma_mult * BitNodeMultipliers.CharismaLevelMultiplier,
   );
 
+  const generateTooltip = ({
+    baseExperience: min,
+    nextExperience: max,
+    currentExperience: current,
+    remainingExperience: remaining,
+    progress
+  }: ISkillProgress): React.ReactElement => {
+    return (
+      <Typography sx={{ textAlign: 'right' }}>
+        <strong>Progress:</strong>&nbsp;
+        {numeralWrapper.formatExp(current)} / {numeralWrapper.formatExp(max - min)}
+        <br />
+        <strong>Remaining:</strong>&nbsp;
+        {numeralWrapper.formatExp(remaining)} ({progress.toFixed(2)}%)
+      </Typography>
+    );
+  }
+
   return (
     <>
       <Table sx={{ display: "block", m: 1 }}>
@@ -288,6 +312,9 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
                 {numeralWrapper.formatHp(player.hp)}&nbsp;/&nbsp;{numeralWrapper.formatHp(player.max_hp)}
               </Typography>
             </TableCell>
+          </TableRow>
+
+          <TableRow>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography id="overview-hp-hook" classes={{ root: classes.hp }}>
                 {/*Hook for player scripts*/}
@@ -302,6 +329,9 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography classes={{ root: classes.money }}>{numeralWrapper.formatMoney(player.money)}</Typography>
             </TableCell>
+          </TableRow>
+
+          <TableRow>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography id="overview-money-hook" classes={{ root: classes.money }}>
                 {/*Hook for player scripts*/}
@@ -309,19 +339,22 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
             </TableCell>
           </TableRow>
 
-          <TableRow>
-            <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.hack }}>Hack&nbsp;</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.hack }}>{numeralWrapper.formatSkill(player.hacking)}</Typography>
-            </TableCell>
-          </TableRow>
+          <Tooltip title={generateTooltip(hackingProgress)}>
+            <TableRow>
+              <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.hack }}>Hack&nbsp;</Typography>
+              </TableCell>
+              <TableCell align="right" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.hack }}>{numeralWrapper.formatSkill(player.hacking)}</Typography>
+              </TableCell>
+            </TableRow>
+          </Tooltip>
           <TableRow>
             {!Settings.DisableOverviewProgressBars && (
               <StatsProgressOverviewCell progress={hackingProgress} color={theme.colors.hack} />
             )}
           </TableRow>
+
           <TableRow>
             <TableCell component="th" scope="row" classes={{ root: classes.cell }}>
               <Typography classes={{ root: classes.hack }}></Typography>
@@ -333,19 +366,16 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
             </TableCell>
           </TableRow>
 
-          <TableRow>
-            <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>Str&nbsp;</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.strength)}</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-str-hook" classes={{ root: classes.combat }}>
-                {/*Hook for player scripts*/}
-              </Typography>
-            </TableCell>
-          </TableRow>
+          <Tooltip title={generateTooltip(strengthProgress)}>
+            <TableRow>
+              <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.combat }}>Str&nbsp;</Typography>
+              </TableCell>
+              <TableCell align="right" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.strength)}</Typography>
+              </TableCell>
+            </TableRow>
+          </Tooltip>
           <TableRow>
             {!Settings.DisableOverviewProgressBars && (
               <StatsProgressOverviewCell progress={strengthProgress} color={theme.colors.combat} />
@@ -353,18 +383,23 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
-            <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>Def&nbsp;</Typography>
-            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.defense)}</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-def-hook" classes={{ root: classes.combat }}>
+              <Typography id="overview-str-hook" classes={{ root: classes.combat }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
           </TableRow>
+
+          <Tooltip title={generateTooltip(defenseProgress)}>
+            <TableRow>
+              <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.combat }}>Def&nbsp;</Typography>
+              </TableCell>
+              <TableCell align="right" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.defense)}</Typography>
+              </TableCell>
+            </TableRow>
+          </Tooltip>
           <TableRow>
             {!Settings.DisableOverviewProgressBars && (
               <StatsProgressOverviewCell progress={defenseProgress} color={theme.colors.combat} />
@@ -372,18 +407,23 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
-            <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>Dex&nbsp;</Typography>
-            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.dexterity)}</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-dex-hook" classes={{ root: classes.combat }}>
+              <Typography id="overview-def-hook" classes={{ root: classes.combat }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
           </TableRow>
+
+          <Tooltip title={generateTooltip(dexterityProgress)}>
+            <TableRow>
+              <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.combat }}>Dex&nbsp;</Typography>
+              </TableCell>
+              <TableCell align="right" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.dexterity)}</Typography>
+              </TableCell>
+            </TableRow>
+          </Tooltip>
           <TableRow>
             {!Settings.DisableOverviewProgressBars && (
               <StatsProgressOverviewCell progress={dexterityProgress} color={theme.colors.combat} />
@@ -391,18 +431,23 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
-            <TableCell component="th" scope="row" classes={{ root: classes.cell }}>
-              <Typography classes={{ root: classes.combat }}>Agi&nbsp;</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cell }}>
-              <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.agility)}</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cell }}>
-              <Typography id="overview-agi-hook" classes={{ root: classes.combat }}>
+            <TableCell align="right" classes={{ root: classes.cellNone }}>
+              <Typography id="overview-dex-hook" classes={{ root: classes.combat }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
           </TableRow>
+
+          <Tooltip title={generateTooltip(agilityProgress)}>
+            <TableRow>
+              <TableCell component="th" scope="row" classes={{ root: classes.cell }}>
+                <Typography classes={{ root: classes.combat }}>Agi&nbsp;</Typography>
+              </TableCell>
+              <TableCell align="right" classes={{ root: classes.cell }}>
+                <Typography classes={{ root: classes.combat }}>{numeralWrapper.formatSkill(player.agility)}</Typography>
+              </TableCell>
+            </TableRow>
+          </Tooltip>
           <TableRow>
             {!Settings.DisableOverviewProgressBars && (
               <StatsProgressOverviewCell progress={agilityProgress} color={theme.colors.combat} />
@@ -410,22 +455,35 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
-            <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.cha }}>Cha&nbsp;</Typography>
-            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.cha }}>{numeralWrapper.formatSkill(player.charisma)}</Typography>
+              <Typography id="overview-agi-hook" classes={{ root: classes.combat }}>
+                {/*Hook for player scripts*/}
+              </Typography>
             </TableCell>
+          </TableRow>
+
+          <Tooltip title={generateTooltip(charismaProgress)}>
+            <TableRow>
+              <TableCell component="th" scope="row" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.cha }}>Cha&nbsp;</Typography>
+              </TableCell>
+              <TableCell align="right" classes={{ root: classes.cellNone }}>
+                <Typography classes={{ root: classes.cha }}>{numeralWrapper.formatSkill(player.charisma)}</Typography>
+              </TableCell>
+            </TableRow>
+          </Tooltip>
+          <TableRow>
+            {!Settings.DisableOverviewProgressBars && (
+              <StatsProgressOverviewCell progress={charismaProgress} color={theme.colors.cha} />
+            )}
+          </TableRow>
+
+          <TableRow>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography id="overview-cha-hook" classes={{ root: classes.cha }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
-          </TableRow>
-          <TableRow>
-            {!Settings.DisableOverviewProgressBars && (
-              <StatsProgressOverviewCell progress={charismaProgress} color={theme.colors.cha} />
-            )}
           </TableRow>
 
           <Intelligence />

--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -49,8 +49,13 @@ function Intelligence(): React.ReactElement {
       </TableRow>
 
       <TableRow>
+        <TableCell id="overview-int-hook-0" component="th" scope="row" classes={{ root: classes.cell }}>
+          <Typography classes={{ root: classes.int }}>
+            {/*Hook for player scripts*/}
+          </Typography>
+        </TableCell>
         <TableCell align="right" classes={{ root: classes.cell }}>
-          <Typography id="overview-int-hook" classes={{ root: classes.int }}>
+          <Typography id="overview-int-hook-1" classes={{ root: classes.int }}>
             {/*Hook for player scripts*/}
           </Typography>
         </TableCell>
@@ -315,8 +320,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
+            <TableCell id="overview-hp-hook-0" component="th" scope="row" classes={{ root: classes.cellNone }}>
+              <Typography classes={{ root: classes.hp }}>
+                {/*Hook for player scripts*/}
+              </Typography>
+            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-hp-hook" classes={{ root: classes.hp }}>
+              <Typography id="overview-hp-hook-1" classes={{ root: classes.hp }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
@@ -332,8 +342,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
+            <TableCell id="overview-money-hook-0" component="th" scope="row" classes={{ root: classes.cellNone }}>
+              <Typography classes={{ root: classes.money }}>
+                {/*Hook for player scripts*/}
+              </Typography>
+            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-money-hook" classes={{ root: classes.money }}>
+              <Typography id="overview-money-hook-1" classes={{ root: classes.money }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
@@ -356,11 +371,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
-            <TableCell component="th" scope="row" classes={{ root: classes.cell }}>
-              <Typography classes={{ root: classes.hack }}></Typography>
+            <TableCell id="overview-hack-hook-0" component="th" scope="row" classes={{ root: classes.cell }}>
+              <Typography classes={{ root: classes.hack }}>
+                {/*Hook for player scripts*/}
+              </Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cell }}>
-              <Typography id="overview-hack-hook" classes={{ root: classes.hack }}>
+              <Typography id="overview-hack-hook-1" classes={{ root: classes.hack }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
@@ -383,8 +400,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
+            <TableCell id="overview-str-hook-0" component="th" scope="row" classes={{ root: classes.cellNone }}>
+              <Typography classes={{ root: classes.combat }}>
+                {/*Hook for player scripts*/}
+              </Typography>
+            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-str-hook" classes={{ root: classes.combat }}>
+              <Typography id="overview-str-hook-1" classes={{ root: classes.combat }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
@@ -407,8 +429,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
+            <TableCell id="overview-def-hook-0" component="th" scope="row" classes={{ root: classes.cellNone }}>
+              <Typography classes={{ root: classes.combat }}>
+                {/*Hook for player scripts*/}
+              </Typography>
+            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-def-hook" classes={{ root: classes.combat }}>
+              <Typography id="overview-def-hook-1" classes={{ root: classes.combat }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
@@ -431,8 +458,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
+            <TableCell id="overview-dex-hook-0" component="th" scope="row" classes={{ root: classes.cellNone }}>
+              <Typography classes={{ root: classes.combat }}>
+                {/*Hook for player scripts*/}
+              </Typography>
+            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-dex-hook" classes={{ root: classes.combat }}>
+              <Typography id="overview-dex-hook-1" classes={{ root: classes.combat }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
@@ -455,8 +487,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
+            <TableCell id="overview-agi-hook-0" component="th" scope="row" classes={{ root: classes.cellNone }}>
+              <Typography classes={{ root: classes.combat }}>
+                {/*Hook for player scripts*/}
+              </Typography>
+            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-agi-hook" classes={{ root: classes.combat }}>
+              <Typography id="overview-agi-hook-1" classes={{ root: classes.combat }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>
@@ -479,8 +516,13 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
           </TableRow>
 
           <TableRow>
+            <TableCell id="overview-cha-hook-0" component="th" scope="row" classes={{ root: classes.cellNone }}>
+              <Typography classes={{ root: classes.cha }}>
+                {/*Hook for player scripts*/}
+              </Typography>
+            </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography id="overview-cha-hook" classes={{ root: classes.cha }}>
+              <Typography id="overview-cha-hook-1" classes={{ root: classes.cha }}>
                 {/*Hook for player scripts*/}
               </Typography>
             </TableCell>

--- a/src/ui/React/StatsProgressBar.tsx
+++ b/src/ui/React/StatsProgressBar.tsx
@@ -1,15 +1,10 @@
 import * as React from "react";
 import LinearProgress from "@mui/material/LinearProgress";
-import { TableCell, Tooltip, Typography } from "@mui/material";
+import { TableCell } from "@mui/material";
 import { characterOverviewStyles } from "./CharacterOverview";
 import { ISkillProgress } from "src/PersonObjects/formulas/skill";
-import { numeralWrapper } from "../numeralFormat";
 
 interface IProgressProps {
-  min: number;
-  max: number;
-  current: number;
-  remaining: number;
   progress: number;
   color?: React.CSSProperties["color"];
 }
@@ -19,30 +14,18 @@ interface IStatsOverviewCellProps {
   color?: React.CSSProperties["color"];
 }
 
-export function StatsProgressBar({ min, max, current, remaining, progress, color }: IProgressProps): React.ReactElement {
-  const tooltip = (
-    <Typography sx={{ textAlign: 'right' }}>
-      <strong>Progress:</strong>&nbsp;
-      {numeralWrapper.formatExp(current)} / {numeralWrapper.formatExp(max - min)}
-      <br />
-      <strong>Remaining:</strong>&nbsp;
-      {numeralWrapper.formatExp(remaining)} ({progress.toFixed(2)}%)
-    </Typography>
-  );
-
+export function StatsProgressBar({ progress, color }: IProgressProps): React.ReactElement {
   return (
-    <Tooltip title={tooltip}>
-      <LinearProgress
-        variant="determinate"
-        value={progress}
-        sx={{
-          backgroundColor: "#111111",
-          "& .MuiLinearProgress-bar1Determinate": {
-            backgroundColor: color,
-          },
-        }}
-      />
-    </Tooltip>
+    <LinearProgress
+      variant="determinate"
+      value={progress}
+      sx={{
+        backgroundColor: "#111111",
+        "& .MuiLinearProgress-bar1Determinate": {
+          backgroundColor: color,
+        },
+      }}
+    />
   );
 }
 
@@ -57,10 +40,6 @@ export function StatsProgressOverviewCell({ progress: skill, color }: IStatsOver
       style={{ paddingBottom: "2px", position: "relative", top: "-3px" }}
     >
       <StatsProgressBar
-        min={skill.baseExperience}
-        max={skill.nextExperience}
-        current={skill.currentExperience}
-        remaining={skill.remainingExperience}
         progress={skill.progress}
         color={color}
       />


### PR DESCRIPTION
### Tooltips
Skill stat tooltips are now attached to the skill text instead of the progress bar, making it easier to hover over them, and also allowing them to be used when progress bars are disabled.

<table>
    <th>Before</th>
    <th>After</th>
    <tr>
      <td><img
          src="https://user-images.githubusercontent.com/60761231/149597109-d843297e-bc2b-4ce6-9c9f-e14c534174d6.gif">
      </td>
      <td><img
          src="https://user-images.githubusercontent.com/60761231/149597206-3333f6d2-7826-4fb9-a420-7399a086cee5.gif">
      </td>
    </tr>
  </table>

### Skill Overview Hooks (Breaking-ish Change)
Reworked the skill hooks system somewhat extensively, adding 2 separate hooks per skill (`overview-{skill}-hook-0` and `overview-{skill}-hook-1`). **This change in hook ID naming is the breaking change.**

This new system allows for hooks to be implemented in a way similar to the pre-existing extra hooks. Rather than only having one cell available, hooks can now be made in 2 cells, as shown in the image below.

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td><img
        src="https://user-images.githubusercontent.com/60761231/149596411-71c163f3-4d92-49d4-b97c-345e17a1724f.png">
    </td>
    <td><img
        src="https://user-images.githubusercontent.com/60761231/149598659-7dd4d93e-17ec-4943-9fd1-257f9823d8b7.png">
    </td>
  </tr>
</table>