### PR TITLE
Update `<Tabs>` sizing and style

### DIFF
--- a/src/Corporation/ui/CityTabs.tsx
+++ b/src/Corporation/ui/CityTabs.tsx
@@ -30,7 +30,7 @@ export function CityTabs(props: IProps): React.ReactElement {
   }
   return (
     <>
-      <Tabs variant="fullWidth" value={city} onChange={handleChange}>
+      <Tabs variant="fullWidth" value={city} onChange={handleChange} sx={{ minWidth: 'fit-content', maxWidth: '65%' }}>
         {Object.values(division.offices).map(
           (office: OfficeSpace | 0) => office !== 0 && <Tab key={office.loc} label={office.loc} value={office.loc} />,
         )}

--- a/src/Corporation/ui/CorporationRoot.tsx
+++ b/src/Corporation/ui/CorporationRoot.tsx
@@ -38,7 +38,7 @@ export function CorporationRoot(): React.ReactElement {
 
   return (
     <Context.Corporation.Provider value={corporation}>
-      <Tabs variant="fullWidth" value={divisionName} onChange={handleChange}>
+      <Tabs variant="fullWidth" value={divisionName} onChange={handleChange} sx={{ minWidth: 'fit-content', maxWidth: '65%' }}>
         <Tab label={corporation.name} value={"Overview"} />
         {corporation.divisions.map((div) => (
           <Tab key={div.name} label={div.name} value={div.name} />

--- a/src/Gang/ui/GangRoot.tsx
+++ b/src/Gang/ui/GangRoot.tsx
@@ -32,7 +32,7 @@ export function GangRoot(): React.ReactElement {
 
   return (
     <Context.Gang.Provider value={gang}>
-      <Tabs variant="fullWidth" value={value} onChange={handleChange}>
+      <Tabs variant="fullWidth" value={value} onChange={handleChange} sx={{ minWidth: 'fit-content', maxWidth: '45%' }}>
         <Tab label="Management" />
         <Tab label="Equipment" />
         <Tab label="Territory" />

--- a/src/Themes/ui/Theme.tsx
+++ b/src/Themes/ui/Theme.tsx
@@ -336,6 +336,24 @@ export function refreshTheme(): void {
               color: Settings.theme.primary,
             },
           },
+          root: {
+            backgroundColor: Settings.theme.backgroundsecondary,
+            border: "1px solid " + Settings.theme.well,
+            margin: '3px',
+
+            "&.Mui-selected": {
+              backgroundColor: Settings.theme.button
+            },
+          },
+        },
+      },
+      MuiTabs: {
+        defaultProps: {
+          TabIndicatorProps: {
+            style: {
+              display: "none"
+            }
+          }
         },
       },
       MuiAlert: {

--- a/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
+++ b/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
@@ -31,9 +31,9 @@ export function ActiveScriptsRoot(props: IProps): React.ReactElement {
   }
   return (
     <>
-      <Tabs variant="fullWidth" value={tab} onChange={handleChange}>
+      <Tabs variant="fullWidth" value={tab} onChange={handleChange} sx={{ minWidth: 'fit-content', maxWidth: '25%' }}>
         <Tab label={"Active"} value={"active"} />
-        <Tab label={"Recent"} value={"recent"} />
+        <Tab label={"Recently Killed"} value={"recent"} />
       </Tabs>
 
       {tab === "active" && <ActiveScriptsPage workerScripts={props.workerScripts} />}


### PR DESCRIPTION
Adjusts the style of all `<Tabs>` and `<Tab>` elements to match the design of script editor tabs.

Also updated the sizing of the tabs on the Active Scripts, Corp, and Gang page [to be more conducive to the way the average user reads the page](https://canary.discord.com/channels/415207508303544321/459097632896188436/933494038382927922)

### Active Scripts sizing

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/60761231/150210108-9f5ff486-5ff9-4759-9f3f-958ab261a418.gif">
    </td>
    <td><img src="https://user-images.githubusercontent.com/60761231/150232795-6a3af12f-1616-4299-8355-b54345081b4f.png">
    </td>
  </tr>
</table>

### Corps tabs sizing

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/60761231/150280415-a85d205f-212f-4ba6-8a46-fef832138717.png">
    </td>
    <td><img src="https://user-images.githubusercontent.com/60761231/150280060-05431824-aca7-4eef-81ca-4697ba286cf1.png">
    </td>
  </tr>
</table>

### Gangs tabs sizing

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/60761231/150280447-9f2e1660-e999-4bdb-86cd-2742bb219d7f.png">
    </td>
    <td><img src="https://user-images.githubusercontent.com/60761231/150280345-7dde7f71-9c28-4c56-a38e-0e7869ee1edd.png">
    </td>
  </tr>
</table>

### All Tabs styling

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/60761231/150233042-eccc02e0-6146-4303-b5d4-fe21a45fd15b.png">
    </td>
    <td><img src="https://user-images.githubusercontent.com/60761231/150232989-b629364a-6ca0-42ed-83c9-8231b9cbd021.png">
    </td>
  </tr>
</table>

New tab style applies to all areas where these components are used:
- Active scripts
- Gangs
- Corps
- Bladeburner

Tested on Firefox 97.0