### PR TITLE
Use min `server.moneyAvailable` of 1$ when growing server money

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -612,12 +612,12 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
           )} (t=${numeralWrapper.formatThreads(threads)}).`,
       );
       return netscriptDelay(growTime * 1000, workerScript).then(function () {
-        const moneyBefore = server.moneyAvailable <= 0 ? 1 : server.moneyAvailable;
-        processSingleServerGrowth(server, threads, Player, host.cpuCores);
+        const moneyBefore = server.moneyAvailable;
+        const growth = processSingleServerGrowth(server, threads, Player, host.cpuCores);
         const moneyAfter = server.moneyAvailable;
         workerScript.scriptRef.recordGrow(server.hostname, threads);
         const expGain = calculateHackingExpGain(server, Player) * threads;
-        const logGrowPercent = moneyAfter / moneyBefore - 1;
+        const logGrowPercent = growth;
         workerScript.log(
           "grow",
           () =>

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -74,8 +74,8 @@ export function processSingleServerGrowth(server: Server, threads: number, p: IP
     serverGrowth = 1;
   }
 
+  server.moneyAvailable = Math.max(server.moneyAvailable, 1); // It can be grown even if it has no money. 1$ min
   const oldMoneyAvailable = server.moneyAvailable;
-  server.moneyAvailable += 1 * threads; // It can be grown even if it has no money
   server.moneyAvailable *= serverGrowth;
 
   // in case of data corruption


### PR DESCRIPTION
fixes #2783

set a min `server.moneyAvailable` of 1$ when growing server money.

it is already in place for scripts, but it was missing for terminal command. Causing divisions by 0

# Bug fix

- Include how it was tested (TODO)
- Include screenshot / gif (if possible) (TODO)
