### PR TITLE
Fix #3037: wrap user-supplied atExit function so that we can't accide…

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -2279,7 +2279,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       if (typeof f !== "function") {
         throw makeRuntimeErrorMsg("atExit", "argument should be function");
       }
-      workerScript.atExit = f;
+      workerScript.atExit = () => { f(); }; // Wrap the user function to prevent WorkerScript leaking as 'this'
     },
     mv: function (host: string, source: string, destination: string): void {
       updateDynamicRam("mv", getRamCost(Player, "mv"));


### PR DESCRIPTION
Fixes #3037, see the bug report for a sample exploit.

Approach chosen is to wrap the user-supplied function in a new function, thus isolating it and preventing any leak of game objects via `this` when `WorkerScript.atExit` is called.