### PR TITLE
docs: fix `@returns` of `bladeburner.getBonusTime()`

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -668,7 +668,7 @@ export declare interface Bladeburner {
      * For example, if an action takes 30 seconds to complete but you’ve accumulated over
      * 30 seconds in bonus time, then the action will only take 6 seconds in real life to complete.
      *
-     * @returns Amount of accumulated “bonus time” (milliseconds) for the Bladeburner mechanic.
+     * @returns Amount of accumulated “bonus time” (seconds) for the Bladeburner mechanic.
      */
     getBonusTime(): number;
 }


### PR DESCRIPTION
# Documentation fix

* update `@returns` of `ns.bladeburner.getBonusTime()` to correctly identify the return value in seconds (not milliseconds)
* you can see on line [663](https://github.com/danielyxie/bitburner/blob/dev/dist/bitburner.d.ts#L663) it correctly says seconds