### PR TITLE
[Balance] Add CalculateShareMult to Field Work and Security Work

### DIFF
--- a/src/PersonObjects/formulas/reputation.ts
+++ b/src/PersonObjects/formulas/reputation.ts
@@ -25,26 +25,19 @@ export function getHackingWorkRepGain(p: IPlayer, f: Faction): number {
 export function getFactionSecurityWorkRepGain(p: IPlayer, f: Faction): number {
   const t =
     (0.9 *
-      (p.hacking / CONSTANTS.MaxSkillLevel +
-        p.strength / CONSTANTS.MaxSkillLevel +
-        p.defense / CONSTANTS.MaxSkillLevel +
-        p.dexterity / CONSTANTS.MaxSkillLevel +
-        p.agility / CONSTANTS.MaxSkillLevel +
-        p.intelligence / CONSTANTS.MaxSkillLevel)) /
-    4.5;
+      (p.strength + p.defense + p.dexterity + p.agility +
+        (p.hacking + p.intelligence) * CalculateShareMult()
+      )
+    ) / CONSTANTS.MaxSkillLevel / 4.5;
   return t * p.faction_rep_mult * mult(f) * p.getIntelligenceBonus(1);
 }
 
 export function getFactionFieldWorkRepGain(p: IPlayer, f: Faction): number {
   const t =
     (0.9 *
-      (p.hacking / CONSTANTS.MaxSkillLevel +
-        p.strength / CONSTANTS.MaxSkillLevel +
-        p.defense / CONSTANTS.MaxSkillLevel +
-        p.dexterity / CONSTANTS.MaxSkillLevel +
-        p.agility / CONSTANTS.MaxSkillLevel +
-        p.charisma / CONSTANTS.MaxSkillLevel +
-        p.intelligence / CONSTANTS.MaxSkillLevel)) /
-    5.5;
+      (p.strength + p.defense + p.dexterity + p.agility + p.charisma +
+        (p.hacking + p.intelligence) * CalculateShareMult()
+      )
+    ) / CONSTANTS.MaxSkillLevel / 5.5;
   return t * p.faction_rep_mult * mult(f) * p.getIntelligenceBonus(1);
 }


### PR DESCRIPTION
Add CalculateShareMult to Field Work and Security Work.
It boosts only hacking and intelligence skills (like it basically does in Hacking Work, as they are the only skills used there), but not the other skills. So if the player is low on hacking but high on combat stats it almost doesn't affect a lot.
Closes #2708