### PR TITLE
Necro script fix

### DIFF
--- a/src/Netscript/ScriptDeath.ts
+++ b/src/Netscript/ScriptDeath.ts
@@ -10,16 +10,16 @@ import { WorkerScript } from "./WorkerScript";
  * script is killed. Which grants the player access to the class and the ability
  * to construct new instances with arbitrary data.
  */
-export class ScriptDeath {  
+export class ScriptDeath {
   /** Process ID number. */
   pid: number;
-  
+
   /** Filename of the script. */
   name: string;
-  
+
   /** IP Address on which the script was running */
   hostname: string;
-  
+
   /** Status message in case of script error. */
   errorMessage = "";
 

--- a/src/Netscript/ScriptDeath.ts
+++ b/src/Netscript/ScriptDeath.ts
@@ -1,0 +1,37 @@
+import { WorkerScript } from "./WorkerScript";
+
+/**
+ * Script death marker.
+ *
+ * IMPORTANT: the game engine should not base any of it's decisions on the data
+ * carried in a ScriptDeath instance.
+ *
+ * This is because ScriptDeath instances are thrown through player code when a
+ * script is killed. Which grants the player access to the class and the ability
+ * to construct new instances with arbitrary data.
+ */
+export class ScriptDeath {  
+  /** Process ID number. */
+  pid: number;
+  
+  /** Filename of the script. */
+  name: string;
+  
+  /** IP Address on which the script was running */
+  hostname: string;
+  
+  /** Status message in case of script error. */
+  errorMessage = "";
+
+  constructor(ws: WorkerScript) {
+    this.pid = ws.pid;
+    this.name = ws.name;
+    this.hostname = ws.hostname;
+    this.errorMessage = ws.errorMessage;
+
+    Object.freeze(this);
+  }
+}
+
+Object.freeze(ScriptDeath);
+Object.freeze(ScriptDeath.prototype);

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -60,7 +60,7 @@ export class WorkerScript {
   env: Environment;
 
   /**
-   * Status message in case of script error. Currently unused I think
+   * Status message in case of script error.
    */
   errorMessage = "";
 

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -2,6 +2,7 @@
  * Stops an actively-running script (represented by a WorkerScript object)
  * and removes it from the global pool of active scripts.
  */
+import { ScriptDeath } from "./ScriptDeath";
 import { WorkerScript } from "./WorkerScript";
 import { workerScripts } from "./WorkerScripts";
 import { WorkerScriptStartStopEventEmitter } from "./WorkerScriptStartStopEventEmitter";
@@ -139,7 +140,7 @@ function killNetscriptDelay(workerScript: WorkerScript): void {
     if (workerScript.delay) {
       clearTimeout(workerScript.delay);
       if (workerScript.delayReject) {
-        workerScript.delayReject(workerScript);
+        workerScript.delayReject(new ScriptDeath(workerScript));
       }
     }
   }

--- a/src/NetscriptEvaluator.ts
+++ b/src/NetscriptEvaluator.ts
@@ -4,8 +4,10 @@ import { ScriptDeath } from "./Netscript/ScriptDeath";
 import { WorkerScript } from "./Netscript/WorkerScript";
 
 export function netscriptDelay(time: number, workerScript: WorkerScript): Promise<void> {
-  if (workerScript.delayReject)
-    workerScript.delayReject(new ScriptDeath(workerScript));
+  // Cancel any pre-existing netscriptDelay'ed function call
+  // TODO: the rejection almost certainly ends up in the uncaught rejection handler.
+  //       Maybe reject with a stack-trace'd error message?
+  if (workerScript.delayReject) workerScript.delayReject();
 
   return new Promise(function (resolve, reject) {
     workerScript.delay = window.setTimeout(() => {

--- a/src/NetscriptEvaluator.ts
+++ b/src/NetscriptEvaluator.ts
@@ -1,15 +1,18 @@
 import { isString } from "./utils/helpers/isString";
 import { GetServer } from "./Server/AllServers";
+import { ScriptDeath } from "./Netscript/ScriptDeath";
 import { WorkerScript } from "./Netscript/WorkerScript";
 
 export function netscriptDelay(time: number, workerScript: WorkerScript): Promise<void> {
-  if (workerScript.delayReject) workerScript.delayReject();
+  if (workerScript.delayReject)
+    workerScript.delayReject(new ScriptDeath(workerScript));
+
   return new Promise(function (resolve, reject) {
     workerScript.delay = window.setTimeout(() => {
       workerScript.delay = null;
       workerScript.delayReject = undefined;
 
-      if (workerScript.env.stopFlag) reject(workerScript);
+      if (workerScript.env.stopFlag) reject(new ScriptDeath(workerScript));
       else resolve();
     }, time);
     workerScript.delayReject = reject;

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -637,9 +637,6 @@ export function NetscriptCorporation(
       const office = getOffice(divisionName, cityName);
       if (!Object.values(EmployeePositions).includes(job)) throw new Error(`'${job}' is not a valid job.`);
       return netscriptDelay(1000, workerScript).then(function () {
-        if (workerScript.env.stopFlag) {
-          return Promise.reject(workerScript);
-        }
         return Promise.resolve(office.setEmployeeToJob(job, amount));
       });
     },

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -149,8 +149,9 @@ function startNetscript2Script(player: IPlayer, workerScript: WorkerScript): Pro
       throw e;
     }
 
-    workerScript.errorMessage = makeRuntimeRejectMsg(workerScript, e);
-    throw new ScriptDeath(workerScript); // Don't know what to do with it, let's rethrow.
+    // Don't know what to do with it, let's try making an error message out of it
+    workerScript.errorMessage = makeRuntimeRejectMsg(workerScript, "" + e);
+    throw new ScriptDeath(workerScript);
   });
 }
 

--- a/src/UncaughtPromiseHandler.ts
+++ b/src/UncaughtPromiseHandler.ts
@@ -1,4 +1,4 @@
-import { WorkerScript } from "./Netscript/WorkerScript";
+import { ScriptDeath } from "./Netscript/ScriptDeath";
 import { isScriptErrorMessage } from "./NetscriptEvaluator";
 import { dialogBoxCreate } from "./ui/React/DialogBox";
 
@@ -14,9 +14,9 @@ export function setupUncaughtPromiseHandler(): void {
       msg += "<br>";
       msg += errorMsg;
       dialogBoxCreate(msg);
-    } else if (e.reason instanceof WorkerScript) {
+    } else if (e.reason instanceof ScriptDeath) {
       const msg =
-        `UNCAUGHT PROMISE ERROR<br>You forgot to await a promise<br>${e.reason.name}@${e.reason.hostname}<br>` +
+        `UNCAUGHT PROMISE ERROR<br>You forgot to await a promise<br>${e.reason.name}@${e.reason.hostname} (PID - ${e.reason.pid})<br>` +
         `Maybe hack / grow / weaken ?`;
       dialogBoxCreate(msg);
     }


### PR DESCRIPTION
Script death is signaled by throwing that script's `WorkerScript` instance. This thrown object can pass through player code, where the player can modify the script's state, and any parts of the game accessible through a `WorkerScript`.

Sample code to illustrate the problem, a simple exploit that restores the script back to running status:

```js
/** @param {NS} ns **/
export async function main(ns) {
  debugger;

  function nekromanteia(f, ...args) {
    try {
      return ns[f](...args);
    }
    catch(e) {
      if(e && e.env && e.env.stopFlag != null) {
        e.env.stopFlag = false;
        ns.tprintf("Call to %s failed due to script death, raised script back from the dead", f);
      }
    }
  }

  ns.exit();

  nekromanteia("tprint", "Arise"); // Whatever throws when called in a dead script is fine

  ns.tprint("Braains");
}
```

The problem is solved by instead throwing instances of a dedicated `ScriptDeath` type, that does not carry direct references to game engine objects.

After the fix the sample exploit no longer works.