### PR TITLE
Corp API: Add setSmartSupplyUseLeftovers

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -49,6 +49,7 @@ import {
   SetMaterialMarketTA2,
   SetProductMarketTA1,
   SetProductMarketTA2,
+  SetSmartSupplyUseLeftovers,
 } from "../Corporation/Actions";
 import { CorporationUnlockUpgrades } from "../Corporation/data/CorporationUnlockUpgrades";
 import { CorporationUpgrades } from "../Corporation/data/CorporationUpgrades";
@@ -409,6 +410,16 @@ export function NetscriptCorporation(
       const enabled = helper.boolean(aenabled);
       const warehouse = getWarehouse(divisionName, cityName);
       SetSmartSupply(warehouse, enabled);
+    },
+    setSmartSupplyUseLeftovers: function (adivisionName: any, acityName: any, amaterialName: any, aenabled: any): void {
+      checkAccess("setSmartSupplyUseLeftovers", 7);
+      const divisionName = helper.string("setSmartSupply", "divisionName", adivisionName);
+      const cityName = helper.string("sellProduct", "cityName", acityName);
+      const materialName = helper.string("sellProduct", "materialName", amaterialName);
+      const enabled = helper.boolean(aenabled);
+      const warehouse = getWarehouse(divisionName, cityName);
+      const material = getMaterial(divisionName, cityName, materialName);
+      SetSmartSupplyUseLeftovers(warehouse, material, enabled);
     },
     buyMaterial: function (adivisionName: any, acityName: any, amaterialName: any, aamt: any): void {
       checkAccess("buyMaterial", 7);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6256,6 +6256,14 @@ export interface WarehouseAPI {
    */
   setSmartSupply(divisionName: string, cityName: string, enabled: boolean): void;
   /**
+   * Set whether smart supply uses leftovers before buying
+   * @param divisionName - Name of the division
+   * @param cityName - Name of the city
+   * @param materialName - Name of the material
+   * @param enabled - smart supply use leftovers enabled
+   */
+  setSmartSupplyUseLeftovers(divisionName: string, cityName: string, materialName: string, enabled: boolean): void;
+  /**
    * Set material buy data
    * @param divisionName - Name of the division
    * @param cityName - Name of the city


### PR DESCRIPTION
The API can already toggle smart supply on/off, but can't manage the
related controls for whether smart supply will draw from the existing
materials in the warehouse. Without it, we can't keep some resources in
storage to boost the production multiplier without disabling smart
supply entirely.

## Testing

Started a corp, opened a Software division, and bought Smart Supply.

Smart supply settings were initially:

![image](https://user-images.githubusercontent.com/510/151041118-2156e9c9-7035-438e-a157-dedb78bb6167.png)

Ran this script:

```js
export async function main(ns) {
    ns.corporation.setSmartSupply('sw', 'Sector-12', true);
    ns.corporation.setSmartSupplyUseLeftovers('sw', 'Sector-12', 'Energy', true);
    ns.corporation.setSmartSupplyUseLeftovers('sw', 'Sector-12', 'Hardware', false);
}
```

And the settings are now:

![image](https://user-images.githubusercontent.com/510/151041660-50dfb2d2-d161-4c4e-8a63-1cd5c58d9204.png)
