### PR TITLE
Fix: Cypress tests for dev (updates to match UI changes)

### DIFF
--- a/cypress/integration/naviguation.spec.ts
+++ b/cypress/integration/naviguation.spec.ts
@@ -3,7 +3,6 @@ export {};
 describe("netscript", () => {
   it("Do naviguation", () => {
     cy.findByRole("button", { name: "SKIP TUTORIAL" }).click();
-    cy.findByText("Got it!").click();
 
     cy.findByText("Dev").click();
     cy.findByText(/Source-Files/i).click();
@@ -23,11 +22,11 @@ describe("netscript", () => {
     cy.findByText(/Experience/i).click();
     cy.findByText(/Tons of exp/i).click();
 
-    cy.findByText("Create Script").click();
-    cy.findByText(/Script name:/i);
+    cy.findByText("Script Editor").click();
+    cy.findByText(/No Open Files/i);
 
     cy.findByText("Active Scripts").click();
-    cy.findByText(/Total online production of/i);
+    cy.findByText(/Total production since last Augment/i);
 
     cy.findByText("Create Program").click();
     cy.findByText(/This page displays/i);
@@ -65,9 +64,9 @@ describe("netscript", () => {
     cy.findByText(/don't reward you for/i);
 
     cy.findByText("Tutorial").click();
-    cy.findByText(/AKA Links to/i);
+    cy.findByText(/Tutorial \/ Documentation/i);
 
     cy.findByText("Options").click();
-    cy.findByText(/Netscript exec time/i);
+    cy.findByText(/\.script exec time/i);
   });
 });

--- a/cypress/integration/netscript.spec.ts
+++ b/cypress/integration/netscript.spec.ts
@@ -3,7 +3,6 @@ export {};
 describe("netscript", () => {
   it("creates and runs a NetScript 2.0 script", () => {
     cy.findByRole("button", { name: "SKIP TUTORIAL" }).click();
-    cy.findByText("Got it!").click();
 
     cy.findByRole("textbox").type("connect n00dles{enter}");
     cy.findByText(/connected to n00dles/i);
@@ -17,12 +16,13 @@ describe("netscript", () => {
     cy.findByRole("textbox").type("nano script.js{enter}");
 
     // monaco can take a bit
-    cy.findByRole("code", { timeout: 15_000 }).type("{selectall}{del}").type(`export const main = async (ns) => {{}
+    cy.findByRole("code", { timeout: 15_000 }).type("{ctrl}a{del}").type(`export const main = async (ns) => {{}
   while(true) {{}
   await ns.hack("n00dles");`);
 
     cy.findByText("RAM: 1.70GB");
-    cy.findByRole("button", { name: /Save & Close/i }).click();
+    cy.findByRole("button", { name: /Save \(Ctrl\/Cmd \+ s\)/i }).click();
+    cy.findByRole("button", { name: /Close \(Ctrl\/Cmd \+ b\)/i }).click();
 
     cy.findByRole("textbox").type("run script.js{enter}");
     cy.findByText(/Running script with 1 thread/);
@@ -33,17 +33,17 @@ describe("netscript", () => {
 
   it("errors and shows a dialog box when static RAM !== dynamic RAM", () => {
     cy.findByRole("button", { name: "SKIP TUTORIAL" }).click();
-    cy.findByText("Got it!").click();
 
     cy.findByRole("textbox").type("nano script.js{enter}");
 
     // monaco can take a bit
-    cy.findByRole("code", { timeout: 15_000 }).type("{selectall}{del}").type(`export const main = async (ns) => {{}
+    cy.findByRole("code", { timeout: 15_000 }).type("{ctrl}a{del}").type(`export const main = async (ns) => {{}
 const command = "hack";
 ns[command]("n00dles");`);
 
     cy.findByText("RAM: 1.60GB");
-    cy.findByRole("button", { name: /Save & Close/i }).click();
+    cy.findByRole("button", { name: /Save \(Ctrl\/Cmd \+ s\)/i }).click();
+    cy.findByRole("button", { name: /Close \(Ctrl\/Cmd \+ b\)/i }).click();
 
     cy.findByRole("textbox").type("run script.js{enter}");
     cy.findByText(/Dynamic RAM usage calculated to be greater than initial RAM usage on fn: hack./i);

--- a/cypress/integration/tutorial.spec.ts
+++ b/cypress/integration/tutorial.spec.ts
@@ -55,7 +55,7 @@ describe("tutorial", () => {
     // monaco can take a bit
     cy.findByRole("code", { timeout: 15_000 }).type("{selectall}{del}").type("while(true) {{}{enter}hack('n00dles');");
 
-    cy.findByRole("button", { name: /Save & Close/i }).click();
+    cy.findByRole("button", { name: /Save \(Ctrl\/Cmd \+ s\)/i }).click();
 
     cy.findByText(/now we'll run the script/i);
     cy.findByRole("textbox").type("free{enter}");
@@ -89,8 +89,7 @@ describe("tutorial", () => {
 
     cy.findByText(/a lot of different documentation about the game/i);
     cy.findByRole("button", { name: "FINISH TUTORIAL" }).click();
-    cy.findByText("Got it!").click();
 
-    cy.findByText(/Tutorial \(AKA Links to Documentation\)/i);
+    cy.findByText(/Tutorial \/ Documentation/i);
   });
 });

--- a/cypress/support/globalHooks.ts
+++ b/cypress/support/globalHooks.ts
@@ -1,9 +1,10 @@
 export {};
 
 beforeEach(() => {
-  cy.visit("/");
-  cy.clearLocalStorage();
-  cy.window().then((win) => {
-    win.indexedDB.deleteDatabase("bitburnerSave");
+  cy.visit("/", {
+    onBeforeLoad(win: Cypress.AUTWindow) {
+      win.indexedDB.deleteDatabase("bitburnerSave");
+    }
   });
+  cy.clearLocalStorage();
 });

--- a/src/BitNode/ui/BitverseRoot.tsx
+++ b/src/BitNode/ui/BitverseRoot.tsx
@@ -85,7 +85,7 @@ function BitNodePortal(props: IPortalProps): React.ReactElement {
           </Typography>
         }
       >
-        <span onClick={() => setPortalOpen(true)} className={cssClass}>
+        <span onClick={() => setPortalOpen(true)} className={cssClass} aria-label={`enter-bitnode-${bitNode.number.toString()}`}>
           <b>O</b>
         </span>
       </Tooltip>


### PR DESCRIPTION
Updates the cypress tests to match the UI changes that have been made over the past few months.

The tests now pass for cy:dev but not cy:test, as the navigation tests currently use the dev menu, which isn't available in the production build. This at least allows us to run the tests when developing, but will need solving for the production build and future automation around that.

One way to solve it would be to set the indexeddb to a saved state which has the relevant requirements for each test in beforeEach. Each test would then have its own preconfigured save file to allow testing of specific situations. I haven't done this as part of this PR, as I feel it may need some discussion.