### PR TITLE
QoI: Increase HacknetNodeElem name colSpan

### DIFF
--- a/src/Hacknet/ui/HacknetNodeElem.tsx
+++ b/src/Hacknet/ui/HacknetNodeElem.tsx
@@ -172,7 +172,7 @@ export function HacknetNodeElem(props: IProps): React.ReactElement {
       <Table size="small">
         <TableBody>
           <TableRow>
-            <TableCell>
+            <TableCell colSpan={3}>
               <Typography>{node.name}</Typography>
             </TableCell>
           </TableRow>


### PR DESCRIPTION
Spanning `{node.name}` across all three table columns in the Hacknet Node UI uses a bit less screen real estate, so that on larger font sizes you don't end up with e.g. "hacknet- " on one line and "node-11" on the next.

![image](https://user-images.githubusercontent.com/8766466/151764378-e84fd4cf-c93a-410b-aecf-eb788a8749da.png)