### PR TITLE
Fix 3019: Clarify between q and Q on achievement descriptions

### DIFF
--- a/src/Achievements/AchievementData.json
+++ b/src/Achievements/AchievementData.json
@@ -130,7 +130,7 @@
     "MONEY_1Q": {
       "ID": "MONEY_1Q",
       "Name": "Here comes the money!",
-      "Description": "Have $1Q on your home computer."
+      "Description": "Have $1Q (Quintillion) on your home computer."
     },
     "MONEY_M1B": {
       "ID": "MONEY_M1B",
@@ -210,7 +210,7 @@
     "STOCK_1q": {
       "ID": "STOCK_1q",
       "Name": "Wolf of wall street.",
-      "Description": "Make 1q on the stock market."
+      "Description": "Make 1q (quadrillion) on the stock market."
     },
     "DISCOUNT": {
       "ID": "DISCOUNT",


### PR DESCRIPTION
Since it's not clear that q == quadrillion and Q == quintillion, the achievements for $1Q and $1q are a bit vague.  This simple fix only changes the 2 related achievement descriptions to make it clear which one is quad and which one is quint.

Fixed descriptions on the 2 achievements with unclear mention of 1Q:
- Here comes the money ($1Q on home server)
- Wolf of wall street (Make $1q on stocks)

Note: only descriptive text is changed in this PR (nothing gameplay related was touched)

Fixes #3019 