### PR TITLE
♿️  (Corp Warehouse UI Accessibility) Stop warehouse UI jump at higher zoom.

### DIFF
--- a/src/Corporation/ui/IndustryWarehouse.tsx
+++ b/src/Corporation/ui/IndustryWarehouse.tsx
@@ -27,6 +27,8 @@ import Tooltip from "@mui/material/Tooltip";
 import Paper from "@mui/material/Paper";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
+import makeStyles from "@mui/styles/makeStyles";
+import createStyles from "@mui/styles/createStyles";
 
 interface IProps {
   corp: ICorporation;
@@ -36,6 +38,14 @@ interface IProps {
   player: IPlayer;
   rerender: () => void;
 }
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    retainHeight: {
+      minHeight: '3em',
+    },
+  })
+);
 
 function WarehouseRoot(props: IProps): React.ReactElement {
   const corp = useCorporation();
@@ -55,6 +65,8 @@ function WarehouseRoot(props: IProps): React.ReactElement {
     corp.funds = corp.funds - sizeUpgradeCost;
     props.rerender();
   }
+
+  const classes = useStyles();
 
   // Current State:
   let stateText;
@@ -158,7 +170,7 @@ function WarehouseRoot(props: IProps): React.ReactElement {
       </Typography>
       <br />
 
-      <Typography>{stateText}</Typography>
+      <Typography className={classes.retainHeight}>{stateText}</Typography>
 
       {corp.unlockUpgrades[1] && (
         <>


### PR DESCRIPTION
Making this PR and hoping it can be merged to help my partner, who has vision problems and requires a higher zoom level to see the UI properly, and others like him who also may need this.

On higher zoom levels, the corp UI jumps regularly, because each frame that the "Current state:" changes length, which is very annoying and makes it hard to hit the buttons especially when on bonus time so the change happens quickly.

Before state: problematic jumping:

https://user-images.githubusercontent.com/1127719/155859098-69edf415-ef9f-44cb-970b-c1f967cb1a17.mov

After PR: reserved space for `Current state` typography element with `minHeight`:

https://user-images.githubusercontent.com/1127719/155859142-6ae4e6da-6bb3-4e2c-9b2e-59d7c139a9e5.mov

At normal zoom there's just some extra space below the "Current state:" text, which I don't think is problematic.

https://user-images.githubusercontent.com/1127719/155859185-bf9623df-3f5d-4cb2-b783-9d1582122445.mov
