### PR TITLE
Fix favor threshold for donateToFaction

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1212,7 +1212,7 @@ export function NetscriptSingularity(
         );
         return false;
       }
-      const repNeededToDonate = Math.round(CONSTANTS.BaseFavorToDonate * BitNodeMultipliers.RepToDonateToFaction);
+      const repNeededToDonate = Math.floor(CONSTANTS.BaseFavorToDonate * BitNodeMultipliers.RepToDonateToFaction);
       if (faction.favor < repNeededToDonate) {
         workerScript.log(
           "donateToFaction",


### PR DESCRIPTION
UI and getFavorToDonate() use floor() to calc donate threshold.
https://github.com/danielyxie/bitburner/blob/9fa706073f75d2cfd00c8ac5ee3db1bccb1b7910/src/NetscriptFunctions.ts#L2170
https://github.com/danielyxie/bitburner/blob/f9499d3259f9583db1b55a3801213c57bab30b0a/src/Faction/ui/FactionRoot.tsx#L111

However, donateToFaction() use round().
So, on the near-threshold, we can donate with UI, but can not donate with donateToFaction().