### PR TITLE
Add missing steam app icon for linux

### DIFF
--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -14,7 +14,14 @@ const debug = process.argv.includes("--debug");
 
 async function createWindow(killall) {
   const setStopProcessHandler = global.app_handlers.stopProcess;
+
+  let icon;
+  if (process.platform == 'linux') {
+    icon = path.join(__dirname, 'icon.png');
+  }
+
   const window = new BrowserWindow({
+    icon,
     show: false,
     backgroundThrottling: false,
     backgroundColor: "#000000",


### PR DESCRIPTION
The tray icon was missing because it has to be added differently for linux.

Tested on Ubuntu.

