### PR TITLE
Bugfix with tons of merge conflictx

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -935,24 +935,28 @@ export declare interface Corporation extends WarehouseAPI, OfficeAPI {
      * Expand to a new industry
      * @param industryType - Name of the industry
      * @param divisionName - Name of the division
+     * @returns Was industry expanded
      */
-    expandIndustry(industryType: string, divisionName: string): void;
+    expandIndustry(industryType: string, divisionName: string): boolean;
     /**
      * Expand to a new city
      * @param divisionName - Name of the division
      * @param cityName - Name of the city
+     * @returns Was expansion successful
      */
-    expandCity(divisionName: string, cityName: string): void;
+    expandCity(divisionName: string, cityName: string): boolean;
     /**
      * Unlock an upgrade
      * @param upgradeName - Name of the upgrade
+     * @returns Was upgrade unlocked
      */
-    unlockUpgrade(upgradeName: string): void;
+    unlockUpgrade(upgradeName: string): boolean;
     /**
      * Level an upgrade.
      * @param upgradeName - Name of the upgrade
+     * @returns Was upgrade leveled
      */
-    levelUpgrade(upgradeName: string): void;
+    levelUpgrade(upgradeName: string): boolean;
     /**
      * Issue dividends
      * @param percent - Percent of profit to issue as dividends.
@@ -4504,8 +4508,9 @@ export declare interface OfficeAPI {
      * @param divisionName - Name of the division
      * @param cityName - Name of the city
      * @param size - Amount of positions to open
+     * @returns Was office size upgraded
      */
-    upgradeOfficeSize(divisionName: string, cityName: string, size: number): void;
+    upgradeOfficeSize(divisionName: string, cityName: string, size: number): boolean;
     /**
      * Throw a party for your employees
      * @param divisionName - Name of the division
@@ -4524,14 +4529,16 @@ export declare interface OfficeAPI {
     /**
      * Hire AdVert.
      * @param divisionName - Name of the division
+     * @returns Was AdVert hired
      */
-    hireAdVert(divisionName: string): void;
+    hireAdVert(divisionName: string): boolean;
     /**
      * Purchase a research
      * @param divisionName - Name of the division
      * @param researchName - Name of the research
+     * @returns Was research completed
      */
-    research(divisionName: string, researchName: string): void;
+    research(divisionName: string, researchName: string): boolean;
     /**
      * Get data about an office
      * @param divisionName - Name of the division
@@ -6628,6 +6635,14 @@ export declare interface WarehouseAPI {
      */
     setSmartSupply(divisionName: string, cityName: string, enabled: boolean): void;
     /**
+     * Set smart supply to use leftovers for a material
+     * @param divisionName - Name of the division
+     * @param cityName - Name of the city
+     * @param materialName - Name of the material
+     * @param enabled - smart supply use leftovers enabled
+     */
+    setSmartSupplyUseLeftovers(divisionName: string, cityName: string, materialName: string, enabled: boolean): void;
+    /**
      * Set material buy data
      * @param divisionName - Name of the division
      * @param cityName - Name of the city
@@ -6724,14 +6739,16 @@ export declare interface WarehouseAPI {
      * Purchase warehouse for a new city
      * @param divisionName - Name of the division
      * @param cityName - Name of the city
+     * @returns Did purchase succeed
      */
-    purchaseWarehouse(divisionName: string, cityName: string): void;
+    purchaseWarehouse(divisionName: string, cityName: string): boolean;
     /**
      * Upgrade warehouse
      * @param divisionName - Name of the division
      * @param cityName - Name of the city
+     * @returns Did upgrade succeed
      */
-    upgradeWarehouse(divisionName: string, cityName: string): void;
+    upgradeWarehouse(divisionName: string, cityName: string): boolean;
     /**
      * Create a new product
      * @param divisionName - Name of the division
@@ -6739,6 +6756,7 @@ export declare interface WarehouseAPI {
      * @param productName - Name of the product
      * @param designInvest - Amount to invest for the design of the product.
      * @param marketingInvest - Amount to invest for the marketing of the product.
+     * @returns Was a new product started
      */
     makeProduct(
     divisionName: string,
@@ -6746,7 +6764,7 @@ export declare interface WarehouseAPI {
     productName: string,
     designInvest: number,
     marketingInvest: number,
-    ): void;
+    ): boolean;
     /**
      * Gets the cost to purchase a warehouse
      * @returns cost

--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -6774,12 +6774,12 @@ export declare interface WarehouseAPI {
      * Gets the cost to upgrade a warehouse to the next level
      * @returns cost to upgrade
      */
-    getUpgradeWarehouseCost(adivisionName: any, acityName: any): number;
+    getUpgradeWarehouseCost(divisionName: string, cityName: string): number;
     /**
      * Check if you have a warehouse in city
      * @returns true if warehouse is present, false if not
      */
-    hasWarehouse(adivisionName: any, acityName: any): boolean;
+    hasWarehouse(divisionName: string, cityName: string): boolean;
 }
 
 export { }

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -49,6 +49,8 @@ export function NewCity(corporation: ICorporation, division: IIndustry, city: st
 
   if (corporation.funds < CorporationConstants.OfficeInitialCost) {
     return false;
+  } else if (division.offices[city]) {
+    return true;
   } else {
     corporation.funds = corporation.funds - CorporationConstants.OfficeInitialCost;
     division.offices[city] = new OfficeSpace({
@@ -285,7 +287,8 @@ export function ThrowParty(corp: ICorporation, office: OfficeSpace, costPerEmplo
 
 export function PurchaseWarehouse(corp: ICorporation, division: IIndustry, city: string): boolean {
   if (corp.funds < CorporationConstants.WarehouseInitialCost) return false;
-  if (division.warehouses[city] instanceof Warehouse) return false;
+  if (!division.offices[city]) return false;
+  if (division.warehouses[city] instanceof Warehouse) return true;
   division.warehouses[city] = new Warehouse({
     corp: corp,
     industry: division,

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -262,6 +262,9 @@ export class Corporation {
   unlock(upgrade: CorporationUnlockUpgrade): void {
     const upgN = upgrade[0],
       price = upgrade[1];
+    if (this.unlockUpgrades[upgN]) {
+      return;
+    }
     while (this.unlockUpgrades.length <= upgN) {
       this.unlockUpgrades.push(0);
     }

--- a/src/Corporation/ui/ExpandIndustryTab.tsx
+++ b/src/Corporation/ui/ExpandIndustryTab.tsx
@@ -36,10 +36,9 @@ export function ExpandIndustryTab(props: IProps): React.ReactElement {
 
   function newIndustry(): void {
     if (disabled) return;
-    try {
-      NewIndustry(corp, industry, name);
-    } catch (err) {
-      dialogBoxCreate(err + "");
+    let error;
+    if (error = NewIndustry(corp, industry, name)) {
+      dialogBoxCreate(error);
       return;
     }
 

--- a/src/Corporation/ui/ExpandNewCity.tsx
+++ b/src/Corporation/ui/ExpandNewCity.tsx
@@ -27,7 +27,10 @@ export function ExpandNewCity(props: IProps): React.ReactElement {
 
   function expand(): void {
     try {
-      NewCity(corp, division, city);
+      if (!NewCity(corp, division, city)) {
+        dialogBoxCreate("Could not expand to new city");
+        return;
+      }
     } catch (err) {
       dialogBoxCreate(err + "");
       return;

--- a/src/Corporation/ui/LevelableUpgrade.tsx
+++ b/src/Corporation/ui/LevelableUpgrade.tsx
@@ -29,10 +29,8 @@ export function LevelableUpgrade(props: IProps): React.ReactElement {
   const tooltip = data[5];
   function onClick(): void {
     if (corp.funds < cost) return;
-    try {
-      LevelUpgrade(corp, props.upgrade);
-    } catch (err) {
-      dialogBoxCreate(err + "");
+    if (!LevelUpgrade(corp, props.upgrade)) {
+      dialogBoxCreate("Could not level upgrade");
     }
     props.rerender();
   }

--- a/src/Corporation/ui/ResearchModal.tsx
+++ b/src/Corporation/ui/ResearchModal.tsx
@@ -35,7 +35,9 @@ function Upgrade({ n, division }: INodeProps): React.ReactElement {
   function research(): void {
     if (n === null || disabled) return;
     try {
-      Research(division, n.text);
+      if (!Research(division, n.text)) {
+        dialogBoxCreate(`Could not purchase ${research.name}`);
+      }
     } catch (err) {
       dialogBoxCreate(err + "");
       return;

--- a/src/Corporation/ui/UnlockUpgrade.tsx
+++ b/src/Corporation/ui/UnlockUpgrade.tsx
@@ -23,10 +23,9 @@ export function UnlockUpgrade(props: IProps): React.ReactElement {
   const tooltip = data[3];
   function onClick(): void {
     if (corp.funds < data[1]) return;
-    try {
-      UU(corp, props.upgradeData);
-    } catch (err) {
-      dialogBoxCreate(err + "");
+    if (!UU(corp, props.upgradeData))
+    {
+      dialogBoxCreate("Could not unlock upgrade");
     }
     props.rerender();
   }

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -235,7 +235,7 @@ export function NetscriptCorporation(
     const division = getDivision(divisionName);
     if (!(cityName in division.warehouses)) throw new Error(`Invalid city name '${cityName}'`);
     const warehouse = division.warehouses[cityName];
-    if (warehouse === 0) throw new Error(`${division.name} has not expanded to '${cityName}'`);
+    if (warehouse === 0) throw new Error(`${division.name} has not purchased a warehouse in '${cityName}'`);
     return warehouse;
   }
 


### PR DESCRIPTION
Fixes a number of minor bugs, documentation issues, and general pain points in the corporation API.
* Adds documentation for setSmartSupplyUseLeftovers
* Fixes any usage in d.ts documentation for getUpgradeWarehouseCost and hasWarehouse
* Fixes several typos/inaccuracies in corp error messages
* Changes the following functions to return true/false for succeed/fail and changes error throwing methods to not throw exceptions due to simple state errors such as duplicate item existing or insufficient funds:
  * purchaseWarehouse
  * upgradeWarehouse
  * upgradeOfficeSize
  * hireAdVert
  * research
  * expandIndustry
  * expandCity
  * unlockUpgrade
  * levelUpgrade
* Changes purchaseMaterial to use 0 for the purchase amount if the purchase amount is less than 0 (i.e. it clears the purchase order)
* Require an office in a city to purchase a warehouse in that city
* Don't buy duplicate offices in cities with offices
* Don't allow purchasing non-levelable upgrades multiple times
* Don't allow purchasing the same research multiple times
* Require funds to upgrade a warehouse

Fixes #2942 

![Documentation](https://user-images.githubusercontent.com/8546867/153785174-0af180a4-2bf0-4cae-b3a1-0e939e1ae252.PNG)

Test script below. Run with zero funds and zero research and with lots of funds and lots of research
```
/** @param {NS} ns **/
/** @param {NS} ns **/
export async function main(ns) {
	let corpFunds = () => ns.corporation.getCorporation().funds;
	ns.tprint(corpFunds())
	const divisionName = 'Software'
	const division = ns.corporation.getDivision(divisionName)
	ns.corporation.setSmartSupplyUseLeftovers(divisionName, 'Sector-12', 'Hardware', true)
	if (ns.corporation.getExpandCityCost() > corpFunds()) {
		ns.corporation.expandCity(divisionName, 'Aevum')
	}
	try {
		ns.corporation.expandCity(divisionName, 'Sector-12')
	} catch (e) {
		ns.tprint(e)
	}
	if (corpFunds() < ns.corporation.getUnlockUpgradeCost('Shady Accounting')) {
		ns.corporation.unlockUpgrade('Shady Accounting')
	}
	if (corpFunds() > 2 * ns.corporation.getUnlockUpgradeCost('Government Partnership')) {
		ns.corporation.unlockUpgrade('Government Partnership')
		let funds = corpFunds()
		ns.corporation.unlockUpgrade('Government Partnership')
		if (funds !== corpFunds()) {
			throw "Double unlock"
		}
	}
	try {
		ns.corporation.unlockUpgrade(divisionName, 'Not an upgrade')
	} catch (e) {
		ns.tprint(e)
	}
	if (corpFunds() < ns.corporation.getExpandCityCost()) {
		ns.corporation.expandCity(divisionName, 'Aevum')
	}
	if (corpFunds() > ns.corporation.getExpandCityCost()) {
		let funds = corpFunds()
		ns.corporation.expandCity(divisionName, 'Sector-12')
		if (funds !== corpFunds()) {
			throw "Double expand"
		}
	}
	if (corpFunds() < ns.corporation.getUpgradeLevelCost('Wilson Analytics')) {
		ns.corporation.levelUpgrade('Wilson Analytics')
	}
	try {
		ns.corporation.levelUpgrade(divisionName, 'Not an upgrade')
	} catch (e) {
		ns.tprint(e)
	}
	if (ns.corporation.getOfficeSizeUpgradeCost(divisionName, 'Sector-12', 15) > corpFunds()) {
		ns.corporation.upgradeOfficeSize(divisionName, 'Sector-12', 15)
	}
	try {
		ns.corporation.upgradeOfficeSize(divisionName, 'Not a city')
	} catch (e) {
		ns.tprint(e)
	}
	if (ns.corporation.getHireAdVertCost(divisionName) > corpFunds()) {
		ns.corporation.hireAdVert(divisionName)
	}
	if (ns.corporation.getResearchCost(divisionName, 'Bulk Purchasing') > ns.corporation.getDivision(divisionName).research) {
		ns.corporation.research(divisionName, 'Bulk Purchasing')
	}
	if (2 * ns.corporation.getResearchCost(divisionName, 'Hi-Tech R&D Laboratory') < ns.corporation.getDivision(divisionName).research) {
		ns.corporation.research(divisionName, 'Hi-Tech R&D Laboratory')
		let rp = ns.corporation.getDivision(divisionName).research
		ns.corporation.research(divisionName, 'Hi-Tech R&D Laboratory')
		if (rp !== ns.corporation.getDivision(divisionName).research) {
			throw "Double research"
		}
	}
	if (ns.corporation.getPurchaseWarehouseCost() > corpFunds()) {
		ns.corporation.purchaseWarehouse(divisionName, 'Aevum')
	}
	if (ns.corporation.getPurchaseWarehouseCost() < corpFunds()) {
		ns.corporation.purchaseWarehouse(divisionName, 'New Tokyo')
		if (ns.corporation.hasWarehouse(divisionName, 'New Tokyo')) throw "Bought warehouse without office"
	}
	if (ns.corporation.getUpgradeWarehouseCost(divisionName, 'Sector-12') > corpFunds()) {
		ns.corporation.purchaseWarehouse(divisionName, 'Sector-12')
	}
	ns.tail()
	ns.corporation.expandIndustry('Software', 'Software')
	ns.corporation.expandIndustry('not and industry', 'Hello')
	ns.corporation.expandIndustry('Fishing', '')
	if (ns.corporation.getExpandIndustryCost('Fishing') > corpFunds()) {
		ns.corporation.expandIndustry('Fishing', 'Fishing')
	}
}
```
