### PR TITLE
Use background primary for `<body>`

### DIFF
--- a/src/ui/React/Theme.tsx
+++ b/src/ui/React/Theme.tsx
@@ -362,7 +362,7 @@ export function refreshTheme(): void {
     },
   });
 
-  document.body.style.backgroundColor = theme.colors.black?.toString() ?? "black";
+  document.body.style.backgroundColor = theme.colors.backgroundprimary?.toString() ?? "black";
 }
 refreshTheme();
 


### PR DESCRIPTION
Updates the `<Theme>` element to attempt to pull the user's `theme.backgroundprimary` for the background color of `<body>` before falling back to black.

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/60761231/150027601-30bbb243-3100-410b-b65b-97a672c3a0ea.png">
    </td>
    <td><img src="https://user-images.githubusercontent.com/60761231/150027597-42dab295-0a75-49a1-850b-f0a3d29af7da.png">
    </td>
  </tr>
</table>

Tested on Firefox 97.0