### PR TITLE
When saving we were not saving the script content

### DIFF
--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -118,7 +118,7 @@ export class Script {
    */
   saveScript(player: IPlayer, filename: string, code: string, hostname: string, otherScripts: Script[]): void {
     // Update code and filename
-    this.code = Script.formatCode(this.code);
+    this.code = Script.formatCode(code);
 
     this.filename = filename;
     this.server = hostname;

--- a/test/Script/Script.test.ts
+++ b/test/Script/Script.test.ts
@@ -1,0 +1,29 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { jest, describe, expect, test } from "@jest/globals";
+
+import { Script } from "../../src/Script/Script";
+import { Player } from "../../src/Player";
+
+jest.mock(`!!raw-loader!../NetscriptDefinitions.d.ts`, () => "", {
+    virtual: true,
+});
+
+const code = `/** @param {NS} ns **/
+export async function main(ns) {
+	ns.print(ns.getWeakenTime('n00dles'));
+}`;
+
+describe("Validate Save Script Works", function () {
+
+    it("Save", function () {
+        const server = "home";
+        const filename = "test.js";
+        const player = Player;
+        const script = new Script();
+        script.saveScript(player, filename, code, server, []);
+
+        expect(script.filename).toEqual(filename)
+        expect(script.code).toEqual(code)
+        expect(script.server).toEqual(server)
+    });
+});


### PR DESCRIPTION
# Documentation

- DO NOT CHANGE any markdown/\*.md, these files are autogenerated from NetscriptDefinitions.d.ts and will be overwritten
- DO NOT re-generate the documentation, makes it harder to review.

# Bug fix

In a previous PR when formatting code to remove whitespace they developer did not reference the function parameter but rather the script parameter code.  This means that the file was never saved.

- Include how it was tested
Referenced correct parameter, saved a script and executed it.

- Include screenshot / gif (if possible)
![image](https://user-images.githubusercontent.com/1381210/149606574-e99273fe-f35e-4414-9dc6-9d554fc15da9.png) 

I added a test as well,

![image](https://user-images.githubusercontent.com/1381210/149607433-1efc7f55-2d3e-457e-aaac-5f56ba8f099c.png)


Issue: #2637