### PR TITLE
Add hasOwnProperty check to GetServer

### DIFF
--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -42,8 +42,11 @@ function GetServerByHostname(hostname: string): BaseServer | null {
 
 //Get server by IP or hostname. Returns null if invalid
 export function GetServer(s: string): BaseServer | null {
-  const server = AllServers[s];
-  if (server) return server;
+  if (AllServers.hasOwnProperty(s)) {
+    const server = AllServers[s];
+    if (server) return server;
+  }
+
   if (!isValidIPAddress(s)) {
     return GetServerByHostname(s);
   }


### PR DESCRIPTION
So the player cannot get servers named from generic Object prototype ("constructor", "valueOf", etc) if they don't actually exist.
Fixes #2274