### PR TITLE
fix: electron `windowTracker` crash when reloading and killing scripts

### DIFF
--- a/electron/windowTracker.js
+++ b/electron/windowTracker.js
@@ -29,6 +29,11 @@ const windowTracker = (windowName) => {
   };
 
   const saveState = debounce(() => {
+    if (!window || window.isDestroyed()) {
+      log.silly(`Saving window state failed because window is not available`);
+      return;
+    }
+
     if (!windowState.isMaximized) {
       windowState = window.getBounds();
     }
@@ -41,7 +46,7 @@ const windowTracker = (windowName) => {
 
   const track = (win) => {
     window = win;
-    ['resize', 'move', 'close'].forEach((event) => {
+    ["resize", "move", "close"].forEach((event) => {
       win.on(event, saveState);
     });
   };


### PR DESCRIPTION
## resolves crash in `electron/windowTracker.js` during reload

* currently crashes when running `Reloads -> Reload & Kill All Scripts` menu command
* this fix adds extra checks to window position tracking code to ensure Electron window handles are valid before attempting to access their properties

**Before fix**
![image](https://user-images.githubusercontent.com/53015256/151682983-2f1f2292-ea7a-4bbe-b3a7-bdf77e895864.png)

**After fix:**
![l6fet9gVOI](https://user-images.githubusercontent.com/53015256/155599315-30935f8c-e8cd-4fb8-ad7c-10d1485f5842.png)
