### PR TITLE
add post install to also install electron folder's deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "lint": "eslint --fix . --ext js,jsx,ts,tsx",
     "lint:report": "eslint --ext js,jsx,ts,tsx .",
     "preinstall": "node ./tools/engines-check/engines-check.js",
+    "postinstall": "cd electron && npm install",
     "test": "jest",
     "test:watch": "jest --watch",
     "watch": "webpack --watch --mode production",


### PR DESCRIPTION
fixes #3027

just adds a postinstall script to also install electron folder deps

![image](https://user-images.githubusercontent.com/5182053/155299662-7de21c5e-91d8-40bc-98aa-5b1b4a7c1d5e.png)
