### PR TITLE
electron ui: add `Zoom -> Reset Zoom` command

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -312,6 +312,16 @@ function getMenu(window) {
             }
           },
         },
+        {
+          label: "Reset Zoom",
+          enabled: utils.getZoomFactor() !== 1,
+          accelerator: "CommandOrControl+num0",
+          click: () => {
+            utils.setZoomFactor(window, 1);
+            refreshMenu(window);
+            log.log("Reset zoom");
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
## new menu command: `Zoom -> Reset Zoom`

* allows folks to quickly reset zoom if it has changed
* uses Ctrl/Command+Num0 as keyboard shortcut to follow convention of numpad-based shortcuts used in other Zoom commands

![image](https://user-images.githubusercontent.com/53015256/151682177-34633ad4-fd7b-4417-97c5-84e5f2aa3d25.png)