### PR TITLE
added filter for possibleFactions to filter factions without tasks

### DIFF
--- a/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
+++ b/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
@@ -75,7 +75,10 @@ function possibleFactions(player: IPlayer, sleeve: Sleeve): string[] {
     }
   }
 
-  return factions;
+  return factions.filter(faction => {
+    const facInfo = Factions[faction].getInfo();
+    return facInfo.offerHackingWork || facInfo.offerFieldWork || facInfo.offerSecurityWork
+  });
 }
 
 const tasks: {


### PR DESCRIPTION
# Documentation

fixes #1954

* added filter for possibleFactions to filter factions without tasks

![image](https://user-images.githubusercontent.com/5182053/152783133-a0418e76-5a7c-4ba4-8ad3-66226541e176.png)

