### PR TITLE
Fix black screen caused by modifying array prototype

### DIFF
--- a/src/Locations/ui/City.tsx
+++ b/src/Locations/ui/City.tsx
@@ -132,10 +132,10 @@ function ASCIICity(props: IProps): React.ReactElement {
 
   const elems: JSX.Element[] = [];
   const lines = props.city.asciiArt.split("\n");
-  for (const i in lines) {
+  for (const i of lines) {
     elems.push(
       <Typography key={i} sx={{ lineHeight: "1em", whiteSpace: "pre" }}>
-        {lineElems(lines[i])}
+        {lineElems(i)}
       </Typography>,
     );
   }


### PR DESCRIPTION
Change from a `for ... in` loop to a `for ... of` loop.

Fixes #2647 