### PR TITLE
CORPORATION: Add STORE amount variable in sell product/material actions

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -106,11 +106,10 @@ export function SellMaterial(mat: Material, amt: string, price: string): void {
 
   //Parse quantity
   amt = amt.toUpperCase();
-  if (amt.includes("MAX") || amt.includes("PROD")) {
+  if (amt.includes("MAX") || amt.includes("PROD") || amt.includes("STORE")) {
     let q = amt.replace(/\s+/g, "");
-    q = q.replace(/[^-()\d/*+.MAXPROD]/g, "");
-    let tempQty = q.replace(/MAX/g, "1");
-    tempQty = tempQty.replace(/PROD/g, "1");
+    q = q.replace(/[^-()\d/*+.MAXPRODSTE]/g, "");
+    let tempQty = q.replace(/(MAX|PROD|STORE)/g, "1");
     try {
       tempQty = eval(tempQty);
     } catch (e) {
@@ -145,16 +144,17 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
   if (price.includes("MP")) {
     //Dynamically evaluated quantity. First test to make sure its valid
     //Sanitize input, then replace dynamic variables with arbitrary numbers
+
     price = price.replace(/\s+/g, "");
     price = price.replace(/[^-()\d/*+.MP]/g, "");
     let temp = price.replace(/MP/g, "1");
     try {
       temp = eval(temp);
     } catch (e) {
-      throw new Error("Invalid value or expression for sell quantity field: " + e);
+      throw new Error("Invalid value or expression for sell price field: " + e);
     }
     if (temp == null || isNaN(parseFloat(temp))) {
-      throw new Error("Invalid value or expression for sell quantity field.");
+      throw new Error("Invalid value or expression for sell price field.");
     }
     product.sCost = price; //Use sanitized price
   } else {
@@ -170,20 +170,19 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
 
   // Parse quantity
   amt = amt.toUpperCase();
-  if (amt.includes("MAX") || amt.includes("PROD")) {
+  if (amt.includes("MAX") || amt.includes("PROD") || amt.includes("STORE")) {
     //Dynamically evaluated quantity. First test to make sure its valid
     let qty = amt.replace(/\s+/g, "");
-    qty = qty.replace(/[^-()\d/*+.MAXPROD]/g, "");
-    let temp = qty.replace(/MAX/g, "1");
-    temp = temp.replace(/PROD/g, "1");
+    qty = qty.replace(/[^-()\d/*+.MAXPRODSTE]/g, "");
+    let temp = qty.replace(/(MAX|PROD|STORE)/g, "1");
     try {
       temp = eval(temp);
     } catch (e) {
-      throw new Error("Invalid value or expression for sell price field: " + e);
+      throw new Error("Invalid value or expression for sell quantity field: " + e);
     }
 
     if (temp == null || isNaN(parseFloat(temp))) {
-      throw new Error("Invalid value or expression for sell price field");
+      throw new Error("Invalid value or expression for sell quantity field");
     }
     if (all) {
       for (let i = 0; i < cities.length; ++i) {

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -838,6 +838,7 @@ export class Industry implements IIndustry {
                   //Dynamically evaluated
                   let tmp = (mat.sllman[1] as string).replace(/MAX/g, (maxSell + "").toUpperCase());
                   tmp = tmp.replace(/PROD/g, mat.prd + "");
+                  tmp = tmp.replace(/STORE/g, (mat.qty / (CorporationConstants.SecsPerMarketCycle * marketCycles)) + "");
                   try {
                     sellAmt = eval(tmp);
                   } catch (e) {
@@ -861,7 +862,6 @@ export class Industry implements IIndustry {
                   //Player's input value is just a number
                   sellAmt = Math.min(maxSell, mat.sllman[1] as number);
                 }
-
                 sellAmt = sellAmt * CorporationConstants.SecsPerMarketCycle * marketCycles;
                 sellAmt = Math.min(mat.qty, sellAmt);
                 if (sellAmt < 0) {
@@ -1199,6 +1199,7 @@ export class Industry implements IIndustry {
               //Sell amount is dynamically evaluated
               let tmp = product.sllman[city][1].replace(/MAX/g, (maxSell + "").toUpperCase());
               tmp = tmp.replace(/PROD/g, product.data[city][1]);
+              tmp = tmp.replace(/STORE/g, (product.data[city][0] / (CorporationConstants.SecsPerMarketCycle * marketCycles)) + '');
               try {
                 tmp = eval(tmp);
               } catch (e) {

--- a/src/Corporation/ui/SellMaterialModal.tsx
+++ b/src/Corporation/ui/SellMaterialModal.tsx
@@ -68,6 +68,10 @@ export function SellMaterialModal(props: IProps): React.ReactElement {
         of the material than you produce.
         <br />
         <br />
+        Setting the sell amount to 'STORE' can be used to retain a certain amount and sell the rest. For example, if you
+        set the amount to 'STORE-10', you will sell all material in store, but retain 10 units/second.
+        <br />
+        <br />
         When setting the sell price, you can use the 'MP' variable to designate a dynamically changing price that
         depends on the market price. For example, if you set the sell price to 'MP+10' then it will always be sold at
         $10 above the market price.

--- a/src/Corporation/ui/SellProductModal.tsx
+++ b/src/Corporation/ui/SellProductModal.tsx
@@ -80,6 +80,10 @@ export function SellProductModal(props: IProps): React.ReactElement {
         of the material than you produce.
         <br />
         <br />
+        Setting the sell amount to 'STORE' can be used to retain a certain amount and sell the rest. For example, if you
+        set the amount to 'STORE-10', you will sell all material in store, but retain 10 units/second.
+        <br />
+        <br />
         When setting the sell price, you can use the 'MP' variable to set a dynamically changing price that depends on
         the Product's estimated market price. For example, if you set it to 'MP*5' then it will always be sold at five
         times the estimated market price.


### PR DESCRIPTION
Add a feature i find annoying to be missing: retaining a certain (fixed) amount in store, either to sell later when the price is better or for materials that are used for boosting but also produced (i.e. AI Cores in software).

This adds a new variable "STORE" to the sell material and sell product dialogs which will sell all in store, it can then be used in formulas (i.e. `STORE-10` would sell all in store but keep 10/s).

Fly-by fixed the "price" and "quantity" being switched up in the error messages.

# Documentation

- DO NOT CHANGE any markdown/\*.md, these files are autogenerated from NetscriptDefinitions.d.ts and will be overwritten
- DO NOT re-generate the documentation, makes it harder to review.

# Not a Bug Fix
<img width="413" alt="image" src="https://user-images.githubusercontent.com/16539922/149625539-0ee6d6a3-7ed9-437c-a82c-e00fd4515bf2.png">

