### PR TITLE
Script Editor Improvements

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -198,7 +198,7 @@ export function Root(props: IProps): React.ReactElement {
           });
           editor.focus();
         });
-      } catch {}
+      } catch { }
     } else if (!options.vim) {
       // Whem vim mode is disabled
       vimEditor?.dispose();
@@ -432,7 +432,7 @@ export function Root(props: IProps): React.ReactElement {
     }
     try {
       infLoop(newCode);
-    } catch (err) {}
+    } catch (err) { }
   }
 
   function saveScript(scriptToSave: OpenScript): void {
@@ -714,7 +714,9 @@ export function Root(props: IProps): React.ReactElement {
                 ref={provided.innerRef}
                 {...provided.droppableProps}
                 style={{
-                  backgroundColor: snapshot.isDraggingOver ? "#1F2022" : Settings.theme.backgroundprimary,
+                  backgroundColor: snapshot.isDraggingOver
+                    ? Settings.theme.backgroundsecondary
+                    : Settings.theme.backgroundprimary,
                   overflowX: "scroll",
                 }}
               >
@@ -738,12 +740,14 @@ export function Root(props: IProps): React.ReactElement {
                       >
                         <Button
                           onClick={() => onTabClick(index)}
-                          style={{
-                            background:
-                              currentScript?.fileName === openScripts[index].fileName
-                                ? Settings.theme.secondarydark
-                                : "",
-                          }}
+                          style={
+                            currentScript?.fileName === openScripts[index].fileName ? {
+                              background: Settings.theme.button,
+                              color: Settings.theme.primary
+                            } : {
+                              background: Settings.theme.backgroundsecondary,
+                              color: Settings.theme.secondary
+                            }}
                         >
                           {hostname}:~/{fileName} {dirty(index)}
                         </Button>
@@ -752,10 +756,13 @@ export function Root(props: IProps): React.ReactElement {
                           style={{
                             maxWidth: "20px",
                             minWidth: "20px",
-                            background:
-                              currentScript?.fileName === openScripts[index].fileName
-                                ? Settings.theme.secondarydark
-                                : "",
+                            ...(currentScript?.fileName === openScripts[index].fileName ? {
+                              background: Settings.theme.button,
+                              color: Settings.theme.primary
+                            } : {
+                              background: Settings.theme.backgroundsecondary,
+                              color: Settings.theme.secondary
+                            })
                           }}
                         >
                           x

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -240,7 +240,7 @@ export function Root(props: IProps): React.ReactElement {
 
   async function updateRAM(newCode: string): Promise<void> {
     if (currentScript != null && currentScript.fileName.endsWith(".txt")) {
-      debouncedSetRAM("", []);
+      debouncedSetRAM("N/A", [["N/A", ""]]);
       return;
     }
     setUpdatingRam(true);

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -32,7 +32,6 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
 import SettingsIcon from "@mui/icons-material/Settings";
 import Table from "@mui/material/Table";
 import TableCell from "@mui/material/TableCell";
@@ -814,24 +813,11 @@ export function Root(props: IProps): React.ReactElement {
         ></Box>
 
         <Box display="flex" flexDirection="row" sx={{ m: 1 }} alignItems="center">
+          <Button startIcon={<SettingsIcon />} onClick={() => setOptionsOpen(true)} sx={{ mr: 1 }}>Options</Button>
           <Button onClick={beautify}>Beautify</Button>
           <Button color={updatingRam ? "secondary" : "primary"} sx={{ mx: 1 }} onClick={() => { setRamInfoOpen(true) }}>
             {ram}
           </Button>
-          <Modal open={ramInfoOpen} onClose={() => setRamInfoOpen(false)}>
-            <Table>
-              <TableBody>
-                {ramEntries.map(([n, r]) => (
-                  <React.Fragment key={n + r}>
-                    <TableRow>
-                      <TableCell sx={{ color: Settings.theme.primary }}>{n}</TableCell>
-                      <TableCell align="right" sx={{ color: Settings.theme.primary }}>{r}</TableCell>
-                    </TableRow>
-                  </React.Fragment>
-                ))}
-              </TableBody>
-            </Table>
-          </Modal>
           <Button onClick={save}>Save (Ctrl/Cmd + s)</Button>
           <Button onClick={props.router.toTerminal}>Close (Ctrl/Cmd + b)</Button>
           <Typography sx={{ mx: 1 }}>
@@ -845,12 +831,6 @@ export function Root(props: IProps): React.ReactElement {
               Full
             </Link>
           </Typography>
-          <IconButton style={{ marginLeft: "auto" }} onClick={() => setOptionsOpen(true)}>
-            <>
-              <SettingsIcon />
-              options
-            </>
-          </IconButton>
         </Box>
         <OptionsModal
           open={optionsOpen}
@@ -871,6 +851,20 @@ export function Root(props: IProps): React.ReactElement {
             Settings.MonacoVim = options.vim;
           }}
         />
+        <Modal open={ramInfoOpen} onClose={() => setRamInfoOpen(false)}>
+          <Table>
+            <TableBody>
+              {ramEntries.map(([n, r]) => (
+                <React.Fragment key={n + r}>
+                  <TableRow>
+                    <TableCell sx={{ color: Settings.theme.primary }}>{n}</TableCell>
+                    <TableCell align="right" sx={{ color: Settings.theme.primary }}>{r}</TableCell>
+                  </TableRow>
+                </React.Fragment>
+              ))}
+            </TableBody>
+          </Table>
+        </Modal>
       </div>
       <div
         style={{


### PR DESCRIPTION
### Tabs Visibility
Makes it easier to see which tab is currently active by respecting the user's theme colors.
<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/60761231/149844115-b974f6cb-25ed-4923-9d34-fa81441a3f76.gif">
    </td>
    <td><img src="https://user-images.githubusercontent.com/60761231/149844171-5a7cf4fa-f409-412f-8709-72b55c2673f8.gif">
    </td>
  </tr>
</table>

### Verbose RAM Info Modal
Turns the RAM counter into a button that, when pressed, creates a modal with a table breaking down the static RAM usage of the active script.

![firefox_g5wQt95obq](https://user-images.githubusercontent.com/60761231/149844348-b6b684bf-2c32-442a-a23f-7f48a9bbc0c1.gif)

### Other
- Updated the RAM counter to display `N/A` when editing a `.txt` file.
- Changed the button type of the `Options` button to match the others, and moved it to the front of the buttons list, ensuring it doesn't go off screen easily (fixes #2427)
![image](https://user-images.githubusercontent.com/60761231/149846972-8fcc1ef9-c0b6-4f21-80ec-b6038700b69b.png)


### Testing
- [x] Tabs visibility changes have been tested by ensuring that nothing out of the ordinary occurs during normal usage
- [x] RAM breakdown modal has been tested by opening and closing the modal, and by verifying that there are no console errors

All testing was performed on Firefox 97.0