### PR TITLE
NetscriptDefinitions.d.ts: CrimeStats.name is a string, not a number

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -129,7 +129,7 @@ export interface CrimeStats {
   /** How much money is given */
   money: number;
   /** Name of crime */
-  name: number;
+  name: string;
   /** Milliseconds it takes to attempt the crime */
   time: number;
   /** Description of the crime activity */


### PR DESCRIPTION
Title pretty much says it all, this was incorrectly typed as a number in NetscriptDefinitions.d.ts while getCrimeStats() in CrimeHelpers.ts returns a Crime class, which uses a string for the name.