### PR TITLE
(Not Tested) Show current task on gang management screen

### DIFF
--- a/src/Gang/ui/GangMemberStats.tsx
+++ b/src/Gang/ui/GangMemberStats.tsx
@@ -63,6 +63,7 @@ export function GangMemberStats(props: IProps): React.ReactElement {
 
   const gang = useGang();
   const data = [
+    [`Current Task:`, `${props.member.task}`],
     [`Money:`, <MoneyRate money={5 * props.member.calculateMoneyGain(gang)} />],
     [`Respect:`, `${numeralWrapper.formatRespect(5 * props.member.calculateRespectGain(gang))} / sec`],
     [`Wanted Level:`, `${numeralWrapper.formatWanted(5 * props.member.calculateWantedLevelGain(gang))} / sec`],


### PR DESCRIPTION
Possible fix for #2718
I haven't been able to test it, so please have someone test before implementing.
(To test, simply open the gang management page and see if it looks ok)