### PR TITLE
Add function signature for scp(files, destination)

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1081,7 +1081,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
         workerScript.log("exit", () => "Failed. This is a bug. Report to dev.");
       }
     },
-    scp: async function (scriptname: any, hostname1: any, hostname2: any): Promise<boolean> {
+    scp: async function (scriptname: any, hostname1: any, hostname2?: any): Promise<boolean> {
       updateDynamicRam("scp", getRamCost(Player, "scp"));
       if (arguments.length !== 2 && arguments.length !== 3) {
         throw makeRuntimeErrorMsg("scp", "Takes 2 or 3 arguments");

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4819,6 +4819,7 @@ export interface NS extends Singularity {
    * @param destination - Host of the destination server, which is the server to which the file will be copied.
    * @returns True if the script/literature file is successfully copied over and false otherwise. If the files argument is an array then this function will return true if at least one of the files in the array is successfully copied.
    */
+  scp(files: string | string[], destination: string): Promise<boolean>;
   scp(files: string | string[], source: string, destination: string): Promise<boolean>;
 
   /**


### PR DESCRIPTION
adds
```ts
  scp(files: string | string[], destination: string): Promise<boolean>;
```
to NetscriptDefinitions.d.ts for calling scp with source omitted
