### PR TITLE
📝  (TSDoc Definitions) Add gym workout to stopAction actions.

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1601,9 +1601,10 @@ export interface Singularity {
    * The actions that can be stopped with this function are:
    *
    * * Studying at a university
+   * * Working out at a gym
    * * Working for a company/faction
    * * Creating a program
-   * * Committing a Crime
+   * * Committing a crime
    *
    * This function will return true if the player’s action was ended.
    * It will return false if the player was not performing an action when this function was called.


### PR DESCRIPTION
Updated definition for `Singularity.stopAction()` to add gym workouts to list of stoppable actions.

Aside: The list of actions does not get marked up properly as a list, but I can't fix it. It's an existing issue with `api-extractor` that is more complicated (see https://github.com/microsoft/tsdoc/issues/178)

### Existing doc:

[Singularity.stopAction()](https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.singularity.stopaction.md)

### Screenshot of update

Updated doc generated with `npm run doc` (markdown preview so style does not match github, it will be fine)

<img width="679" alt="Screen Shot 2022-02-24 at 2 57 45 PM" src="https://user-images.githubusercontent.com/1127719/155614518-b4571144-ca90-401c-bc2f-ab2fa5c28068.png">

