### PR TITLE
Fix ns.tail() behaviour for multiple calls

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -39,14 +39,12 @@ export function LogBoxManager(): React.ReactElement {
     () =>
       LogBoxEvents.subscribe((script: RunningScript) => {
         const id = script.server + "-" + script.filename + script.args.map((x: any): string => `${x}`).join("-");
-        if (logs.find((l) => l.id === id)) close(id);
-        Promise.resolve().then(() => {
-          logs.push({
-            id: id,
-            script: script,
-          });
-          rerender();
-        })
+        if (logs.find((l) => l.id === id)) return;
+        logs.push({
+          id: id,
+          script: script,
+        });
+        rerender();
       }),
     [],
   );


### PR DESCRIPTION
This reverts commit 01efd372e95628d419575ade0e6536a458fd61d2.
It reverts the behavior of 'ns.tail' to disallow several windows running for the same script. This caused weird behaviour by opening several windows which closed each other and, sometimes, windows which would then not close themselves.

This PR fixes https://github.com/danielyxie/bitburner/issues/2670

# Bug fix

- tested manually with following scripts:

aaa.js
```
export async function main(ns) {
	ns.print("Hello")
	ns.tail()
	ns.tail()
}
```

bbb.js
```
export async function main(ns) {
	ns.print("BBb")
	ns.tail()
	var a = ns.run("aaa.js")
	ns.tail(a)
}
```
