### PR TITLE
Clarify units for RunningScript.*RunningTime

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -105,9 +105,11 @@ interface RunningScript {
   logs: string[];
   offlineExpGained: number;
   offlineMoneyMade: number;
+  /** Offline running time of the script, in seconds **/
   offlineRunningTime: number;
   onlineExpGained: number;
   onlineMoneyMade: number;
+  /** Online running time of the script, in seconds **/
   onlineRunningTime: number;
   pid: number;
   ramUsage: number;


### PR DESCRIPTION
Most other times are specified in milliseconds, rather than the seconds used for the running time - this should be made clear in the docs.

