### PR TITLE
Add ns.ui.getGameInfo() to retrieve game version

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -368,6 +368,7 @@ export const RamCosts: IMap<any> = {
     getStyles: 0,
     setStyles: 0,
     resetStyles: 0,
+    getGameInfo: 0,
   },
 
   heart: {

--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -2,11 +2,13 @@ import { INetscriptHelper } from "./INetscriptHelper";
 import { WorkerScript } from "../Netscript/WorkerScript";
 import { IPlayer } from "../PersonObjects/IPlayer";
 import { getRamCost } from "../Netscript/RamCostGenerator";
-import { IStyleSettings, UserInterface as IUserInterface, UserInterfaceTheme } from "../ScriptEditor/NetscriptDefinitions";
+import { GameInfo, IStyleSettings, UserInterface as IUserInterface, UserInterfaceTheme } from "../ScriptEditor/NetscriptDefinitions";
 import { Settings } from "../Settings/Settings";
 import { ThemeEvents } from "../ui/React/Theme";
 import { defaultTheme } from "../Settings/Themes";
 import { defaultStyles } from "../Settings/Styles";
+import { CONSTANTS } from "../Constants";
+import { hash } from "../hash/hash";
 
 export function NetscriptUserInterface(
   player: IPlayer,
@@ -84,6 +86,19 @@ export function NetscriptUserInterface(
       Settings.styles = { ...defaultStyles };
       ThemeEvents.emit();
       workerScript.log("ui.resetStyles", () => `Reinitialized styles to default`);
+    },
+
+    getGameInfo: function (): GameInfo {
+      helper.updateDynamicRam("getGameInfo", getRamCost(player, "ui", "getGameInfo"));
+      const version = CONSTANTS.VersionString;
+      const commit = hash();
+      const platform = (navigator.userAgent.toLowerCase().indexOf(" electron/") > -1) ? 'Steam' : 'Browser';
+
+      const gameInfo = {
+        version, commit, platform,
+      }
+
+      return gameInfo;
     }
   }
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4065,6 +4065,13 @@ interface UserInterface {
    * RAM cost: cost: 0 GB
    */
   resetStyles(): void;
+
+  /**
+   * Gets the current game information (version, commit, ...)
+   * @remarks
+   * RAM cost: 0 GB
+   */
+  getGameInfo(): GameInfo;
 }
 
 /**
@@ -6572,4 +6579,14 @@ interface UserInterfaceTheme {
 interface IStyleSettings {
   fontFamily: string;
   lineHeight: number;
+}
+
+/**
+ * Game Information
+ * @internal
+ */
+interface GameInfo {
+  version: string;
+  commit: string;
+  platform: string;
 }


### PR DESCRIPTION
## Add ns.ui.getGameInfo() to retrieve game version

Might be useful for players that want to log data externally.

Returns `{ version, commit, platform }`

### Testing

A basic script was tested to check the current version.

### Screenshots

![firefox_BaKjb9hcJp](https://user-images.githubusercontent.com/1521080/149667169-e8ed31d6-91bb-4b3c-8b6f-fdb500936f41.png)

![firefox_qx9u6xHO7q](https://user-images.githubusercontent.com/1521080/149667013-4b5e8057-a814-40bb-ba83-09e8acb49a5d.png)
