### PR TITLE
Fix incorrect result being detected on the roulette table

### DIFF
--- a/src/Casino/Roulette.tsx
+++ b/src/Casino/Roulette.tsx
@@ -40,13 +40,13 @@ const strategies: {
 } = {
   Red: {
     match: (n: number): boolean => {
-      if (n === 0) return false;
       return redNumbers.includes(n);
     },
     payout: 1,
   },
   Black: {
     match: (n: number): boolean => {
+      if (n === 0) return false;
       return !redNumbers.includes(n);
     },
     payout: 1,

--- a/src/Casino/Roulette.tsx
+++ b/src/Casino/Roulette.tsx
@@ -118,12 +118,6 @@ export function Roulette(props: IProps): React.ReactElement {
   const [status, setStatus] = useState<string | JSX.Element>("waiting");
   const [n, setN] = useState(0);
   const [lock, setLock] = useState(true);
-  const [strategy, setStrategy] = useState<Strategy>({
-    payout: 0,
-    match: (): boolean => {
-      return false;
-    },
-  });
 
   useEffect(() => {
     const i = window.setInterval(step, 50);
@@ -156,13 +150,12 @@ export function Roulette(props: IProps): React.ReactElement {
     return `${n}${color}`;
   }
 
-  function play(s: Strategy): void {
+  function play(strategy: Strategy): void {
     if (reachedLimit(props.p)) return;
 
     setCanPlay(false);
     setLock(false);
     setStatus("playing");
-    setStrategy(s);
 
     setTimeout(() => {
       let n = Math.floor(rng.random() * 37);


### PR DESCRIPTION
Resolves #2382
Resolves #2086
Also fixes an issue where choosing black would result in a win if 0 came in.

Fixes were manually tested in the browser after running `npm run start:dev`.

The main issue (for the first 2 fixes) was that it always used the previous strategy, rather than the current one, when doing the check.

The issue was easy to recreate as the first spin always lost no matter the result:
1. go to the casino
2. select roulette
3. choose black (or anything that has to high chance, to speed up process)
4. if black comes in, notice you lose
5. if red comes in, select "stop playing" and go back to step 2.

I solved it by removing the reliance on state (as it wasn't updating before the result was checked), and just using the strategy directly. The slots suffer from a similar issue, so i'll submit a fix for that too at some point.