### PR TITLE
Fixing Broken Error Message

### DIFF
--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -284,7 +284,7 @@ export function NetscriptSleeve(player: IPlayer, workerScript: WorkerScript, hel
     },
     purchaseSleeveAug: function (asleeveNumber: any = 0, aaugName: any = ""): boolean {
       const sleeveNumber = helper.number("purchaseSleeveAug", "sleeveNumber", asleeveNumber);
-      const augName = helper.string("setToUniversityCourse", "augName", aaugName);
+      const augName = helper.string("purchaseSleeveAug", "augName", aaugName);
       helper.updateDynamicRam("purchaseSleeveAug", getRamCost(player, "sleeve", "purchaseSleeveAug"));
       checkSleeveAPIAccess("purchaseSleeveAug");
       checkSleeveNumber("purchaseSleeveAug", sleeveNumber);


### PR DESCRIPTION
Resolves an issue with an error message I was getting when trying to purchase augmentations automatically.
![image](https://user-images.githubusercontent.com/25071563/152056955-cf9ae607-13f9-4783-a826-af14bf2e73bc.png)

This issue can be reproduced with the following NS2 snippet (which I realize should fail. This update is just addressing the odd error message)

```js
for (var i = 0; i < ns.sleeve.getNumSleeves(); i++) {
	while (ns.sleeve.getSleevePurchasableAugs(i).length > 0) {
		ns.sleeve.purchaseSleeveAug(i, ns.sleeve.getSleevePurchasableAugs(i)[0]);
	}
}
```