### PR TITLE
Remove duplicated 'cost' keyword for RAM cost.

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3932,7 +3932,7 @@ interface Stanek {
   /**
    * List possible fragments.
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    *
    * @returns List of possible fragments.
    */
@@ -3941,7 +3941,7 @@ interface Stanek {
   /**
    * List of fragments in Stanek's Gift.
    * @remarks
-   * RAM cost: cost: 5 GB
+   * RAM cost: 5 GB
    *
    * @returns List of active fragments placed on Stanek's Gift.
    */
@@ -3950,14 +3950,14 @@ interface Stanek {
   /**
    * Clear the board of all fragments.
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    */
   clear(): void;
 
   /**
    * Check if fragment can be placed at specified location.
    * @remarks
-   * RAM cost: cost: 0.5 GB
+   * RAM cost: 0.5 GB
    *
    * @param rootX - rootX Root X against which to align the top left of the fragment.
    * @param rootY - rootY Root Y against which to align the top left of the fragment.
@@ -3969,7 +3969,7 @@ interface Stanek {
   /**
    * Place fragment on Stanek's Gift.
    * @remarks
-   * RAM cost: cost: 5 GB
+   * RAM cost: 5 GB
    *
    * @param rootX - X against which to align the top left of the fragment.
    * @param rootY - Y against which to align the top left of the fragment.
@@ -3981,7 +3981,7 @@ interface Stanek {
   /**
    * Get placed fragment at location.
    * @remarks
-   * RAM cost: cost: 5 GB
+   * RAM cost: 5 GB
    *
    * @param rootX - X against which to align the top left of the fragment.
    * @param rootY - Y against which to align the top left of the fragment.
@@ -3992,7 +3992,7 @@ interface Stanek {
   /**
    * Remove fragment at location.
    * @remarks
-   * RAM cost: cost: 0.15 GB
+   * RAM cost: 0.15 GB
    *
    * @param rootX - X against which to align the top left of the fragment.
    * @param rootY - Y against which to align the top left of the fragment.
@@ -4009,7 +4009,7 @@ interface UserInterface {
   /**
    * Get the current theme
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    *
    * @returns An object containing the theme's colors
    */
@@ -4018,7 +4018,7 @@ interface UserInterface {
   /**
    * Sets the current theme
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    * @example
    * Usage example (NS2)
    * ```ts
@@ -4032,14 +4032,14 @@ interface UserInterface {
   /**
    * Resets the player's theme to the default values
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    */
   resetTheme(): void;
 
   /**
    * Get the current styles
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    *
    * @returns An object containing the player's styles
    */
@@ -4048,7 +4048,7 @@ interface UserInterface {
   /**
    * Sets the current styles
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    * @example
    * Usage example (NS2)
    * ```ts
@@ -4062,7 +4062,7 @@ interface UserInterface {
   /**
    * Resets the player's styles to the default values
    * @remarks
-   * RAM cost: cost: 0 GB
+   * RAM cost: 0 GB
    */
   resetStyles(): void;
 }


### PR DESCRIPTION
## Remove duplicated 'cost' keyword for RAM cost.

Only some of the entries had this, so I assume they were introduced by a bad find & replace.

### Testing

Checked the definitions in the editor.

### Screenshots

![firefox_kZ4QcmpgDy](https://user-images.githubusercontent.com/1521080/149667325-acb3791f-7af8-4971-aedc-4bd2abfd1eae.png)

