### PR TITLE
WIP: 2734: Fix regex to enable alpha transparency hex codes (8 digits)

### DIFF
--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -28,7 +28,7 @@ export function NetscriptUserInterface(
 
     setTheme: function (newTheme: UserInterfaceTheme): void {
       helper.updateDynamicRam("setTheme", getRamCost(player, "ui", "setTheme"));
-      const hex = /^(#)((?:[A-Fa-f0-9]{3}){1,2})$/;
+      const hex = /^(#)((?:[A-Fa-f0-9]{2}){3,4}|(?:[A-Fa-f0-9]{3}))$/;
       const currentTheme = {...Settings.theme}
       const errors: string[] = [];
       for (const key of Object.keys(newTheme)) {


### PR DESCRIPTION
# Bug fix

Fixes #2734 by modifying regex to that documented. WIP currently to determine additional affects of enabling this to users, suggested by @MartinFournier.

Reproduction notes:
```
wget https://raw.githubusercontent.com/PhilipArmstead/bitburner-apps/master/apps/theme-browser/dist/main.js bitpacks/theme-browser/theme-browser.js

run bitpacks/theme-browser/theme-browser.js --apply {"primarylight":"#D5FF80","primary":"#AAD94C","primarydark":"#86B300","successlight":"#D5FF80","success":"#AAD94C","successdark":"#86B300","errorlight":"#FF6666","error":"#D95757","errordark":"#B95757","secondarylight":"#8A9199","secondary":"#707A8C","secondarydark":"#565B66","warninglight":"#FFCC66","warning":"#E6B450","warningdark":"#C69450","infolight":"#73D0FF","info":"#59C2FF","infodark":"#39A2DF","welllight":"#47526680","well":"#1F2430","white":"#BFBDB6","black":"#0B0E14","hp":"#F07178","money":"#E6B673","hack":"#7FD962","combat":"#ACB6BFAC","cha":"#D2A6FF","int":"#39BAE6","rep":"#95E6CB","disabled":"#409FFF8D","backgroundprimary":"#0B0E14","backgroundsecondary":"#1A1F28","button":"#3B404A"}
```

Before:
![screencapture-danielyxie-github-io-bitburner-2022-01-21-17_17_28](https://user-images.githubusercontent.com/8268249/150571116-27a00ba9-6b57-4cfc-b416-7ca6b4db6994.png)

After:
![screencapture-localhost-8000-2022-01-21-17_16_08](https://user-images.githubusercontent.com/8268249/150571134-b7c28edf-1747-46b0-b6b9-9d0fba874538.png)

---

Faction invite (for reference on modal):
![image](https://user-images.githubusercontent.com/8268249/150576113-a2983706-f771-4ff1-9ba0-73faa3e8bd30.png)
