### PR TITLE
Update scriptKill example

### DIFF
--- a/doc/source/netscript/basicfunctions/scriptKill.rst
+++ b/doc/source/netscript/basicfunctions/scriptKill.rst
@@ -15,4 +15,4 @@ scriptKill() Netscript Function
 
     .. code-block:: javascript
 
-        scriptKill("demo.script"); // returns: true
+        scriptKill("demo.script", "home"); // returns: true


### PR DESCRIPTION
Function requires a hostname. Added the "home" hostname as an example.