### PR TITLE
Improve hack money drained from server rounding system

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -357,7 +357,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
           maxThreadNeeded = 1e6;
         }
 
-        let moneyDrained = Math.floor(server.moneyAvailable * percentHacked) * threads;
+        let moneyDrained = Math.floor(server.moneyAvailable * percentHacked * threads);
 
         // Over-the-top safety checks
         if (moneyDrained <= 0) {


### PR DESCRIPTION
fixes #2786 
 
round `moneyDrained` after multiplying by `threads`, not before

with current behavior if `server.moneyAvailable * percentHacked` < 1, then it results in no money hacked, causing #2786

# Bug fix

- Include how it was tested (TODO)
- Include screenshot / gif (if possible) (TODO)
