### PR TITLE
Fix "travel" achievement icon

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -380,7 +380,7 @@ export const achievements: IMap<Achievement> = {
   },
   TRAVEL: {
     ...achievementData["TRAVEL"],
-    Icon: "travel",
+    Icon: "TRAVEL",
     Condition: () => Player.city !== CityName.Sector12,
   },
   WORKOUT: {


### PR DESCRIPTION
Svg file name is uppercase, resulting in empty icon (due to 404) in the browser version