### PR TITLE
Speed up employee productivity calculation

### DIFF
--- a/src/Corporation/Employee.ts
+++ b/src/Corporation/Employee.ts
@@ -2,9 +2,7 @@ import { CorporationConstants } from "./data/Constants";
 import { getRandomInt } from "../utils/helpers/getRandomInt";
 import { Generic_fromJSON, Generic_toJSON, Reviver } from "../utils/JSONReviver";
 import { EmployeePositions } from "./EmployeePositions";
-import { ICorporation } from "./ICorporation";
 import { OfficeSpace } from "./OfficeSpace";
-import { IIndustry } from "./IIndustry";
 
 interface IParams {
   name?: string;
@@ -18,6 +16,13 @@ interface IParams {
   efficiency?: number;
   salary?: number;
   loc?: string;
+}
+
+interface EmployeeStatMultipliers {
+  cre: number;
+  cha: number;
+  int: number;
+  eff: number;
 }
 
 export class Employee {
@@ -82,11 +87,11 @@ export class Employee {
     return salary;
   }
 
-  calculateProductivity(corporation: ICorporation, industry: IIndustry): number {
-    const effCre = this.cre * corporation.getEmployeeCreMultiplier() * industry.getEmployeeCreMultiplier(),
-      effCha = this.cha * corporation.getEmployeeChaMultiplier() * industry.getEmployeeChaMultiplier(),
-      effInt = this.int * corporation.getEmployeeIntMultiplier() * industry.getEmployeeIntMultiplier(),
-      effEff = this.eff * corporation.getEmployeeEffMultiplier() * industry.getEmployeeEffMultiplier();
+  calculateProductivity(mults: EmployeeStatMultipliers): number {
+    const effCre = this.cre * mults.cre,
+      effCha = this.cha * mults.cha,
+      effInt = this.int * mults.int,
+      effEff = this.eff * mults.eff;
     const prodBase = this.mor * this.hap * this.ene * 1e-6;
     let prodMult = 0;
     switch (this.pos) {

--- a/src/Corporation/OfficeSpace.ts
+++ b/src/Corporation/OfficeSpace.ts
@@ -107,10 +107,17 @@ export class OfficeSpace {
       this.employeeProd[name] = 0;
     }
 
+    const mults = {
+      cre: corporation.getEmployeeCreMultiplier() * industry.getEmployeeCreMultiplier(),
+      cha: corporation.getEmployeeChaMultiplier() * industry.getEmployeeChaMultiplier(),
+      int: corporation.getEmployeeIntMultiplier() * industry.getEmployeeIntMultiplier(),
+      eff: corporation.getEmployeeEffMultiplier() * industry.getEmployeeEffMultiplier(),
+    };
+
     let total = 0;
     for (let i = 0; i < this.employees.length; ++i) {
       const employee = this.employees[i];
-      const prod = employee.calculateProductivity(corporation, industry);
+      const prod = employee.calculateProductivity(mults);
       this.employeeProd[employee.pos] += prod;
       total += prod;
     }


### PR DESCRIPTION
The previous implementation was recomputing the corporate and industry
employee stat multipliers for every employee. Industry multipliers
require looping through the entire industry research tree each time.
The values don't change within a single productivity recalc, so
calculate them once and pass them to each employee.

TBH the issue probably isn't noticeable until absurd employee counts; I
had let a script scale up to ~200k total employees across every product
industry. Between this and probably some GC issues, pauses were pushing
250ms which is enough to make just switching between screens obviously
lag.

## Testing

Dev mode, spun up a corp with 120k employees. Before:
![employee-prod-before](https://user-images.githubusercontent.com/510/151495649-5b194828-70df-4a85-9008-4cb0a5558aef.png)

After:
![employee-prod-after](https://user-images.githubusercontent.com/510/151495671-8a5b9bd2-b9a7-4326-b435-1acf9789cbfb.png)

Script used to set up the corp:

```js
export async function main(ns) {
	ns.corporation.expandIndustry('Agriculture', 'ag');
	ns.corporation.expandIndustry('RealEstate', 're');
	ns.corporation.expandIndustry('Software', 'sw');
	ns.corporation.expandIndustry('Tobacco', 'tb');

	for (const div of ['ag', 're', 'sw', 'tb']) {
		for (const city of ['Aevum', 'Chongqing', 'Sector-12', 'Ishima', 'New Tokyo', 'Volhaven']) {
			if (city != 'Sector-12')
				ns.corporation.expandCity(div, city);

			ns.corporation.upgradeOfficeSize(div, city, 5000);
			while (ns.corporation.getOffice(div, city).employees.length < ns.corporation.getOffice(div, city).size)
				ns.corporation.hireEmployee(div, city);
			
			for (const job of ['Operations', 'Engineer', 'Business', 'Management', 'Research & Development'])
				await ns.corporation.setAutoJobAssignment(div, city, job, 1000);
		}
	}
}
```