### PR TITLE
Add rounding to getPurchaseServerCost

### DIFF
--- a/src/Server/ServerPurchases.ts
+++ b/src/Server/ServerPurchases.ts
@@ -30,7 +30,7 @@ export function getPurchaseServerCost(ram: number): number {
 
   const upg = Math.max(0, Math.log(sanitizedRam) / Math.log(2) - 6);
 
-  return (
+  return Math.round(
     sanitizedRam *
     CONSTANTS.BaseCostFor1GBOfRamServer *
     BitNodeMultipliers.PurchasedServerCost *


### PR DESCRIPTION
The prices like "23795200.000000004" don't look nice for human eyes.
Fixes #2812