### PR TITLE
Added getDarkwebProgramCost and related unit tests to the api. 

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -4794,7 +4794,10 @@ export declare interface Singularity {
      * You MUST have a TOR router in order to use this function. The price returned 
      * by this function is the same price you would see with buy -l from the terminal.
      * Returns the cost of the program if it has not been purchased yet, 0 if it 
-     * has already been purchased, or -1 if the program does not exist
+     * has already been purchased, or -1 if Tor has not been purchased (and thus
+     * the program/exploit is not available for purchase).
+     * 
+     * If the program does not exist, an error is thrown.
      * 
      *
      * @example
@@ -4809,8 +4812,8 @@ export declare interface Singularity {
      * ```
      * @param programName - Name of program to check the price of
      * @returns Floating point number representing the price of the specified darkweb program
-     * (if not yet purchased), 0 if it has already been purchased, or -1 if the specified 
-     * program/exploit does not exist
+     * (if not yet purchased), 0 if it has already been purchased, or -1 if Tor has not been 
+     * purchased. Throws an error if the specified program/exploit does not exist
      */
     getDarkwebProgramCost(programName: string): number;
 

--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -4785,6 +4785,36 @@ export declare interface Singularity {
     purchaseTor(): boolean;
 
     /**
+     * Check the price of an exploit on the dark web 
+     * @remarks
+     * RAM cost: 0.5 GB * 16/4/1
+     *
+     *
+     * This function allows you to check the price of a darkweb exploit/program. 
+     * You MUST have a TOR router in order to use this function. The price returned 
+     * by this function is the same price you would see with buy -l from the terminal.
+     * Returns the cost of the program if it has not been purchased yet, 0 if it 
+     * has already been purchased, or -1 if the program does not exist
+     * 
+     *
+     * @example
+     * ```ts
+     * // NS1
+     * getDarkwebProgramCost("brutessh.exe");
+     * ```
+     * @example
+     * ```ts
+     * // NS2
+     * ns.getDarkwebProgramCost("brutessh.exe");
+     * ```
+     * @param programName - Name of program to check the price of
+     * @returns Floating point number representing the price of the specified darkweb program
+     * (if not yet purchased), 0 if it has already been purchased, or -1 if the specified 
+     * program/exploit does not exist
+     */
+    getDarkwebProgramCost(programName: string): number;
+
+    /**
      * Purchase a program from the dark web.
      * @remarks
      * RAM cost: 2 GB * 16/4/1

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -222,6 +222,7 @@ export const RamCosts: IMap<any> = {
   manualHack: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost),
   installBackdoor: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost),
   getStats: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost / 4),
+  getDarkwebProgramCost: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost / 4),
   getCharacterInformation: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost / 4),
   hospitalize: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost / 4),
   isBusy: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost / 4),

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -558,6 +558,34 @@ export function NetscriptSingularity(
       player.gainIntelligenceExp(CONSTANTS.IntelligenceSingFnBaseExpGain / 50);
       return true;
     },
+    getDarkwebProgramCost: function (programName: any): any {
+      helper.updateDynamicRam("getDarkwebProgramCost", getRamCost(player, "getDarkwebProgramCost"));
+      helper.checkSingularityAccess("getDarkwebProgramCost");
+
+      // If we don't have Tor, log it and return -1
+      if (!player.hasTorRouter()) {
+        workerScript.log("getDarkwebProgramCost", () => "You do not have the TOR router.");
+        return -1;
+      }
+
+      programName = programName.toLowerCase();
+      const item = Object.values(DarkWebItems).find((i) => i.program.toLowerCase() === programName);
+
+      // If the program doesn't exist, throw an error. The reasoning here is that the 99% case is that
+      // the player will be using this in automation scripts, and if they're asking for a program that 
+      // doesn't exist, it's the first time they've run the script. So throw an error to let them know
+      // that they need to fix it.
+      if (item == null) {
+        throw helper.makeRuntimeErrorMsg("getDarkwebProgramCost", `No such exploit ('${programName}') found on the darkweb! ` 
+            + `\nThis function is not case-sensitive. Did you perhaps forget .exe at the end?`);
+      }
+
+      if (player.hasProgram(item.program)) {
+        workerScript.log("purchaseProgram", () => `You already have the '${item.program}' program`);
+        return 0;
+      }
+      return item.price;
+    },
     getCurrentServer: function (): any {
       helper.updateDynamicRam("getCurrentServer", getRamCost(player, "getCurrentServer"));
       helper.checkSingularityAccess("getCurrentServer");

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -565,6 +565,8 @@ export function NetscriptSingularity(
       // If we don't have Tor, log it and return -1
       if (!player.hasTorRouter()) {
         workerScript.log("getDarkwebProgramCost", () => "You do not have the TOR router.");
+        // returning -1 rather than throwing an error to be consistent with purchaseProgram
+        // which returns false if tor has 
         return -1;
       }
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -581,7 +581,7 @@ export function NetscriptSingularity(
       }
 
       if (player.hasProgram(item.program)) {
-        workerScript.log("purchaseProgram", () => `You already have the '${item.program}' program`);
+        workerScript.log("getDarkwebProgramCost", () => `You already have the '${item.program}' program`);
         return 0;
       }
       return item.price;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1549,6 +1549,36 @@ export interface Singularity {
   purchaseTor(): boolean;
 
   /**
+   * Check the price of an exploit on the dark web 
+   * @remarks
+   * RAM cost: 0.5 GB * 16/4/1
+   *
+   *
+   * This function allows you to check the price of a darkweb exploit/program. 
+   * You MUST have a TOR router in order to use this function. The price returned 
+   * by this function is the same price you would see with buy -l from the terminal.
+   * Returns the cost of the program if it has not been purchased yet, 0 if it 
+   * has already been purchased, or -1 if the program does not exist
+   * 
+   *
+   * @example
+   * ```ts
+   * // NS1
+   * getDarkwebProgramCost("brutessh.exe");
+   * ```
+   * @example
+   * ```ts
+   * // NS2
+   * ns.getDarkwebProgramCost("brutessh.exe");
+   * ```
+   * @param programName - Name of program to check the price of
+   * @returns Floating point number representing the price of the specified darkweb program
+   * (if not yet purchased), 0 if it has already been purchased, or -1 if the specified 
+   * program/exploit does not exist
+   */
+   getDarkwebProgramCost(programName: string): number;
+
+  /**
    * Purchase a program from the dark web.
    * @remarks
    * RAM cost: 2 GB * 16/4/1
@@ -1574,7 +1604,7 @@ export interface Singularity {
    */
   purchaseProgram(programName: string): boolean;
 
-  /**
+   /**
    * Check if the player is busy.
    * @remarks
    * RAM cost: 0.5 GB * 16/4/1

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1558,7 +1558,10 @@ export interface Singularity {
    * You MUST have a TOR router in order to use this function. The price returned 
    * by this function is the same price you would see with buy -l from the terminal.
    * Returns the cost of the program if it has not been purchased yet, 0 if it 
-   * has already been purchased, or -1 if the program does not exist
+   * has already been purchased, or -1 if Tor has not been purchased (and thus
+   * the program/exploit is not available for purchase).
+   * 
+   * If the program does not exist, an error is thrown.
    * 
    *
    * @example
@@ -1573,10 +1576,10 @@ export interface Singularity {
    * ```
    * @param programName - Name of program to check the price of
    * @returns Floating point number representing the price of the specified darkweb program
-   * (if not yet purchased), 0 if it has already been purchased, or -1 if the specified 
-   * program/exploit does not exist
+   * (if not yet purchased), 0 if it has already been purchased, or -1 if Tor has not been 
+   * purchased. Throws an error if the specified program/exploit does not exist
    */
-   getDarkwebProgramCost(programName: string): number;
+    getDarkwebProgramCost(programName: string): number;
 
   /**
    * Purchase a program from the dark web.

--- a/test/Netscript/DynamicRamCalculation.test.js
+++ b/test/Netscript/DynamicRamCalculation.test.js
@@ -699,6 +699,11 @@ describe("Netscript Dynamic RAM Calculation/Generation Tests", function () {
       await testNonzeroDynamicRamCost(f);
     });
 
+    it("getDarkwebProgramCost()", async function () {
+      const f = ["getDarkwebProgramCost"];
+      await testNonzeroDynamicRamCost(f);
+    });
+
     it("getStats()", async function () {
       const f = ["getStats"];
       await testNonzeroDynamicRamCost(f);

--- a/test/Netscript/StaticRamCalculation.test.js
+++ b/test/Netscript/StaticRamCalculation.test.js
@@ -637,6 +637,11 @@ describe("Netscript Static RAM Calculation/Generation Tests", function () {
       await expectNonZeroRamCost(f);
     });
 
+    it("getDarkwebProgramCost()", async function () {
+      const f = ["getDarkwebProgramCost"];
+      await expectNonZeroRamCost(f);
+    });
+
     it("getStats()", async function () {
       const f = ["getStats"];
       await expectNonZeroRamCost(f);


### PR DESCRIPTION
Gets the price of a specified darkweb program.

```js
let price = ns.getDarkwebProgramCost("brutessh.exe");
// get the price

ns.tprint(price);
// print the price to the terminal. Will output -1 if Tor has not been purchased, 
// otherwise will print 500000 if brutessh.exe has not been purchased yet, or 
// 0 if it has already been purchased. 

price = ns.getDarkwebProgramCost("bogusProgram.exe");
// throws an exception, since bogusProgram.exe isn't a darkweb program 
```

The reasoning for throwing an error if the program name is incorrect is that 99% of the time, if players get the name of the program wrong, it's probably the first time they've tried to execute the script, so giving them a big fat error will help with rapid debugging.

I followed the example of purchaseProgram in terms of the unit tests I created, and for the documentation.