### PR TITLE
Change job shortcut test to match sidebar item

### DIFF
--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -297,7 +297,7 @@ export function SidebarRoot(props: IProps): React.ReactElement {
       } else if (event.keyCode === KEY.W && event.altKey) {
         event.preventDefault();
         clickCity();
-      } else if (event.keyCode === KEY.J && event.altKey && !event.ctrlKey && !event.metaKey && props.player.hasJob()) {
+      } else if (event.keyCode === KEY.J && event.altKey && !event.ctrlKey && !event.metaKey && canJob) {
         // ctrl/cmd + alt + j is shortcut to open Chrome dev tools
         event.preventDefault();
         clickJob();


### PR DESCRIPTION
## Change job shortcut test to match sidebar item

I switched it to match the same condition as the sidebar menu item, 
which checks for `player.companyName` that should be set to the
latest company the player worked at. 

This can prevent a crash loading the jobs page with an invalid `companyName`.

This fixes a problem a user had where the `player.companyName` was empty
while actually having items in `player.jobs`, but I could not figure out how
to replicate. It may have had something to do with part-time jobs.

Fixes #2450

### Testing
Tested using the save game from #2450, screenshots are from that save.

### Screenshots

![firefox_xPXzDZjGq9](https://user-images.githubusercontent.com/1521080/149773533-dab02404-074b-4085-bf01-0cb08627d5f4.png)

![firefox_f0Xz0AMIhe](https://user-images.githubusercontent.com/1521080/149774870-ab56dd90-5328-4dae-9b03-f8bb82eb1a00.png)

![firefox_YH95k5o6sv](https://user-images.githubusercontent.com/1521080/149773547-afdf6c86-34af-4999-81f9-23d1501dca7a.png)
