### PR TITLE
Fixed array comparison handling of NaN

### DIFF
--- a/src/utils/helpers/compareArrays.ts
+++ b/src/utils/helpers/compareArrays.ts
@@ -20,7 +20,8 @@ export function compareArrays<T>(a1: T[], a2: T[]): boolean {
       if (!compareArrays(elem1, elem2)) {
         return false;
       }
-    } else if (a1[i] !== a2[i]) {
+    } else if (a1[i] !== a2[i] && !(Number.isNaN(a1[i]) && Number.isNaN(a2[i]))) {
+      // strict (in)equality considers NaN not equal to itself
       return false;
     }
   }


### PR DESCRIPTION
Issue #2033 is fixed, not by using Object.is as recommended by [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#when_to_use_object.is_versus_triple_equals) because it would have caused issues with +0 and -0 not being equal.
Tested using the method described in the issue.
