### PR TITLE
Display bonus time in sleeve detailed stats panel

### DIFF
--- a/src/DevMenu/ui/Sleeves.tsx
+++ b/src/DevMenu/ui/Sleeves.tsx
@@ -8,6 +8,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import { IPlayer } from "../../PersonObjects/IPlayer";
+import { Adjuster } from "./Adjuster";
 
 interface IProps {
   player: IPlayer;
@@ -35,6 +36,12 @@ export function Sleeves(props: IProps): React.ReactElement {
   function sleeveSyncClearAll(): void {
     for (let i = 0; i < props.player.sleeves.length; ++i) {
       props.player.sleeves[i].sync = 0;
+    }
+  }
+
+  function sleeveSetStoredCycles(cycles: number): void {
+    for (let i = 0; i < props.player.sleeves.length; ++i) {
+      props.player.sleeves[i].storedCycles = cycles;
     }
   }
 
@@ -66,6 +73,18 @@ export function Sleeves(props: IProps): React.ReactElement {
               </td>
               <td>
                 <Button onClick={sleeveSyncClearAll}>Clear all</Button>
+              </td>
+            </tr>
+            <tr>
+              <td colSpan={3}>
+                <Adjuster
+                  label="Stored Cycles"
+                  placeholder="cycles"
+                  tons={() => sleeveSetStoredCycles(10000000)}
+                  add={sleeveSetStoredCycles}
+                  subtract={sleeveSetStoredCycles}
+                  reset={() => sleeveSetStoredCycles(0)}
+                />
               </td>
             </tr>
           </tbody>

--- a/src/PersonObjects/Sleeve/ui/MoreStatsModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/MoreStatsModal.tsx
@@ -1,5 +1,8 @@
 import { Sleeve } from "../Sleeve";
 import { numeralWrapper } from "../../../ui/numeralFormat";
+import { convertTimeMsToTimeElapsedString } from "../../../utils/StringHelperFunctions";
+import { CONSTANTS } from "../../../Constants";
+import { Typography } from "@mui/material";
 import { StatsTable } from "../../../ui/React/StatsTable";
 import { Modal } from "../../../ui/React/Modal";
 import React from "react";
@@ -80,6 +83,13 @@ export function MoreStatsModal(props: IProps): React.ReactElement {
         ]}
         title="Multipliers:"
       />
+
+      {/* Check for storedCycles to be a bit over 0 to prevent jittering */}
+      {props.sleeve.storedCycles > 10 && (
+        <Typography sx={{ py: 2 }}>
+          Bonus Time: {convertTimeMsToTimeElapsedString(props.sleeve.storedCycles * CONSTANTS.MilliPerCycle)}
+        </Typography>
+      )}
     </Modal>
   );
 }


### PR DESCRIPTION
## Display bonus time in sleeve detailed stats panel

Display the sleeve's (storedCycles * constants.millisPerCycle) in the "More Stats" panel of the sleeves.

Also adds a field to modify the stored cycles in the dev menu.

### Testing

Tested with 0 stored cycles and with various amounts.

### Screenshots

![firefox_2aGKSSzhef](https://user-images.githubusercontent.com/1521080/150529600-64edfd32-3da1-4c48-ad2e-47872898124f.png)

![firefox_s8WKs5Qm84](https://user-images.githubusercontent.com/1521080/150529775-adf7294a-cae9-4df3-82d9-acf864806182.png)

