### PR TITLE
correct tax calculation of corporation dividends

### DIFF
--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -148,14 +148,7 @@ export class Corporation {
     const totalDividends = (this.dividendPercentage / 100) * cycleProfit;
     const dividendsPerShare = totalDividends / this.totalShares;
     const dividends = this.numShares * dividendsPerShare;
-    let upgrades = -0.15;
-    if (this.unlockUpgrades[5] === 1) {
-      upgrades += 0.05;
-    }
-    if (this.unlockUpgrades[6] === 1) {
-      upgrades += 0.1;
-    }
-    return Math.pow(dividends, BitNodeMultipliers.CorporationSoftCap + upgrades);
+    return Math.pow(dividends, BitNodeMultipliers.CorporationSoftCap) * (1 - (this.dividendTaxPercentage / 100));
   }
 
   determineValuation(): number {

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -284,7 +284,7 @@ function DividendsStats({ profit }: IDividendsStatsProps): React.ReactElement {
         ["Retained Profits (after dividends):", <MoneyRate money={retainedEarnings} />],
         ["Dividend Percentage:", numeralWrapper.format(corp.dividendPercentage / 100, "0%")],
         ["Dividends per share:", <MoneyRate money={dividendsPerShare} />],
-        ["Your earnings as a shareholder:", <MoneyRate money={corp.getDividends()} />],
+        ["Your earnings as a shareholder:", <MoneyRate money={corp.getDividends() / CorporationConstants.SecsPerMarketCycle} />],
       ]}
     />
   );


### PR DESCRIPTION
This PR attempts to fix the inconsistent dividend tax rates.

To begin with, the game uses the following formula to calculate dividends after taxes:
```
return Math.pow(dividends, BitNodeMultipliers.CorporationSoftCap + upgrades);
```
Where (with values from my corporation)
```
dividends = 107718488.83520724
BitNodeMultipliers.CorporationSoftCap = 1
upgrades = -0.15
```
Yields the mathematical expression
```
107718488.83520724^0.85 = 6721198.38429
```
Which is 
```
6721198.38429 / 107718488.83520724 = 0.0624
or
93.76% effective tax rate
```
This 93.76% tax rate is far, far off the `dividendTaxPercentage = 50;`found within the same file.


Additionally, having had both of the upgrades (reducing tax by 5% and 10% respectively) would've changed the expression to:
```
107718488.83520724^1 = 107718488.83520724
```
Which, quite obviously, is the equivalent of paying _**no tax at all**_, rather than the expected 35%

As such, I propose the formula to be changed to:
```
return Math.pow(dividends, BitNodeMultipliers.CorporationSoftCap) * (1 - (this.dividendTaxPercentage / 100));
```
Alternatively (but more disruptively),
```
return dividends * BitNodeMultipliers.CorporationSoftCap * (1 - (this.dividendTaxPercentage / 100));
```

This change maintains the power relation between dividends and BitNodeMultipliers.CorporationSoftCap, but changes the taxes to scale more linearly with upgrades.
As a consequence, this makes corporation dividends much more profitable early game (50% tax instead of >90%), but much less profitable late game (35% tax instead of 0%).

I've looked through past commits, but wasn't able find any reference to this.
This leaves the possibility that this behavior is 100% inteded, and the problem lies within the user interface rather than the formulas.

Furthermore, with both upgrades present I've identified in the overview that dividends per second are an order of magnitude greater than my actual income.
This is because the dividends get calculated once every 10 seconds, but the overview pretends that this happens once per second instead.

![image](https://user-images.githubusercontent.com/2227951/152774606-1d979edf-26c6-4d1b-8b19-48fe3a6d9393.png)

fixes https://github.com/danielyxie/bitburner/issues/2261