### PR TITLE
FIX: tutorial typo

### DIFF
--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -212,7 +212,7 @@ export function InteractiveTutorialRoot(): React.ReactElement {
 
           <Typography>
             {" "}
-            we can see that the n00dles server is only one node away. Let's connect so it now using:
+            we can see that the n00dles server is only one node away. Let's connect to it now using:
           </Typography>
 
           <Typography classes={{ root: classes.textfield }}>{"[home ~/]> connect n00dles"}</Typography>


### PR DESCRIPTION
"connect so it" -> "connect to it"