### PR TITLE
Fix issues with timestamps on same line as clickable script rows in `ls`

### DIFF
--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -127,7 +127,7 @@ export function ls(
     const classes = makeStyles((theme: Theme) =>
       createStyles({
         scriptLinksWrap: {
-          display: "flex",
+          display: "inline-flex",
           color: theme.palette.warning.main,
         },
         scriptLink: {


### PR DESCRIPTION
Fixes oddity with new clickable script links in `ls` command, particularly when timestamps are also enabled:

**Currently:**
![bitburner_qQvInEShj1](https://user-images.githubusercontent.com/53015256/149647339-4391d58c-d006-48be-9106-d9359d3d14ee.png)

**Updated:**
![bitburner_BOWs7zs0zC](https://user-images.githubusercontent.com/53015256/149647344-980f2d62-f69c-48c8-a8a7-993b5aa76346.png)
