### PR TITLE
Band-aid fix for visible 'spoilers' in factions RTD

### DIFF
--- a/doc/source/basicgameplay/factions.rst
+++ b/doc/source/basicgameplay/factions.rst
@@ -30,6 +30,11 @@ from faction to faction.
 
 List of Factions and their Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. raw:: html
+
+	<details><summary><a>Early Game Factions</a></summary>
+
+.. _gameplay_factions:: 
 
 +---------------------+----------------+-----------------------------------------+-------------------------------+
 | Early Game          | Faction Name   | Requirements                            | Joining this Faction prevents |
@@ -46,7 +51,18 @@ List of Factions and their Requirements
 |                     |                | * Total Hacknet RAM of 8                |                               |
 |                     |                | * Total Hacknet Cores of 4              |                               |
 +---------------------+----------------+-----------------------------------------+-------------------------------+
-| City Factions       | Sector-12      | * Be in Sector-12                       | * Chongqing                   |
+.. raw:: html
+
+	</details>
+	<details><summary><a>City Factions</a></summary>
+
+.. _gameplay_factions:: 
+
++---------------------+----------------+-----------------------------------------+-------------------------------+
+| City Factions       | Faction Name   | Requirements                            | Joining this Faction prevents |
+|                     |                |                                         | you from joining:             |
++                     +----------------+-----------------------------------------+-------------------------------+
+|                     | Sector-12      | * Be in Sector-12                       | * Chongqing                   |
 |                     |                | * $15m                                  | * New Tokyo                   |
 |                     |                |                                         | * Ishima                      |
 |                     |                |                                         | * Volhaven                    |
@@ -74,8 +90,19 @@ List of Factions and their Requirements
 |                     |                |                                         | * New Tokyo                   |
 |                     |                |                                         | * Ishima                      |
 +---------------------+----------------+-----------------------------------------+-------------------------------+
-| Hacking             | NiteSec        | * Install a backdoor on the avmnite-02h |                               |
-| Groups              |                |   server                                |                               |
+.. raw:: html
+
+	</details>
+	<details><summary><a>Hacking Groups</a></summary>
+
+.. _gameplay_factions:: 
+
++---------------------+----------------+-----------------------------------------+-------------------------------+
+| Hacking             | Faction Name   | Requirements                            | Joining this Faction prevents |
+| Groups              |                |                                         | you from joining:             |
++                     +----------------+-----------------------------------------+-------------------------------+
+|                     | NiteSec        | * Install a backdoor on the avmnite-02h |                               |
+|                     |                |   server                                |                               |
 |                     |                |                                         |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
 |                     | The Black Hand | * Install a backdoor on the I.I.I.I     |                               |
@@ -86,7 +113,18 @@ List of Factions and their Requirements
 |                     |                |   server                                |                               |
 |                     |                |                                         |                               |
 +---------------------+----------------+-----------------------------------------+-------------------------------+
-| Megacorporations    | ECorp          | * Have 200k reputation with             |                               |
+.. raw:: html
+
+	</details>
+	<details><summary><a>Megacorporations</a></summary>
+
+.. _gameplay_factions:: 
+
++---------------------+----------------+-----------------------------------------+-------------------------------+
+| Megacorporations    | Faction Name   | Requirements                            | Joining this Faction prevents |
+|                     |                |                                         | you from joining:             |
++                     +----------------+-----------------------------------------+-------------------------------+
+|                     | ECorp          | * Have 200k reputation with             |                               |
 |                     |                |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
 |                     | MegaCorp       | * Have 200k reputation with             |                               |
@@ -118,8 +156,19 @@ List of Factions and their Requirements
 |                     |                | * Install a backdoor on the             |                               |
 |                     |                |   fulcrumassets server                  |                               |
 +---------------------+----------------+-----------------------------------------+-------------------------------+
-| Criminal            | Slum Snakes    | * All Combat Stats of 30                |                               |
-| Organizations       |                | * -9 Karma                              |                               |
+.. raw:: html
+
+	</details>
+	<details><summary><a>Criminal Organizations</a></summary>
+
+.. _gameplay_factions:: 
+
++---------------------+----------------+-----------------------------------------+-------------------------------+
+| Criminal            | Faction Name   | Requirements                            | Joining this Faction prevents |
+| Organizations       |                |                                         | you from joining:             |
++                     +----------------+-----------------------------------------+-------------------------------+
+|                     | Slum Snakes    | * All Combat Stats of 30                |                               |
+|                     |                | * -9 Karma                              |                               |
 |                     |                | * $1m                                   |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
 |                     | Tetrads        | * Be in Chongqing, New Tokyo, or Ishima |                               |
@@ -150,8 +199,19 @@ List of Factions and their Requirements
 |                     |                | * -90 Karma                             |                               |
 |                     |                | * Not working for CIA or NSA            |                               |
 +---------------------+----------------+-----------------------------------------+-------------------------------+
-| Endgame             | The Covenant   | * 20 Augmentations                      |                               |
-| Factions            |                | * $75b                                  |                               |
+.. raw:: html
+
+	</details>
+	<details><summary><a>Endgame Factions</a></summary>
+
+.. _gameplay_factions:: 
+
++---------------------+----------------+-----------------------------------------+-------------------------------+
+| Endgame             | Faction Name   | Requirements                            | Joining this Faction prevents |
+| Factions            |                |                                         | you from joining:             |
++                     +----------------+-----------------------------------------+-------------------------------+
+|                     | The Covenant   | * 20 Augmentations                      |                               |
+|                     |                | * $75b                                  |                               |
 |                     |                | * Hacking Level of 850                  |                               |
 |                     |                | * All Combat Stats of 850               |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
@@ -165,3 +225,6 @@ List of Factions and their Requirements
 |                     |                | * Hacking Level of 1500                 |                               |
 |                     |                | * All Combat Stats of 1200              |                               |
 +---------------------+----------------+-----------------------------------------+-------------------------------+
+.. raw:: html
+
+	</details><br>


### PR DESCRIPTION
Segments the table into multiple expandable parts using the raw RST directive to add HTML directly to the page. Not really a great practice, but would at least quell any arguments as to how spoiler heavy the page is in the meantime.

I'm not sure that the proposed change is up to standard, but will open the PR based on initial feedback to screenshots and leave for others to decide.

Screenshots of what it looked like after generation on my PC. 

![Code_2022-01-24_21-02-34](https://user-images.githubusercontent.com/13705865/150868236-cf179262-94e7-4de0-91c3-bd8c8aff8bf2.png)

![explorer_2022-01-24_21-04-13](https://user-images.githubusercontent.com/13705865/150868241-70340306-68dd-473b-8922-d45043a5a6a9.png)

![explorer_2022-01-24_21-03-36](https://user-images.githubusercontent.com/13705865/150868244-4e2d97a6-f2c2-4cfc-ae7a-f425a6ee28da.png)
