### PR TITLE
(ALPHA) growthAnalyze (choice 2 / less vodoo) - only merge one of these

### DIFF
--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -71,8 +71,8 @@ export function numCycleForGrowth(server: Server, growth: number, p: IPlayer, co
  * with parameters that are the same (for compatibility), but functionality is slightly different.
  * This function can ONLY be used to calculate the threads needed for a given server in its current state,
  * and so wouldn't be appropriate to use for formulas.exe or ns.growthAnalyze (as those are meant to
- * provide theoretical scenaarios, or inverse hack respectively). Players COULD use this function with a
- * custom server object with the correct moneyAvailable and moneyMax amounts, combined with a multplier
+ * provide theoretical scenarios, or inverse hack respectively). Players COULD use this function with a
+ * custom server object with the correct moneyAvailable and moneyMax amounts, combined with a multiplier
  * correctly calculated to bring the server to a new moneyAvailable (ie, pasing in moneyAvailable 300 and x2
  * when you want the number of threads required to grow that particular server from 300 to 600), and this
  * function would pass back the correct number of threads. But the key thing is that it doesn't just
@@ -81,8 +81,8 @@ export function numCycleForGrowth(server: Server, growth: number, p: IPlayer, co
  * application, so another function with different parameters is provided for that case below this one.
  * Instead this function is meant to hand-off from the old numCycleForGrowth function to the new one
  * where used internally for pro-rating or the like. Where you have applied a grow and want to determine
- * how many htreads were needed for THAT SPECIFIC grow case using a multiplier.
- * Idealy, this function, and the original function above will be depreciated to use the methodology
+ * how many threads were needed for THAT SPECIFIC grow case using a multiplier.
+ * Ideally, this function, and the original function above will be depreciated to use the methodology
  * and inputs of the new function below this one. Even for internal cases (it's actually easier to do so).
  * @param server - Server being grown
  * @param growth - How much the server is being grown by, in DECIMAL form (e.g. 1.5 rather than 50)
@@ -98,7 +98,7 @@ export function numCycleForGrowthTransition(server: Server, growth: number, p: I
  * (ie, how many threads to grow this server from $200 to $600 for example). Used primarily for a formulas (or possibly growthAnalyze)
  * type of application. It lets you "theorycraft" and easily ask what-if type questions. It's also the one that implements the
  * main thread calculation algorith, and so is the fuinction all helper functions should call.
- * It protects the inputs (so putting in INFINITY for targetMoney will use moneyMax, putting in a nagitive for start will use 0, etc.)
+ * It protects the inputs (so putting in INFINITY for targetMoney will use moneyMax, putting in a negative for start will use 0, etc.)
  * @param server - Server being grown
  * @param targetMoney - How much you want the server grown TO (not by), for instance, to grow from 200 to 600, input 600
  * @param startMoney - How much you are growing the server from, for instance, to grow from 200 to 600, input 200

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -94,7 +94,7 @@ export function numCycleForGrowthTransition(server: Server, growth: number, p: I
 }
 
 /**
- * This function calculates the number of threads needed to grow a server from one $amount to a the same or higher $amount
+ * This function calculates the number of threads needed to grow a server from one $amount to a higher $amount
  * (ie, how many threads to grow this server from $200 to $600 for example). Used primarily for a formulas (or possibly growthAnalyze)
  * type of application. It lets you "theorycraft" and easily ask what-if type questions. It's also the one that implements the
  * main thread calculation algorith, and so is the fuinction all helper functions should call.

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -146,7 +146,7 @@ export function numCycleForGrowthCorrected(server: Server, targetMoney: number, 
  * @param p - Reference to Player object
  * @returns Number of "growth cycles" needed to reverse the described hack
  */
-export function numCycleForGrowthByHackAmt(server: Server, hackAmt: number, prehackMoney: number, p: IPlayer, cores = 1) {
+export function numCycleForGrowthByHackAmt(server: Server, hackAmt: number, prehackMoney: number, p: IPlayer, cores = 1): number{
 	if (prehackMoney > server.moneyMax) { prehackMoney = server.moneyMax; }
 	const posthackAmt = Math.floor(prehackMoney * Math.min(1, Math.max(0, (1 - hackAmt))));
 	return numCycleForGrowthCorrected(server, prehackMoney, posthackAmt, p, cores);

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -97,7 +97,7 @@ export function numCycleForGrowthTransition(server: Server, growth: number, p: I
  * This function calculates the number of threads needed to grow a server from one $amount to a higher $amount
  * (ie, how many threads to grow this server from $200 to $600 for example). Used primarily for a formulas (or possibly growthAnalyze)
  * type of application. It lets you "theorycraft" and easily ask what-if type questions. It's also the one that implements the
- * main thread calculation algorith, and so is the fuinction all helper functions should call.
+ * main thread calculation algorith, and so is the function all helper functions should call.
  * It protects the inputs (so putting in INFINITY for targetMoney will use moneyMax, putting in a negative for start will use 0, etc.)
  * @param server - Server being grown
  * @param targetMoney - How much you want the server grown TO (not by), for instance, to grow from 200 to 600, input 600

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -149,7 +149,7 @@ export function numCycleForGrowthCorrected(server: Server, targetMoney: number, 
 export function numCycleForGrowthByHackAmt(server: Server, hackAmt: number, prehackMoney: number, p: IPlayer, cores = 1): number{
 	if (prehackMoney > server.moneyMax) prehackMoney = server.moneyMax;
 	const posthacMoney = Math.floor(prehackMoney * Math.min(1, Math.max(0, (1 - hackAmt))));
-	return numCycleForGrowthCorrected(server, posthacMoney, prehackMoney, p, cores);
+	return numCycleForGrowthCorrected(server, prehackMoney, posthacMoney, p, cores);
 }
 
 /**
@@ -165,7 +165,7 @@ export function numCycleForGrowthByMultiplier(server: Server, growth: number, p:
   if (!(growth > 1.0)) growth = 1.0; //prevent /0 and other issues
 	const posthacMoney = server.moneyMax;
   const prehackMoney = server.moneyMax / growth;
-	return numCycleForGrowthCorrected(server, posthacMoney, prehackMoney, p, cores);
+	return numCycleForGrowthCorrected(server, prehackMoney, posthacMoney, p, cores);
 }
 
 

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -104,6 +104,7 @@ export function numCycleForGrowthTransition(server: Server, growth: number, p: I
  * @param startMoney - How much you are growing the server from, for instance, to grow from 200 to 600, input 200
  * @param p - Reference to Player object
  * @returns Number of "growth cycles" needed
+ */
 export function numCycleForGrowthCorrected(server: Server, targetMoney: number, startMoney: number, p: IPlayer, cores = 1): number {
   return 0; //left off here.
 }

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -146,10 +146,10 @@ export function numCycleForGrowthCorrected(server: Server, targetMoney: number, 
  * @param p - Reference to Player object
  * @returns Number of "growth cycles" needed to reverse the described hack
  */
-export function numCycleForGrowthByHackAmt(server, hackAmt: number, prehackMoney: number, p: IPlayer, cores = 1) {
-	if (prehackMoney > server.moneyMax) { preHackAmt = server.moneyMax; }
+export function numCycleForGrowthByHackAmt(server: Server, hackAmt: number, prehackMoney: number, p: IPlayer, cores = 1) {
+	if (prehackMoney > server.moneyMax) { prehackMoney = server.moneyMax; }
 	const posthackAmt = Math.floor(prehackMoney * Math.min(1, Math.max(0, (1 - hackAmt))));
-	return numCycleForGrowthCorrected(server, preHackAmt, posthackAmt, player, difficulty, cores, capGrowMult);
+	return numCycleForGrowthCorrected(server, prehackMoney, posthackAmt, p, cores);
 }
 
 //Applied server growth for a single server. Returns the percentage growth

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -162,10 +162,10 @@ export function numCycleForGrowthByHackAmt(server: Server, hackAmt: number, preh
  * @returns Number of "growth cycles" needed
  */
 export function numCycleForGrowthByMultiplier(server: Server, growth: number, p: IPlayer, cores = 1): number{
-  if (!(growth > 1.0)) growth = 1.0;
+  if (!(growth > 1.0)) growth = 1.0; //prevent /0 and other issues
 	const posthacMoney = server.moneyMax;
   const prehackMoney = server.moneyMax / growth;
-	return numCycleForGrowthCorrected(server, prehackMoney, posthacMoney, p, cores);
+	return numCycleForGrowthCorrected(server, posthacMoney, prehackMoney, p, cores);
 }
 
 

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -73,7 +73,7 @@ export function numCycleForGrowth(server: Server, growth: number, p: IPlayer, co
  * and so wouldn't be appropriate to use for formulas.exe or ns.growthAnalyze (as those are meant to
  * provide theoretical scenarios, or inverse hack respectively). Players COULD use this function with a
  * custom server object with the correct moneyAvailable and moneyMax amounts, combined with a multiplier
- * correctly calculated to bring the server to a new moneyAvailable (ie, pasing in moneyAvailable 300 and x2
+ * correctly calculated to bring the server to a new moneyAvailable (ie, passing in moneyAvailable 300 and x2
  * when you want the number of threads required to grow that particular server from 300 to 600), and this
  * function would pass back the correct number of threads. But the key thing is that it doesn't just
  * inverse/undo a hack (since the amount hacked from/to matters, not just the multiplier).

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -139,9 +139,7 @@ export function numCycleForGrowthCorrected(server: Server, targetMoney: number, 
 /**
  * This function calculates the number of threads needed to grow a server based on a pre-hack money and hackAmt
  * (ie, if you're hacking a server with $1e6 moneyAvail for 60%, this function will tell you how many threads to regrow it
- * PROBABLY the best replacement for the current ns.growthAnalyze
- * NOTE: prehackMoney can be removed as a parameter and server.moneyMax used in its place. The return value would then give a thread count
- * that would slowly grow the server more than it is hacked until reaching moneyMax where it would return the correct number of threads.
+ * A good replacement for the current ns.growthAnalyze if you want players to have more control/responsibility
  * @param server - Server being grown
  * @param hackAmt - the amount hacked (total, not per thread) - as a decimal (like 0.60 for hacking 60% of available money)
  * @param prehackMoney - how much money the server had before being hacked (like 200000 for hacking a server that had $200000 on it at time of hacking)
@@ -149,10 +147,27 @@ export function numCycleForGrowthCorrected(server: Server, targetMoney: number, 
  * @returns Number of "growth cycles" needed to reverse the described hack
  */
 export function numCycleForGrowthByHackAmt(server: Server, hackAmt: number, prehackMoney: number, p: IPlayer, cores = 1): number{
-	if (prehackMoney > server.moneyMax) { prehackMoney = server.moneyMax; }
-	const posthackAmt = Math.floor(prehackMoney * Math.min(1, Math.max(0, (1 - hackAmt))));
-	return numCycleForGrowthCorrected(server, prehackMoney, posthackAmt, p, cores);
+	if (prehackMoney > server.moneyMax) prehackMoney = server.moneyMax;
+	const posthacMoney = Math.floor(prehackMoney * Math.min(1, Math.max(0, (1 - hackAmt))));
+	return numCycleForGrowthCorrected(server, posthacMoney, prehackMoney, p, cores);
 }
+
+/**
+ * This function calculates the number of threads needed to grow a server based on a multiplier (and assumes the hack was against a moneyMax'ed server)
+ * (ie, if you're hacking a server with for 60%, this function will tell you how many threads to regrow it if it were maxed when you hacked it)
+ * PROBABLY the best replacement for the current ns.growthAnalyze to maintain existing scripts
+ * @param server - Server being grown
+ * @param growth - How much the server is being grown by, as a multiple in DECIMAL form (e.g. 1.5 rather than 50). Infinity is acceptable.
+ * @param p - Reference to Player object
+ * @returns Number of "growth cycles" needed
+ */
+export function numCycleForGrowthByMultiplier(server: Server, growth: number, p: IPlayer, cores = 1): number{
+  if (!(growth > 1.0)) growth = 1.0;
+	const posthacMoney = server.moneyMax;
+  const prehackMoney = server.moneyMax / growth;
+	return numCycleForGrowthCorrected(server, posthacMoney, prehackMoney, p, cores);
+}
+
 
 //Applied server growth for a single server. Returns the percentage growth
 export function processSingleServerGrowth(server: Server, threads: number, p: IPlayer, cores = 1): number {

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -140,6 +140,8 @@ export function numCycleForGrowthCorrected(server: Server, targetMoney: number, 
  * This function calculates the number of threads needed to grow a server based on a pre-hack money and hackAmt
  * (ie, if you're hacking a server with $1e6 moneyAvail for 60%, this function will tell you how many threads to regrow it
  * PROBABLY the best replacement for the current ns.growthAnalyze
+ * NOTE: prehackMoney can be removed as a parameter and server.moneyMax used in its place. The return value would then give a thread count
+ * that would slowly grow the server more than it is hacked until reaching moneyMax where it would return the correct number of threads.
  * @param server - Server being grown
  * @param hackAmt - the amount hacked (total, not per thread) - as a decimal (like 0.60 for hacking 60% of available money)
  * @param prehackMoney - how much money the server had before being hacked (like 200000 for hacking a server that had $200000 on it at time of hacking)

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -106,7 +106,7 @@ export function numCycleForGrowthTransition(server: Server, growth: number, p: I
  * @returns Number of "growth cycles" needed
  */
 export function numCycleForGrowthCorrected(server: Server, targetMoney: number, startMoney: number, p: IPlayer, cores = 1): number {
- 	if (startMoney == server.moneyMax) { return 0; } //no growth possible, no threads needed
+ 	if (startMoney >= server.moneyMax) { return 0; } //no growth possible, no threads needed
 	if (startMoney < 0) { startMoney = 0; } // servers "can't" have less than 0 dollars on them
 	if (targetMoney > server.moneyMax) { targetMoney = server.moneyMax; } // can't grow a server to more than its moneyMax
 

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -66,6 +66,48 @@ export function numCycleForGrowth(server: Server, growth: number, p: IPlayer, co
   return cycles;
 }
 
+/**
+ * Replacement function for the above function that accounts for the +$1/thread functionality of grow
+ * with parameters that are the same (for compatibility), but functionality is slightly different.
+ * This function can ONLY be used to calculate the threads needed for a given server in its current state,
+ * and so wouldn't be appropriate to use for formulas.exe or ns.growthAnalyze (as those are meant to
+ * provide theoretical scenaarios, or inverse hack respectively). Players COULD use this function with a
+ * custom server object with the correct moneyAvailable and moneyMax amounts, combined with a multplier
+ * correctly calculated to bring the server to a new moneyAvailable (ie, pasing in moneyAvailable 300 and x2
+ * when you want the number of threads required to grow that particular server from 300 to 600), and this
+ * function would pass back the correct number of threads. But the key thing is that it doesn't just
+ * inverse/undo a hack (since the amount hacked from/to matters, not just the multiplier).
+ * The above is also a rather unnecessarily obtuse way of thinking about it for a formulas.exe type of
+ * application, so another function with different parameters is provided for that case below this one.
+ * Instead this function is meant to hand-off from the old numCycleForGrowth function to the new one
+ * where used internally for pro-rating or the like. Where you have applied a grow and want to determine
+ * how many htreads were needed for THAT SPECIFIC grow case using a multiplier.
+ * Idealy, this function, and the original function above will be depreciated to use the methodology
+ * and inputs of the new function below this one. Even for internal cases (it's actually easier to do so).
+ * @param server - Server being grown
+ * @param growth - How much the server is being grown by, in DECIMAL form (e.g. 1.5 rather than 50)
+ * @param p - Reference to Player object
+ * @returns Number of "growth cycles" needed
+ */
+export function numCycleForGrowthTransition(server: Server, growth: number, p: IPlayer, cores = 1): number {
+  return numCycleForGrowthCorrected(server, server.moneyAvailable * growth, server.moneyAvailable, p, cores);
+}
+
+/**
+ * This function calculates the number of threads needed to grow a server from one $amount to a the same or higher $amount
+ * (ie, how many threads to grow this server from $200 to $600 for example). Used primarily for a formulas (or possibly growthAnalyze)
+ * type of application. It lets you "theorycraft" and easily ask what-if type questions. It's also the one that implements the
+ * main thread calculation algorith, and so is the fuinction all helper functions should call.
+ * It protects the inputs (so putting in INFINITY for targetMoney will use moneyMax, putting in a nagitive for start will use 0, etc.)
+ * @param server - Server being grown
+ * @param targetMoney - How much you want the server grown TO (not by), for instance, to grow from 200 to 600, input 600
+ * @param startMoney - How much you are growing the server from, for instance, to grow from 200 to 600, input 200
+ * @param p - Reference to Player object
+ * @returns Number of "growth cycles" needed
+export function numCycleForGrowthCorrected(server: Server, targetMoney: number, startMoney: number, p: IPlayer, cores = 1): number {
+  return 0; //left off here.
+}
+
 //Applied server growth for a single server. Returns the percentage growth
 export function processSingleServerGrowth(server: Server, threads: number, p: IPlayer, cores = 1): number {
   let serverGrowth = calculateServerGrowth(server, threads, p, cores);

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -165,7 +165,7 @@ export function numCycleForGrowthByMultiplier(server: Server, growth: number, p:
   if (!(growth > 1.0)) growth = 1.0;
 	const posthacMoney = server.moneyMax;
   const prehackMoney = server.moneyMax / growth;
-	return numCycleForGrowthCorrected(server, posthacMoney, prehackMoney, p, cores);
+	return numCycleForGrowthCorrected(server, prehackMoney, posthacMoney, p, cores);
 }
 
 

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -146,7 +146,6 @@ export function numCycleForGrowthCorrected(server: Server, targetMoney: number, 
  * @param p - Reference to Player object
  * @returns Number of "growth cycles" needed to reverse the described hack
  */
-server: Server, targetMoney: number, startMoney: number, p: IPlayer, cores = 1): number
 export function numCycleForGrowthByHackAmt(server, hackAmt: number, prehackMoney: number, p: IPlayer, cores = 1) {
 	if (prehackMoney > server.moneyMax) { preHackAmt = server.moneyMax; }
 	const posthackAmt = Math.floor(prehackMoney * Math.min(1, Math.max(0, (1 - hackAmt))));


### PR DESCRIPTION
This implementation involves a simple (and poorly optimized) 50% partition search approximation methodology to determine the number of threads actually required to grow a server from one amount to another.

The advantages of this approach over option 1 is that it allows for the current mechanic of +$1/grow thread pre-multiplier.
The disadvantage is that it can't seamlessly replace the previous functionality (this is just a fact of the current implementation of grow).

The advantage over option 2 is just less math wizardry. Partition searches are a relatively entry level concept compared to using advanced approximation techniques. The disadvantage is that it's almost certainly slower.