### PR TITLE
Better readable production equation (rewording)

### DIFF
--- a/src/Corporation/ui/IndustryProductEquation.tsx
+++ b/src/Corporation/ui/IndustryProductEquation.tsx
@@ -13,12 +13,12 @@ export function IndustryProductEquation(props: IProps): React.ReactElement {
     if (reqAmt === undefined) continue;
     reqs.push(String.raw`${reqAmt}\text{ }${reqMat}`);
   }
-  const prod = props.division.prodMats.slice();
+  const prod = props.division.prodMats.map((p) => `1\\text{ }${p}`);
   if (props.division.makesProducts) {
-    prod.push(props.division.type);
+    prod.push("Products");
   }
 
   return (
-    <MathJaxWrapper>{"\\(" + reqs.join("+") + `\\Rightarrow` + prod.map((p) => `1 \\text{${p}}`).join("+") + "\\)"}</MathJaxWrapper>
+    <MathJaxWrapper>{"\\(" + reqs.join("+") + `\\Rightarrow ` + prod.join("+") + "\\)"}</MathJaxWrapper>
   );
 }


### PR DESCRIPTION
Some formulas were misleading, examples:
```
0.5 Food + 0.5 Water + 0.2 Energy => 1 Food
5 Metal + 5 Energy + 2 Water + 4 Hardware => 1 RealEstate + 1 RealEstate
```
This patch rewords them into:
```
0.5 Food + 0.5 Water + 0.2 Energy => Products
5 Metal + 5 Energy + 2 Water + 4 Hardware => 1 RealEstate + Products
```
Also there are no "1" near product in output, because product production multiplier differs from material production multiplier (this also encourages to develop multiple products rather than one)