### PR TITLE
Make crimes detection a little more friendly

### DIFF
--- a/src/Crime/CrimeHelpers.ts
+++ b/src/Crime/CrimeHelpers.ts
@@ -42,9 +42,9 @@ export function findCrime(roughName: string): Crime | null {
     return Crimes.Larceny;
   } else if (roughName.includes("drugs")) {
     return Crimes.DealDrugs;
-  } else if (roughName.includes("bond") && roughName.includes("forge")) {
+  } else if (roughName.includes("bond") && roughName.includes("forg")) {
     return Crimes.BondForgery;
-  } else if (roughName.includes("traffick") && roughName.includes("arms")) {
+  } else if ((roughName.includes("traffic") || (roughName.includes("illegal")) && roughName.includes("arms")) {
     return Crimes.TraffickArms;
   } else if (roughName.includes("homicide")) {
     return Crimes.Homicide;
@@ -52,7 +52,7 @@ export function findCrime(roughName: string): Crime | null {
     return Crimes.GrandTheftAuto;
   } else if (roughName.includes("kidnap")) {
     return Crimes.Kidnap;
-  } else if (roughName.includes("assassinate") || roughName.includes("assassination")) {
+  } else if (roughName.includes("assassin")) {
     return Crimes.Assassination;
   } else if (roughName.includes("heist")) {
     return Crimes.Heist;

--- a/src/Crime/CrimeHelpers.ts
+++ b/src/Crime/CrimeHelpers.ts
@@ -42,7 +42,7 @@ export function findCrime(roughName: string): Crime | null {
     return Crimes.Larceny;
   } else if (roughName.includes("drugs")) {
     return Crimes.DealDrugs;
-  } else if (roughName.includes("bond") && roughName.includes("forg")) {
+  } else if (roughName.includes("bond") && roughName.includes("forge")) {
     return Crimes.BondForgery;
   } else if ((roughName.includes("traffic") || (roughName.includes("illegal")) && roughName.includes("arms")) {
     return Crimes.TraffickArms;


### PR DESCRIPTION
Initially just wanted to change "traffick" to "traffic" (as that supports both the American and British spelling), but then noticed there were a couple of other ones that could be made slightly less restrictive to improve detection. All changes make detection LESS RESTRICTIVE for the player (ie, they have more ways to provide the parameter), none are MORE RESTRICTIVE (ie, won't break any existing code, etc.)

Anything that worked before will still work, but now a few things that may not have worked before - like "traffic arms" (without the k), "illegal arms", and "assassin" will work. (Also allowed for the common misspelling of "forgary")