### PR TITLE
HacknetServer Grow/Weaken error messages

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -143,7 +143,7 @@ export class Terminal implements ITerminal {
   startGrow(player: IPlayer): void {
     const server = player.getCurrentServer();
     if (server instanceof HacknetServer) {
-      this.error("Cannot hack this kind of server");
+      this.error("Cannot grow this kind of server");
       return;
     }
     if (!(server instanceof Server)) throw new Error("server should be normal server");
@@ -152,7 +152,7 @@ export class Terminal implements ITerminal {
   startWeaken(player: IPlayer): void {
     const server = player.getCurrentServer();
     if (server instanceof HacknetServer) {
-      this.error("Cannot hack this kind of server");
+      this.error("Cannot weaken this kind of server");
       return;
     }
     if (!(server instanceof Server)) throw new Error("server should be normal server");
@@ -241,7 +241,7 @@ export class Terminal implements ITerminal {
     if (cancelled) return;
 
     if (server instanceof HacknetServer) {
-      this.error("Cannot hack this kind of server");
+      this.error("Cannot grow this kind of server");
       return;
     }
     if (!(server instanceof Server)) throw new Error("server should be normal server");
@@ -268,7 +268,7 @@ export class Terminal implements ITerminal {
     if (cancelled) return;
 
     if (server instanceof HacknetServer) {
-      this.error("Cannot hack this kind of server");
+      this.error("Cannot weaken this kind of server");
       return;
     }
     if (!(server instanceof Server)) throw new Error("server should be normal server");


### PR DESCRIPTION
It may be intentional to use "hack" for all 3 (ie, assume the player makes the connection that can't hack, also means can't grow or weaken), in which case, disregard.
On the other hand, it could've easily been a copy/paste artifact, and this would be more explicitly clear, so thought it was worth bringing up.