### PR TITLE
📝  (TSDoc Definitions) Inherits doc for overloaded NS methods.

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4926,6 +4926,34 @@ export interface NS extends Singularity {
    * @returns True if the script is successfully killed, and false otherwise.
    */
   kill(script: number): boolean;
+
+  /**
+   * {@inheritDoc NS.(kill:1)}
+   * @example
+   * ```ts
+   * // NS1:
+   * //The following example will try to kill a script named foo.script on the foodnstuff server that was ran with no arguments:
+   * kill("foo.script", "foodnstuff");
+   *
+   * //The following will try to kill a script named foo.script on the current server that was ran with no arguments:
+   * kill("foo.script", getHostname());
+   *
+   * //The following will try to kill a script named foo.script on the current server that was ran with the arguments 1 and “foodnstuff”:
+   * kill("foo.script", getHostname(), 1, "foodnstuff");
+   * ```
+   * @example
+   * ```ts
+   * // NS2:
+   * //The following example will try to kill a script named foo.script on the foodnstuff server that was ran with no arguments:
+   * ns.kill("foo.script", "foodnstuff");
+   *
+   * //The following will try to kill a script named foo.script on the current server that was ran with no arguments:
+   * ns.kill("foo.script", getHostname());
+   *
+   * //The following will try to kill a script named foo.script on the current server that was ran with the arguments 1 and “foodnstuff”:
+   * ns.kill("foo.script", getHostname(), 1, "foodnstuff");
+   * ```
+   */
   kill(script: string, host: string, ...args: string[]): boolean;
 
   /**
@@ -4991,6 +5019,37 @@ export interface NS extends Singularity {
    * @returns True if the script/literature file is successfully copied over and false otherwise. If the files argument is an array then this function will return true if at least one of the files in the array is successfully copied.
    */
   scp(files: string | string[], destination: string): Promise<boolean>;
+
+  /**
+   * {@inheritDoc NS.(scp:1)}
+   * @example
+   * ```ts
+   * // NS1:
+   * //Copies foo.lit from the helios server to the home computer:
+   * scp("foo.lit", "helios", "home");
+   *
+   * //Tries to copy three files from rothman-uni to home computer:
+   * files = ["foo1.lit", "foo2.script", "foo3.script"];
+   * scp(files, "rothman-uni", "home");
+   * ```
+   * @example
+   * ```ts
+   * // NS2:
+   * //Copies foo.lit from the helios server to the home computer:
+   * await ns.scp("foo.lit", "helios", "home");
+   *
+   * //Tries to copy three files from rothman-uni to home computer:
+   * files = ["foo1.lit", "foo2.script", "foo3.script"];
+   * await ns.scp(files, "rothman-uni", "home");
+   * ```
+   * @example
+   * ```ts
+   * //ns2, copies files from home to a target server
+   * const server = ns.args[0];
+   * const files = ["hack.js","weaken.js","grow.js"];
+   * await ns.scp(files, "home", server);
+   * ```
+   */
   scp(files: string | string[], source: string, destination: string): Promise<boolean>;
 
   /**
@@ -5795,6 +5854,10 @@ export interface NS extends Singularity {
    * @returns Amount of income the specified script generates while online.
    */
   getScriptIncome(): [number, number];
+
+  /**
+   * {@inheritDoc NS.(getScriptIncome:1)}
+   */
   getScriptIncome(script: string, host: string, ...args: string[]): number;
 
   /**
@@ -5815,6 +5878,10 @@ export interface NS extends Singularity {
    * @returns Amount of hacking experience the specified script generates while online.
    */
   getScriptExpGain(): number;
+
+  /**
+   * {@inheritDoc NS.(getScriptExpGain:1)}
+   */
   getScriptExpGain(script: string, host: string, ...args: string[]): number;
 
   /**


### PR DESCRIPTION
The overloaded methods `NS.kill()`, `NS.getScriptExpGain()`,
`NS.getScriptIncome()`, and `NS.scp()` have broken documentation because the
overloaded function is not documented correctly. I've added `@inheritDoc` tags to
the declarations in order to associate the documentation to the overloaded method.

Screenshots included of fixed docs (markdown preview, style is not exactly the same as github)

### [NS.kill()](https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.ns.kill_1.md)
![Screen Shot 2022-02-22 at 6 30 53 PM](https://user-images.githubusercontent.com/1127719/155248949-7987f4bc-8426-4d9d-8d0f-cbc0ea8bc824.png)
![Screen Shot 2022-02-22 at 6 31 09 PM](https://user-images.githubusercontent.com/1127719/155248961-f0b55076-a218-4422-9614-102d3db3b4eb.png)

### [NS.scp()](https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.ns.scp_1.md)
![Screen Shot 2022-02-22 at 6 35 29 PM](https://user-images.githubusercontent.com/1127719/155249104-e257bc88-b162-4fe0-b36f-03fc63cfb3d5.png)

### [NS.getScriptExpGain()](https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.ns.getscriptexpgain_1.md)
![Screen Shot 2022-02-22 at 6 32 06 PM](https://user-images.githubusercontent.com/1127719/155249287-29ded6e7-a04f-40da-8bb3-d599652ab056.png)

### [NS.getScriptIncome()](https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.ns.getscriptincome_1.md)
![Screen Shot 2022-02-22 at 6 31 47 PM](https://user-images.githubusercontent.com/1127719/155249317-8547e752-56a4-4384-9f9f-f97e71b4949b.png)


