### PR TITLE
Fix research tree of product industries post-prestige

### DIFF
--- a/src/Corporation/IndustryData.tsx
+++ b/src/Corporation/IndustryData.tsx
@@ -227,13 +227,13 @@ export function resetIndustryResearchTrees(): void {
   IndustryResearchTrees.Agriculture = getBaseResearchTreeCopy();
   IndustryResearchTrees.Fishing = getBaseResearchTreeCopy();
   IndustryResearchTrees.Mining = getBaseResearchTreeCopy();
-  IndustryResearchTrees.Food = getBaseResearchTreeCopy();
-  IndustryResearchTrees.Tobacco = getBaseResearchTreeCopy();
+  IndustryResearchTrees.Food = getProductIndustryResearchTreeCopy();
+  IndustryResearchTrees.Tobacco = getProductIndustryResearchTreeCopy();
   IndustryResearchTrees.Chemical = getBaseResearchTreeCopy();
-  IndustryResearchTrees.Pharmaceutical = getBaseResearchTreeCopy();
-  IndustryResearchTrees.Computer = getBaseResearchTreeCopy();
-  IndustryResearchTrees.Robotics = getBaseResearchTreeCopy();
-  IndustryResearchTrees.Software = getBaseResearchTreeCopy();
-  IndustryResearchTrees.Healthcare = getBaseResearchTreeCopy();
-  IndustryResearchTrees.RealEstate = getBaseResearchTreeCopy();
+  IndustryResearchTrees.Pharmaceutical = getProductIndustryResearchTreeCopy();
+  IndustryResearchTrees.Computer = getProductIndustryResearchTreeCopy();
+  IndustryResearchTrees.Robotics = getProductIndustryResearchTreeCopy();
+  IndustryResearchTrees.Software = getProductIndustryResearchTreeCopy();
+  IndustryResearchTrees.Healthcare = getProductIndustryResearchTreeCopy();
+  IndustryResearchTrees.RealEstate = getProductIndustryResearchTreeCopy();
 }


### PR DESCRIPTION
After destroying a BitNode, the `resetIndustryResearchTrees` reset all
industries to the _base_ research tree, leaving the product industries
without the `uPgrade` researches in the graph. So corporations started
in the next BitNode were unable to expand product capacity.

This fixes that reset function to use the correct product industry tree.

## Reproduce

Dev menu, formed a corp with a software division named `sw` and looked at the research tree. All is well:

![image](https://user-images.githubusercontent.com/510/152624174-927b0a53-2d88-425e-aa5c-b0e56c48ff7d.png)

Hack daemon to prestige and repeat the corp formation:

![image](https://user-images.githubusercontent.com/510/152624209-5efbad74-76ed-441a-a2ba-2cd9be6ba126.png)

Fulcrum and below are gone.

## After

On this branch, same process and fulcrum is back:

![image](https://user-images.githubusercontent.com/510/152624263-4c68bde9-2625-4c28-b285-45ca765ee5a7.png)
