### PR TITLE
Indicate that getRunningScript can return null

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5396,7 +5396,7 @@ export interface NS extends Singularity {
    * @param filename - Optional. Filename or PID of the script.
    * @param hostname - Optional. Name of host server the script is running on.
    * @param args  - Arguments to identify the script
-   * @returns info about a running script
+   * @returns The info about the running script if found, and null otherwise.
    */
   getRunningScript(filename?: FilenameOrPID, hostname?: string, ...args: (string | number)[]): RunningScript;
 


### PR DESCRIPTION
This tripped me up when using it -- I wasn't sure how to test whether a running script existed. Not sure whether the type should be updated to `RunningScript | null` or not so I left as is and just changed the comment, but let me know if I should update the type too!

Feel free to reject, nit, or ask for changes :)