### PR TITLE
Update spawn.rst

### DIFF
--- a/doc/source/netscript/basicfunctions/spawn.rst
+++ b/doc/source/netscript/basicfunctions/spawn.rst
@@ -23,4 +23,4 @@ spawn() Netscript Function
 
     .. code-block:: javascript
 
-        spawn('foo.script', 10, 'foodnstuff', 90); // "run foo.script 10 foodnstuff 90" in 10 seconds.
+        spawn('foo.script', 10, 'foodnstuff', 90); // "run foo.script foodnstuff 90 -t 10" in 10 seconds.


### PR DESCRIPTION
Code example comment represented passing '10' as an arg to the script, when actually it's the number of threads so a `-t 10` flag.  Fixed the comment to show this.

