### PR TITLE
Add check for hash capacity > 0 for MAX_CACHE

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -553,7 +553,9 @@ export const achievements: IMap<Achievement> = {
     ...achievementData["MAX_CACHE"],
     Icon: "HASHNETCAP",
     Visible: () => hasAccessToSF(Player, 9),
-    Condition: () => hasHacknetServers(Player) && Player.hashManager.hashes === Player.hashManager.capacity,
+    Condition: () => hasHacknetServers(Player) &&
+      Player.hashManager.hashes === Player.hashManager.capacity &&
+      Player.hashManager.capacity > 0,
   },
   SLEEVE_8: {
     ...achievementData["SLEEVE_8"],


### PR DESCRIPTION
## Add check for hash capacity > 0 for MAX_CACHE

Achievement would trigger as soon as you entered the node as the
capacity was 0.

It looks like this fix was lost in a merge resolution (see PR #2459)

Fixes #2663

### Testing

Tested using the dev menu on a fresh save, bitflumed to start BN9 from blank state, no achievement received until you have some capacity

### Screenshots

![firefox_uWnUIEcaf9](https://user-images.githubusercontent.com/1521080/149668602-cf590e0b-ba94-476a-9fa8-357dd2282968.png)
![firefox_NUForK7NXA](https://user-images.githubusercontent.com/1521080/149668603-055f5c07-e5c6-48d4-971a-d354d0e3a83d.png)

