### PR TITLE
Handle 'export default' in static RAM calculation

### DIFF
--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -388,7 +388,8 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): any {
           }
         },
         FunctionDeclaration: (node: any) => {
-          const key = currentModule + "." + node.id.name;
+          // node.id will be null when using 'export default'. Add a module name indicating the default export.
+          const key = currentModule + "." + (node.id === null ? "__SPECIAL_DEFAULT_EXPORT__" : node.id.name);
           walk.recursive(node, { key: key }, commonVisitors());
         },
       },


### PR DESCRIPTION
This prevents the parser from crashing on 'export default'. All functions inside the imported file that 'export default' will be counted towards static RAM cost.

Resolves https://github.com/danielyxie/bitburner/issues/2609