### PR TITLE
Store Electron window position in user settings 

### DIFF
--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -8,6 +8,7 @@ const api = require("./api-server");
 const cp = require("child_process");
 const path = require("path");
 const fs = require("fs");
+const { windowTracker } = require("./windowTracker");
 const { fileURLToPath } = require("url");
 
 const debug = process.argv.includes("--debug");
@@ -20,18 +21,28 @@ async function createWindow(killall) {
     icon = path.join(__dirname, 'icon.png');
   }
 
+  const tracker = windowTracker('main');
   const window = new BrowserWindow({
     icon,
     show: false,
     backgroundThrottling: false,
     backgroundColor: "#000000",
+    title: 'Bitburner',
+    x: tracker.state.x,
+    y: tracker.state.y,
+    width: tracker.state.width,
+    height: tracker.state.height,
+    minWidth: 600,
+    minHeight: 400,
     webPreferences: {
       nativeWindowOpen: true,
     },
   });
 
+  setTimeout(() => tracker.track(window), 1000);
+  if (tracker.state.isMaximized) window.maximize();
+
   window.removeMenu();
-  window.maximize();
   noScripts = killall ? { query: { noScripts: killall } } : {};
   window.loadFile("index.html", noScripts);
   window.show();

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "electron-config": "^2.0.0",
-        "electron-log": "^4.4.4"
+        "electron-log": "^4.4.4",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/conf": {
@@ -103,6 +104,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/make-dir": {
       "version": "1.3.0",
@@ -258,6 +264,11 @@
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "make-dir": {
       "version": "1.3.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "electron-config": "^2.0.0",
-    "electron-log": "^4.4.4"
+    "electron-log": "^4.4.4",
+    "lodash": "^4.17.21"
   }
 }

--- a/electron/windowTracker.js
+++ b/electron/windowTracker.js
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { screen } = require("electron");
+const log = require("electron-log");
+const debounce = require("lodash/debounce");
+const Config = require("electron-config");
+const config = new Config();
+
+// https://stackoverflow.com/a/68627253
+const windowTracker = (windowName) => {
+  let window, windowState;
+
+  const setBounds = () => {
+    // Restore from appConfig
+    if (config.has(`window.${windowName}`)) {
+      windowState = config.get(`window.${windowName}`);
+      return;
+    }
+
+    const size = screen.getPrimaryDisplay().workAreaSize;
+
+    // Default
+    windowState = {
+      x: undefined,
+      y: undefined,
+      width: size.width,
+      height: size.height,
+      isMaximized: true,
+    };
+  };
+
+  const saveState = debounce(() => {
+    if (!windowState.isMaximized) {
+      windowState = window.getBounds();
+    }
+
+    windowState.isMaximized = window.isMaximized();
+    log.silly(`Saving window.${windowName} to configs`);
+    config.set(`window.${windowName}`, windowState);
+    log.silly(windowState);
+  }, 1000);
+
+  const track = (win) => {
+    window = win;
+    ['resize', 'move', 'close'].forEach((event) => {
+      win.on(event, saveState);
+    });
+  };
+
+  setBounds();
+
+  return {
+    state: {
+      x: windowState.x,
+      y: windowState.y,
+      width: windowState.width,
+      height: windowState.height,
+      isMaximized: windowState.isMaximized,
+    },
+    track,
+  };
+};
+
+module.exports = { windowTracker };


### PR DESCRIPTION
This allows the user to not have a fully maximized window on every game launch (very useful on ultrawide).

Adds a min height & width as well as a default title.

Tested on MacOS, Ubuntu & Windows.