### PR TITLE
Expose product and material details in API match UI

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -332,10 +332,13 @@ export function NetscriptCorporation(
       const cityName = helper.string("getMaterial", "cityName", acityName);
       const materialName = helper.string("getMaterial", "materialName", amaterialName);
       const material = getMaterial(divisionName, cityName, materialName);
+      const corporation = getCorporation();
       return {
         name: material.name,
         qty: material.qty,
         qlt: material.qlt,
+        dmd: corporation.unlockUpgrades[2] ? material.dmd : undefined,
+        cmp: corporation.unlockUpgrades[3] ? material.cmp : undefined,
         prod: material.prd,
         sell: material.sll,
       };
@@ -345,10 +348,13 @@ export function NetscriptCorporation(
       const divisionName = helper.string("getProduct", "divisionName", adivisionName);
       const productName = helper.string("getProduct", "productName", aproductName);
       const product = getProduct(divisionName, productName);
+      const corporation = getCorporation();
       return {
         name: product.name,
-        dmd: product.dmd,
-        cmp: product.cmp,
+        dmd: corporation.unlockUpgrades[2] ? product.dmd : undefined,
+        cmp: corporation.unlockUpgrades[3] ? product.cmp : undefined,
+        rat: product.rat,
+        properties: {qlt:product.qlt, per:product.per, dur:product.dur, rel:product.rel, aes:product.aes, fea:product.fea},
         pCost: product.pCost,
         sCost: product.sCost,
         cityData: product.data,

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6585,10 +6585,14 @@ interface Employee {
 interface Product {
   /** Name of the product */
   name: string;
-  /** Demand for the product */
-  dmd: number;
-  /** Competition for the product */
-  cmp: number;
+  /** Demand for the product, only present if "Market Research - Demand" unlocked */
+  dmd: number | undefined;
+  /** Competition for the product, only present if "Market Research - Competition" unlocked */
+  cmp: number | undefined;
+  /** Product Rating */
+  rat: number;
+  /** Product Properties. The data is {qlt, per, dur, rel, aes, fea} */
+  properties: { [key: string]: number };
   /** Production cost */
   pCost: number;
   /** Sell cost, can be "MP+5" */
@@ -6612,6 +6616,10 @@ interface Material {
   qty: number;
   /** Quality of the material */
   qlt: number;
+  /** Demand for the material, only present if "Market Research - Demand" unlocked */
+  dmd: number | undefined;
+  /** Competition for the material, only present if "Market Research - Competition" unlocked */
+  cmp: number | undefined;
   /** Amount of material produced  */
   prod: number;
   /** Amount of material sold  */


### PR DESCRIPTION
Some Corporation Product and Material numbers are available in hover text in the UI, but not over API. This adds them to the APIs.

Specifically, 
Product Rating, and "properties" like quality, aesthetics, etc.
Material Demand, Competition

Demand and Competition are locked behind appropriate Unlock Upgrades. This is a change for Products, where they were previously available over API without the upgrades.

Test Code:
```javascript
/** @param {NS} ns **/
export async function main(ns) {
    // please use dev menu to go to BN.3
    // and give yourself a bunch of RAM
    const nsc = ns.corporation;
    const divisionName = 'Tobacco';
    const cityName = 'Sector-12';
    const materialName = 'Hardware';
    const productName = 'P:1e10';

    //nsc.createCorporation("a", false);
    if (! nsc.hasUnlockUpgrade('Warehouse API')) {
        nsc.unlockUpgrade('Warehouse API');
    }
    if (! nsc.getCorporation().divisions.some(d=>d.name===divisionName)) {
        ns.tprint(JSON.stringify(nsc.getCorporation().divisions));
        nsc.expandIndustry(divisionName, divisionName);
    }
    if (! nsc.getDivision(divisionName).products.includes(productName)) {
        nsc.makeProduct(divisionName, cityName, productName, 1e9, 1e9);
    }

    ns.tprint(`Before Unlocks:`);
    let material = nsc.getMaterial(divisionName, cityName, materialName);
    let product = nsc.getProduct(divisionName, productName);
    ns.tprint(`\tProduct Properties: ${JSON.stringify(product.properties)}`);
    ns.tprint(`\tProduct Rating: ${product.rat}`);
    ns.tprint(`\tProduct Demand: ${product.dmd}`);
    ns.tprint(`\tProduct Competition: ${product.cmp}`);
    ns.tprint(`\tMaterial Demand: ${material.dmd}`);
    ns.tprint(`\tMaterial Competition: ${material.cmp}`);

    ns.tprint(`After Demand:`);
    nsc.unlockUpgrade('Market Research - Demand');
    material = nsc.getMaterial(divisionName, cityName, materialName);
    product = nsc.getProduct(divisionName, productName);
    ns.tprint(`\tProduct Rating: ${product.rat}`);
    ns.tprint(`\tProduct Demand: ${product.dmd}`);
    ns.tprint(`\tProduct Competition: ${product.cmp}`);
    ns.tprint(`\tMaterial Demand: ${material.dmd}`);
    ns.tprint(`\tMaterial Competition: ${material.cmp}`);

    ns.tprint(`After Both:`);
    nsc.unlockUpgrade('Market Data - Competition');
    material = nsc.getMaterial(divisionName, cityName, materialName);
    product = nsc.getProduct(divisionName, productName);
    ns.tprint(`\tProduct Rating: ${product.rat}`);
    ns.tprint(`\tProduct Demand: ${product.dmd}`);
    ns.tprint(`\tProduct Competition: ${product.cmp}`);
    ns.tprint(`\tMaterial Demand: ${material.dmd}`);
    ns.tprint(`\tMaterial Competition: ${material.cmp}`);
}
```