### PR TITLE
fix: fixed hackAnalyzeThreads returning infinity

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -536,6 +536,10 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       const percentHacked = calculatePercentMoneyHacked(server, Player);
 
+      if (percentHacked === 0 || server.moneyAvailable === 0) {
+        return 0; // To prevent returning infinity below
+      }
+
       return hackAmount / Math.floor(server.moneyAvailable * percentHacked);
     },
     hackAnalyze: function (hostname: any): any {


### PR DESCRIPTION
# Bug fix

When using hackAnalyzeThreads, the function returns Infinity when percentage hacked is 0 or there's no money in the server. Added a guard to make sure that user doesn't allocate memory for these edge cases.
