### PR TITLE
Add ns.printf function

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -114,6 +114,7 @@ export const RamCosts: IMap<any> = {
   weaken: RamCostConstants.ScriptWeakenRamCost,
   weakenAnalyze: RamCostConstants.ScriptWeakenAnalyzeRamCost,
   print: 0,
+  printf: 0,
   tprint: 0,
   clearLog: 0,
   disableLog: 0,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -722,6 +722,12 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       }
       workerScript.print(argsToString(args));
     },
+    printf: function (format: string, ...args: any[]): void {
+      if (typeof format !== "string") {
+        throw makeRuntimeErrorMsg("printf", "First argument must be string for the format.");
+      }
+      workerScript.print(vsprintf(format, args));
+    },
     tprint: function (...args: any[]): void {
       if (args.length === 0) {
         throw makeRuntimeErrorMsg("tprint", "Takes at least 1 argument.");

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4461,6 +4461,17 @@ export interface NS extends Singularity {
   print(...args: any[]): void;
 
   /**
+   * Prints a formatted string to the script’s logs.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * see: https://github.com/alexei/sprintf.js
+   * @param format - format of the message
+   * @param args - Value(s) to be printed.
+   */
+  printf(format: string, ...args: any[]): void;
+
+  /**
    * Prints one or more values or variables to the Terminal.
    * @remarks
    * RAM cost: 0 GB


### PR DESCRIPTION
Behaviour is consistent with that of tprintf versus tprint and
should be equivalent to ns.print(ns.sprintf(...))

Closes #2380

## Testing
This is a very simple function, so testing was similarly brief. Ran a happy path and two failure tests to show equivalence with print(sprintf), see screenshots.

![Screenshot_20220121_112123](https://user-images.githubusercontent.com/1348714/150520457-50c2d46e-505e-432e-a586-93e345f1641e.png)  
![Screenshot_20220121_112331](https://user-images.githubusercontent.com/1348714/150520459-311d3e38-6787-43a4-aeee-78af21216acb.png)  
![Screenshot_20220121_112427](https://user-images.githubusercontent.com/1348714/150520460-7f97c8a5-624a-4385-9158-d8e3bd8ca652.png)  

