### PR TITLE
Change typedef of data arg of writePort() and tryWritePort() to type `any`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitburner",
   "license": "SEE LICENSE IN license.txt",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "electron-main.js",
   "author": {
     "name": "Daniel Xie & Olivier Gagnon"

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5547,7 +5547,7 @@ export interface NS extends Singularity {
    * @param data - Data to write.
    * @returns True if the data is successfully written to the port, and false otherwise.
    */
-  tryWritePort(port: number, data: string[] | number): Promise<boolean>;
+  tryWritePort(port: number, data: any): Promise<boolean>;
 
   /**
    * Read content of a file.
@@ -5608,7 +5608,7 @@ export interface NS extends Singularity {
    * Write data to that netscript port.
    * @returns The data popped off the queue if it was full.
    */
-  writePort(port: number, data: string | number): Promise<any>;
+  writePort(port: number, data: any): Promise<any>;
   /**
    * Read data from a port.
    * @remarks


### PR DESCRIPTION
## Summary
- change the type of `data` from `string[]` or `number` to `any`. 
- Up version number to match version in src/CONSTANTS.ts

## Why make the changes
- TS compilation error when trying to write data to port that is not a string array or number
- After searching the code history, think that this might be something that is overlooked

## References
- https://github.com/danielyxie/bitburner/blob/dev/src/ScriptEditor/NetscriptDefinitions.d.ts#L5550
- https://github.com/danielyxie/bitburner/blob/dev/src/NetscriptFunctions.ts#L1826
- https://github.com/danielyxie/bitburner/commit/6bd6b3061e58bde49e51b97ba97558884b31f0c0#diff-e5908fdbe41686830d15ad3405a219bebe335e4fe5d0d346eba7dc73644e65b2L2969
