### PR TITLE
Copy terminal command history into game save

### DIFF
--- a/src/PersonObjects/IPlayer.ts
+++ b/src/PersonObjects/IPlayer.ts
@@ -72,6 +72,7 @@ export interface IPlayer {
   sourceFiles: IPlayerOwnedSourceFile[];
   exploits: Exploit[];
   achievements: PlayerAchievement[];
+  terminalCommandHistory: string[];
   lastUpdate: number;
   totalPlaytime: number;
 

--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -77,6 +77,7 @@ export class PlayerObject implements IPlayer {
   sourceFiles: IPlayerOwnedSourceFile[];
   exploits: Exploit[];
   achievements: PlayerAchievement[];
+  terminalCommandHistory: string[];
   lastUpdate: number;
   totalPlaytime: number;
 
@@ -471,6 +472,7 @@ export class PlayerObject implements IPlayer {
 
     this.exploits = [];
     this.achievements = [];
+    this.terminalCommandHistory = [];
 
     this.init = generalMethods.init;
     this.prestigeAugmentation = generalMethods.prestigeAugmentation;

--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -21,6 +21,7 @@ export const TerminalHelpText: string[] = [
   "    grow                                 Spoof money in a servers bank account, increasing the amount available.",
   "    hack                                 Hack the current machine",
   "    help [command]                       Display this help text, or the help text for a command",
+  "    history [-c]                         Display the terminal history",
   "    home                                 Connect to home computer",
   "    hostname                             Displays the hostname of the machine",
   "    kill [script/pid] [args...]          Stops the specified script on the current server ",
@@ -253,6 +254,12 @@ export const HelpTexts: IMap<string[]> = {
     "    help alias",
     " ",
     "    help scan-analyze",
+    " ",
+  ],
+  history: [
+    "Usage: history [-c]",
+    " ",
+    "Without arguments, displays the terminal command history. To clear the history, pass in the '-c' argument.",
     " ",
   ],
   home: [

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -48,6 +48,7 @@ import { free } from "./commands/free";
 import { grow } from "./commands/grow";
 import { hack } from "./commands/hack";
 import { help } from "./commands/help";
+import { history } from "./commands/history";
 import { home } from "./commands/home";
 import { hostname } from "./commands/hostname";
 import { kill } from "./commands/kill";
@@ -576,6 +577,7 @@ export class Terminal implements ITerminal {
       if (this.commandHistory.length > 50) {
         this.commandHistory.splice(0, 1);
       }
+      player.terminalCommandHistory = this.commandHistory;
     }
     this.commandHistoryIndex = this.commandHistory.length;
     const allCommands = ParseCommands(commands);
@@ -785,6 +787,7 @@ export class Terminal implements ITerminal {
       grow: grow,
       hack: hack,
       help: help,
+      history: history,
       home: home,
       hostname: hostname,
       kill: kill,

--- a/src/Terminal/commands/history.ts
+++ b/src/Terminal/commands/history.ts
@@ -1,0 +1,27 @@
+import { ITerminal } from "../ITerminal";
+import { IRouter } from "../../ui/Router";
+import { IPlayer } from "../../PersonObjects/IPlayer";
+import { BaseServer } from "../../Server/BaseServer";
+
+export function history(
+  terminal: ITerminal,
+  router: IRouter,
+  player: IPlayer,
+  server: BaseServer,
+  args: (string | number | boolean)[],
+): void {
+  if (args.length === 0) {
+    terminal.commandHistory.forEach((command, index) => {
+      terminal.print(`${index.toString().padStart(2)} ${command}`);
+    });
+    return;
+  }
+  const arg = args[0] + "";
+  if (arg === "-c" || arg === "--clear") {
+    player.terminalCommandHistory = [];
+    terminal.commandHistory = [];
+    terminal.commandHistoryIndex = 1;
+  } else {
+    terminal.error("Incorrect usage of history command. usage: history [-c]");
+  }
+}

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -52,6 +52,12 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
   const [possibilities, setPossibilities] = useState<string[]>([]);
   const classes = useStyles();
 
+  // If we have no data in the current terminal history, let's initialize it from the player save
+  if (terminal.commandHistory.length === 0 && player.terminalCommandHistory.length > 0) {
+    terminal.commandHistory = player.terminalCommandHistory;
+    terminal.commandHistoryIndex = terminal.commandHistory.length;
+  }
+
   // Need to run after state updates, for example if we need to move cursor
   // *after* we modify input
   useEffect(() => {


### PR DESCRIPTION
## Copy terminal command history into game save

Copy the terminal commands into the player object so that they are saved between game reloads. Helpful while developing with hot-reload to not having to retype commands.

Adds a 'history' command to display history, and a 'history -c' command to clear it from both the current terminal & the player's save. I copied the `history` command (https://ss64.com/bash/history.html), but only implemented -c since the others seemed mostly useless.

Note that it is not cleared on BN prestige, but I believe that's fine like that since we still keep our scripts.

### Testing

Tested terminal history on game reloads, page changes, augmentation & BN prestige

### Screenshots

![firefox_NtE11SVZaQ](https://user-images.githubusercontent.com/1521080/149621261-675aa300-ecf0-498b-8b27-e01d61ad0b55.png)

![firefox_w20ha64e40](https://user-images.githubusercontent.com/1521080/149621268-d5650bbe-e02b-40b1-9999-de2a3fd03cc2.png)

![firefox_UymZY134Kt](https://user-images.githubusercontent.com/1521080/149621254-57e7a744-2bcb-4aa1-84d8-7a99d0f848d1.png)
