### PR TITLE
Fix log message in ns.bladeburner.startAction

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -2083,7 +2083,7 @@ export class Bladeburner implements IBladeburner {
       this.startAction(player, actionId);
       workerScript.log(
         "bladeburner.startAction",
-        () => `Starting bladeburner action with type '${type}' and name ${name}"`,
+        () => `Starting bladeburner action with type '${type}' and name '${name}'`,
       );
       return true;
     } catch (e: any) {


### PR DESCRIPTION
Fixes a logging issue where the 2nd parameter isn't wrapped in single quotes. Technically untested but it's a trivial logging change. Before was 1 quotation mark at the end of the word, now I've wrapped the word with single quotes.

Before / Expected After:

```diff
-bladeburner.startAction: Starting bladeburner action with type 'Contracts' and name Tracking"
+bladeburner.startAction: Starting bladeburner action with type 'Contracts' and name 'Tracking'
```

Technically untested in the game, I haven't tried setting up a dev instance yet.