### PR TITLE
Correction for ns.hack pro-rated security increase

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -352,7 +352,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       if (rand < hackChance) {
         // Success!
         const percentHacked = calculatePercentMoneyHacked(server, Player);
-        let maxThreadNeeded = Math.ceil((1 / percentHacked) * (server.moneyAvailable / server.moneyMax));
+        let maxThreadNeeded = Math.ceil(1 / percentHacked);
         if (isNaN(maxThreadNeeded)) {
           // Server has a 'max money' of 0 (probably). We'll set this to an arbitrarily large value
           maxThreadNeeded = 1e6;


### PR DESCRIPTION
corrects an issue where hacking with more threads than was needed to hack all remaining money from a server with availMoney < maxMoney would have irregular results on security increase.

fix for issue #2307
discord thread: https://discord.com/channels/415207508303544321/931980343970513026/931980345329479750

# Documentation

- DO NOT CHANGE any markdown/\*.md, these files are autogenerated from NetscriptDefinitions.d.ts and will be overwritten
- DO NOT re-generate the documentation, makes it harder to review.

# Bug fix

- Include how it was tested
- Include screenshot / gif (if possible)
