### PR TITLE
Don't check only gangs for sleeve augs

### DIFF
--- a/src/PersonObjects/Sleeve/SleeveHelpers.ts
+++ b/src/PersonObjects/Sleeve/SleeveHelpers.ts
@@ -52,8 +52,6 @@ export function findSleevePurchasableAugs(sleeve: Sleeve, p: IPlayer): Augmentat
         availableAugs.push(aug);
       }
     }
-
-    return availableAugs;
   }
 
   for (const facName of p.factions) {


### PR DESCRIPTION
It is possible for a player to qualify for an aug through a faction and
not the gang, e.g. when the gang is newly formed and still getting up to
speed. So, we need to consider both gang qualifications and faction
qualifications when constructing the sleeve augmentation list.

tested by loading my save which doesn't have enough gang rep to qualify for any augs but does quality through factions. before this fix the sleeve augs pane was empty, after the fix it is correctly populated. then used the dev menu to add gang faction rep so it would qualify for augs through there and verified that those showed up and did not create duplicate entries.
