### PR TITLE
Modify electron build script to allow platform selection

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -16,6 +16,8 @@
     "./dist/**/*",
     "./node_modules/**/*",
     "./public/**/*",
+    "./src/**",
+    "./lib/**,",
     "*.js"
   ],
   "directories": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
     "watch:dev": "webpack --watch --mode development",
     "electron": "sh ./package.sh",
     "electron:packager": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png --no-prune",
+    "electron:packager-all": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png",
+    "electron:packager-win": "electron-packager .package bitburner --platform win32 --arch x64 --out .build --overwrite --icon .package/icon.png",
+    "electron:packager-mac": "electron-packager .package bitburner --platform darwin --arch x64 --out .build --overwrite --icon .package/icon.png",
+    "electron:packager-linux": "electron-packager .package bitburner --platform linux --arch x64 --out .build --overwrite --icon .package/icon.png",
     "allbuild": "npm run build && npm run electron && git add --all && git commit --amend --no-edit && git push -f -u origin dev"
   }
 }

--- a/package.sh
+++ b/package.sh
@@ -26,5 +26,6 @@ cd electron
 npm install
 cd ..
 
+BUILD_PLATFORM="${1:-"all"}"
 # And finally build the app.
-npm run electron:packager
+npm run electron:packager-$BUILD_PLATFORM

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Clear out any files remaining from old builds
+rm -rf .package
+
 mkdir -p .package/dist/src/ThirdParty || true
 mkdir -p .package/src/ThirdParty || true
 mkdir -p .package/node_modules || true


### PR DESCRIPTION
This allows quicker development by only building what you need

```sh
npm run electron -- mac
```

Also removes previous build data by clearing the .package folder before building.