### PR TITLE
Bug fix corporation expressions

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -109,8 +109,8 @@ export function SellMaterial(mat: Material, amt: string, price: string): void {
   if (amt.includes("MAX") || amt.includes("PROD")) {
     let q = amt.replace(/\s+/g, "");
     q = q.replace(/[^-()\d/*+.MAXPROD]/g, "");
-    let tempQty = q.replace(/MAX/g, "1");
-    tempQty = tempQty.replace(/PROD/g, "1");
+    let tempQty = q.replace(/MAX/g, mat.maxsll.toString());
+    tempQty = tempQty.replace(/PROD/g, mat.prd.toString());
     try {
       tempQty = eval(tempQty);
     } catch (e) {

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -174,8 +174,8 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
     //Dynamically evaluated quantity. First test to make sure its valid
     let qty = amt.replace(/\s+/g, "");
     qty = qty.replace(/[^-()\d/*+.MAXPROD]/g, "");
-    let temp = qty.replace(/MAX/g, "1");
-    temp = temp.replace(/PROD/g, "1");
+    let temp = qty.replace(/MAX/g, product.maxsll.toString());
+    temp = temp.replace(/PROD/g, product.data[city][1].toString());
     try {
       temp = eval(temp);
     } catch (e) {

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -828,7 +828,7 @@ export class Industry implements IIndustry {
                   }
                 }
 
-                const maxSell =
+                mat.maxsll =
                   (mat.qlt + 0.001) *
                   marketFactor *
                   markup *
@@ -839,7 +839,7 @@ export class Industry implements IIndustry {
                 let sellAmt;
                 if (isString(mat.sllman[1])) {
                   //Dynamically evaluated
-                  let tmp = (mat.sllman[1] as string).replace(/MAX/g, (maxSell + "").toUpperCase());
+                  let tmp = (mat.sllman[1] as string).replace(/MAX/g, (mat.maxsll + "").toUpperCase());
                   tmp = tmp.replace(/PROD/g, mat.prd + "");
                   try {
                     sellAmt = eval(tmp);
@@ -856,13 +856,13 @@ export class Industry implements IIndustry {
                     );
                     sellAmt = 0;
                   }
-                  sellAmt = Math.min(maxSell, sellAmt);
+                  sellAmt = Math.min(mat.maxsll, sellAmt);
                 } else if (mat.sllman[1] === -1) {
                   //Backwards compatibility, -1 = MAX
-                  sellAmt = maxSell;
+                  sellAmt = mat.maxsll;
                 } else {
                   //Player's input value is just a number
-                  sellAmt = Math.min(maxSell, mat.sllman[1] as number);
+                  sellAmt = Math.min(mat.maxsll, mat.sllman[1] as number);
                 }
 
                 sellAmt = sellAmt * CorporationConstants.SecsPerMarketCycle * marketCycles;

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -1188,8 +1188,7 @@ export class Industry implements IIndustry {
               }
             }
 
-            const maxSell =
-              0.5 *
+            product.maxsll = 0.5 *
               Math.pow(product.rat, 0.65) *
               marketFactor *
               corporation.getSalesMultiplier() *
@@ -1200,7 +1199,7 @@ export class Industry implements IIndustry {
             let sellAmt;
             if (product.sllman[city][0] && isString(product.sllman[city][1])) {
               //Sell amount is dynamically evaluated
-              let tmp = product.sllman[city][1].replace(/MAX/g, (maxSell + "").toUpperCase());
+              let tmp = product.sllman[city][1].replace(/MAX/g, (product.maxsll + "").toUpperCase());
               tmp = tmp.replace(/PROD/g, product.data[city][1]);
               try {
                 tmp = eval(tmp);
@@ -1214,16 +1213,16 @@ export class Industry implements IIndustry {
                     city +
                     " office. Sell price is being set to MAX",
                 );
-                tmp = maxSell;
+                tmp = product.maxsll;
               }
-              sellAmt = Math.min(maxSell, tmp);
+              sellAmt = Math.min(product.maxsll, tmp);
             } else if (product.sllman[city][0] && product.sllman[city][1] > 0) {
               //Sell amount is manually limited
-              sellAmt = Math.min(maxSell, product.sllman[city][1]);
+              sellAmt = Math.min(product.maxsll, product.sllman[city][1]);
             } else if (product.sllman[city][0] === false) {
               sellAmt = 0;
             } else {
-              sellAmt = maxSell;
+              sellAmt = product.maxsll;
             }
             if (sellAmt < 0) {
               sellAmt = 0;

--- a/src/Corporation/Material.ts
+++ b/src/Corporation/Material.ts
@@ -62,6 +62,9 @@ export class Material {
   marketTa2 = false;
   marketTa2Price = 0;
 
+  // Determines the maximum amount of this material that can be sold in one market cycle
+  maxsll = 0;
+
   constructor(params: IConstructorParams = {}) {
     if (params.name) {
       this.name = params.name;

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -96,6 +96,8 @@ export class Product {
   marketTa2 = false;
   marketTa2Price: IMap<number> = createCityMap<number>(0);
 
+  // Determines the maximum amount of this product that can be sold in one market cycle
+  maxsll = 0
   constructor(params: IConstructorParams = {}) {
     this.name = params.name ? params.name : "";
     this.dmd = params.demand ? params.demand : 0;

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -97,7 +97,7 @@ export class Product {
   marketTa2Price: IMap<number> = createCityMap<number>(0);
 
   // Determines the maximum amount of this product that can be sold in one market cycle
-  maxsll = 0
+  maxsll = 0;
   constructor(params: IConstructorParams = {}) {
     this.name = params.name ? params.name : "";
     this.dmd = params.demand ? params.demand : 0;


### PR DESCRIPTION
Fixed bug that caused an error when trying to set a dynamic expression to sell materials or products (e.g. PROD-500). [See Issue](https://github.com/danielyxie/bitburner/issues/2719)

**Changes**
- Added property "maxsll" to Material.ts and Product.ts
- The result of the calculation of maxSell will now be written to the property "maxsll" of the corresponding material or product
- Temporary quantity evaluation does not use "1" anymore. Instead it uses the effective production rate respectively the maximum amount of the product or material that can be sold.

**How it was tested**
Entered expressions where the evaluation leads to negative result and error message was displayed as expected.