### PR TITLE
Shortcuts now check to see if feature is unlocked

### DIFF
--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -319,10 +319,10 @@ export function SidebarRoot(props: IProps): React.ReactElement {
       } else if (event.keyCode === KEY.U && event.altKey) {
         event.preventDefault();
         clickTutorial();
-      } else if (event.keyCode === KEY.B && event.altKey) {
+      } else if (event.keyCode === KEY.B && event.altKey && props.player.bladeburner) {
         event.preventDefault();
         clickBladeburner();
-      } else if (event.keyCode === KEY.G && event.altKey) {
+      } else if (event.keyCode === KEY.G && event.altKey && props.player.gang) {
         event.preventDefault();
         clickGang();
       }


### PR DESCRIPTION
## Shortcuts now check to see if feature is unlocked

The sidebar now checks if the Player has unlocked the features before using the router to head to the new page.
  - Check added for Bladeburner
  - Check added for Gangs

Fixes #2659
Fixes #2262 
Fixes #2669
Fixes #2117 (Could not reproduce point number 2)

### Testing

Tested both shortcuts on a save without & with the features to ensure we don't get shipped to recovery when unavailable.
Note that ALT+B is used by Firefox on Windows 10, so the Bladeburner shortcut doesn't work there.
