### PR TITLE
Set nativeWindowOpen to fix deprecation warning

### DIFF
--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -18,6 +18,9 @@ async function createWindow(killall) {
     show: false,
     backgroundThrottling: false,
     backgroundColor: "#000000",
+    webPreferences: {
+      nativeWindowOpen: true,
+    },
   });
 
   window.removeMenu();


### PR DESCRIPTION
If we update to v15 we could hit this breaking change. It'll be the default so might as well specify it right now so we don't depend on the other behaviour. This resolves a depreciation warning when starting the app.

https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-150

> Prior to Electron 15, window.open was by default shimmed to use BrowserWindowProxy. This meant that window.open('about:blank') did not work to open synchronously scriptable child windows, among other incompatibilities. nativeWindowOpen is no longer experimental, and is now the default.

Tested on Windows 10 and Ubuntu without any issues to open links and such.