### PR TITLE
Force achievements recalculation on bitnode completion

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -72,6 +72,7 @@ import { LogBoxManager } from "./React/LogBoxManager";
 import { AlertManager } from "./React/AlertManager";
 import { PromptManager } from "./React/PromptManager";
 import { InvitationModal } from "../Faction/ui/InvitationModal";
+import { calculateAchievements } from "../Achievements/Achievements";
 
 import { enterBitNode } from "../RedPill";
 import { Context } from "./Context";
@@ -286,6 +287,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     toBitVerse: (flume: boolean, quick: boolean) => {
       setFlume(flume);
       setQuick(quick);
+      calculateAchievements();
       setPage(Page.BitVerse);
     },
     toInfiltration: (location: Location) => {


### PR DESCRIPTION
Prevents player from missing some bitnode completion achievements if he/she enters new bitnode before the periodic achievements recheck occurs.
Fixes this issue: https://steamcommunity.com/app/1812820/discussions/1/3200371016620820841/