### PR TITLE
Fix for ui of gang members current task when set via api

### DIFF
--- a/src/Gang/ui/TaskSelector.tsx
+++ b/src/Gang/ui/TaskSelector.tsx
@@ -21,6 +21,13 @@ export function TaskSelector(props: IProps): React.ReactElement {
   const gang = useGang();
   const [currentTask, setCurrentTask] = useState(props.member.task);
 
+  const contextMember = gang.members.find(member => member.name == props.member.name)
+  if (contextMember &&
+    contextMember.task != currentTask
+  ) {
+    setCurrentTask(contextMember.task)
+  }
+
   function onChange(event: SelectChangeEvent<string>): void {
     const task = event.target.value;
     props.member.assignToTask(task);


### PR DESCRIPTION
currently when using the api to set a members task it is updating everything but the dropdown of the current selected task, Note: this is only an issue when setting the task while you have the gang menu open.

# Bug fix
fixes #2718 
fixes #2149
* Added check to manually update interal state of dropdown on change of a members task via api

Tested by setting a gang members task manually then running 

```
sleep ns.sleep(5000)
ns.gang.setMemberTask("hghgm", "Deal Drugs" )
```

Before: you see the description of the task update but not the dropdown itself
After: the dropdown reflects the current task correctly 