### PR TITLE
Fix augmentation order when set to alphabetically

### DIFF
--- a/src/Augmentation/ui/InstalledAugmentations.tsx
+++ b/src/Augmentation/ui/InstalledAugmentations.tsx
@@ -26,7 +26,7 @@ export function InstalledAugmentations(): React.ReactElement {
 
   if (Settings.OwnedAugmentationsOrder === OwnedAugmentationsOrderSetting.Alphabetically) {
     sourceAugs.sort((aug1, aug2) => {
-      return aug1.name <= aug2.name ? -1 : 1;
+      return aug1.name.localeCompare(aug2.name);
     });
   }
 


### PR DESCRIPTION
# Fix installed augmentation sort

## Current behaviour

Currently, when in `OwnedAugmentationsOrderSetting.Alphabetically` sorting mode, augmentation names are compared by char code, which results in "CRTX" being sorted before "Cash" (since `'R' < 'a' == true`).

## Bug fix

Use in-built `localeCompare` to correctly sort augmentation names. The following js-fiddle illustrates the proposed change: 
https://jsfiddle.net/e0d9n8sL/3/
