### PR TITLE
Separate WARN/ERROR/SUCESS/INFO into their own functions

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -726,48 +726,71 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       if (args.length === 0) {
         throw makeRuntimeErrorMsg("tprint", "Takes at least 1 argument.");
       }
-      const str = argsToString(args);
-      if (str.startsWith("ERROR") || str.startsWith("FAIL")) {
-        Terminal.error(`${workerScript.scriptRef.filename}: ${str}`);
-        return;
+
+      Terminal.print(`${workerScript.scriptRef.filename}: ${argsToString(args)}`);
+    },
+    tsuccess: function (...args: any[]): void {
+      if (args.length === 0) {
+        throw makeRuntimeErrorMsg("tsuccess", "Takes at least 1 argument.");
       }
-      if (str.startsWith("SUCCESS")) {
-        Terminal.success(`${workerScript.scriptRef.filename}: ${str}`);
-        return;
+
+      Terminal.success(`${workerScript.scriptRef.filename}: ${argsToString(args)}`);
+    },
+    tinfo: function (...args: any[]): void {
+      if (args.length === 0) {
+        throw makeRuntimeErrorMsg("tinfo", "Takes at least 1 argument.");
       }
-      if (str.startsWith("WARN")) {
-        Terminal.warn(`${workerScript.scriptRef.filename}: ${str}`);
-        return;
+
+      Terminal.info(`${workerScript.scriptRef.filename}: ${argsToString(args)}`);
+    },
+    twarn: function (...args: any[]): void {
+      if (args.length === 0) {
+        throw makeRuntimeErrorMsg("twarn", "Takes at least 1 argument.");
       }
-      if (str.startsWith("INFO")) {
-        Terminal.info(`${workerScript.scriptRef.filename}: ${str}`);
-        return;
+
+      Terminal.warn(`${workerScript.scriptRef.filename}: ${argsToString(args)}`);
+    },
+    terror: function (...args: any[]): void {
+      if (args.length === 0) {
+        throw makeRuntimeErrorMsg("terror", "Takes at least 1 argument.");
       }
-      Terminal.print(`${workerScript.scriptRef.filename}: ${str}`);
+
+      Terminal.error(`${workerScript.scriptRef.filename}: ${argsToString(args)}`);
     },
     tprintf: function (format: any, ...args: any): any {
       if (typeof format !== "string") {
         throw makeRuntimeErrorMsg("tprintf", "First argument must be string for the format.");
       }
-      const str = vsprintf(format, args);
 
-      if (str.startsWith("ERROR") || str.startsWith("FAIL")) {
-        Terminal.error(`${str}`);
-        return;
+      Terminal.print(vsprintf(format, args));
+    },
+    twarnf: function (format: any, ...args: any): any {
+      if (typeof format !== "string") {
+        throw makeRuntimeErrorMsg("twarnf", "First argument must be string for the format.");
       }
-      if (str.startsWith("SUCCESS")) {
-        Terminal.success(`${str}`);
-        return;
+
+      Terminal.warn(vsprintf(format, args));
+    },
+    terrorf: function (format: any, ...args: any): any {
+      if (typeof format !== "string") {
+        throw makeRuntimeErrorMsg("terrorf", "First argument must be string for the format.");
       }
-      if (str.startsWith("WARN")) {
-        Terminal.warn(`${str}`);
-        return;
+
+      Terminal.error(vsprintf(format, args));
+    },
+    tsuccessf: function (format: any, ...args: any): any {
+      if (typeof format !== "string") {
+        throw makeRuntimeErrorMsg("tsuccessf", "First argument must be string for the format.");
       }
-      if (str.startsWith("INFO")) {
-        Terminal.info(`${str}`);
-        return;
+
+      Terminal.success(vsprintf(format, args));
+    },
+    tinfof: function (format: any, ...args: any): any {
+      if (typeof format !== "string") {
+        throw makeRuntimeErrorMsg("tinfof", "First argument must be string for the format.");
       }
-      Terminal.print(`${str}`);
+
+      Terminal.info(vsprintf(format, args));
     },
     clearLog: function (): any {
       workerScript.scriptRef.clearLog();

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4461,7 +4461,7 @@ export interface NS extends Singularity {
   print(...args: any[]): void;
 
   /**
-   * Prints one or more values or variables to the Terminal.
+   * Prints one or more values or variables to the Terminal using the DEFAULT coloring.
    * @remarks
    * RAM cost: 0 GB
    *
@@ -4470,7 +4470,43 @@ export interface NS extends Singularity {
   tprint(...args: any[]): void;
 
   /**
-   * Prints a raw value or a variable to the Terminal.
+   * Prints one or more values or variables to the Terminal using the WARN coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param args - Value(s) to be printed.
+   */
+  twarn(...args: any[]): void;
+  
+  /**
+   * Prints one or more values or variables to the Terminal using the INFO coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param args - Value(s) to be printed.
+   */
+  tinfo(...args: any[]): void;
+  
+  /**
+   * Prints one or more values or variables to the Terminal using the SUCCESS coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param args - Value(s) to be printed.
+   */
+  tsuccess(...args: any[]): void;
+
+  /**
+   * Prints one or more values or variables to the Terminal using the ERROR coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param args - Value(s) to be printed.
+   */
+  terror(...args: any[]): void;
+
+  /**
+   * Prints a raw value or a variable to the Terminal with the DEFAULT coloring.
    * @remarks
    * RAM cost: 0 GB
    *
@@ -4478,6 +4514,46 @@ export interface NS extends Singularity {
    * @param msg - Value to be printed.
    */
   tprintf(format: string, ...values: any[]): void;
+
+  /**
+   * Prints a raw value or a variable to the Terminal with the WARN coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param format - format of the message
+   * @param msg - Value to be printed.
+   */
+  twarnf(format: string, ...values: any[]): void;
+
+  /**
+   * Prints a raw value or a variable to the Terminal with the INFO coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param format - format of the message
+   * @param msg - Value to be printed.
+   */
+  tinfof(format: string, ...values: any[]): void;
+
+  /**
+   * Prints a raw value or a variable to the Terminal with the SUCCESS coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param format - format of the message
+   * @param msg - Value to be printed.
+   */
+  tsuccessf(format: string, ...values: any[]): void;
+
+  /**
+   * Prints a raw value or a variable to the Terminal with the ERROR coloring.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * @param format - format of the message
+   * @param msg - Value to be printed.
+   */
+  terrorf(format: string, ...values: any[]): void;
 
   /**
    * Clears the script’s logs.


### PR DESCRIPTION
Instead of having to prepend a message with WARN/ERROR/SUCCESS/INFO, they each have their own function.

There'd now be a tprint, twarn, tsuccess and terror, as well as format versions of all of those. 
