### PR TITLE
added pre tags to support \n

### DIFF
--- a/src/ui/React/PromptManager.tsx
+++ b/src/ui/React/PromptManager.tsx
@@ -42,7 +42,9 @@ export function PromptManager(): React.ReactElement {
     <>
       {prompt != null && (
         <Modal open={true} onClose={close}>
-          <Typography>{prompt.txt}</Typography>
+          <pre>
+            <Typography>{prompt.txt}</Typography>
+          </pre>
           <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', paddingTop: '10px' }}>
             <Button style={{ marginRight: 'auto' }} onClick={yes}>Yes</Button>
             <Button onClick={no}>No</Button>


### PR DESCRIPTION
# Bug fix

fixes #2520

* added pre tags t support \n in prompt

```
if !(await ns.prompt(`Are you sure?\nThis will overwrite all the current files`)) {
    ns.exit()
}
```

![image](https://user-images.githubusercontent.com/5182053/154833548-b3f47f9c-6c06-4d8d-a47c-793f0bdc4c53.png)

