### PR TITLE
DuplicationSleeve wrong info fixed

### DIFF
--- a/doc/source/advancedgameplay/sleeves.rst
+++ b/doc/source/advancedgameplay/sleeves.rst
@@ -39,8 +39,7 @@ There are two methods of obtaining Duplicate Sleeves:
 
 1. Destroy BitNode-10. Each completion give you one additional Duplicate Sleeve
 2. Purchase Duplicate Sleeves from :ref:`the faction The Covenant <gameplay_factions>`.
-   This is only available in BitNodes-10 and above, and is only available after defeating
-   BitNode-10 at least once. Sleeves purchased this way are **permanent** (they persist
+   This is only available in BitNodes-10. Sleeves purchased this way are **permanent** (they persist
    through BitNodes). You can purchase up to 5 Duplicate Sleeves from The Covenant.
 
 Synchronization


### PR DESCRIPTION
# Documentation
Currently it states that you can buy duplicate sleeves and upgrade memory in any bitnode at or above BN.10 which you can't, you can only purchase it at BN.10.

- DO NOT CHANGE any markdown/\*.md, these files are autogenerated from NetscriptDefinitions.d.ts and will be overwritten
- DO NOT re-generate the documentation, makes it harder to review.

# Bug fix
No tests or screenshots needed.

- Include how it was tested
- Include screenshot / gif (if possible)
