### PR TITLE
sort player's joined factions for cleaner rendering

### DIFF
--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -19,6 +19,42 @@ import { SourceFileFlags } from "../SourceFile/SourceFileFlags";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { InvitationEvent } from "./ui/InvitationModal";
 
+const factionOrder = [
+  "CyberSec",
+  "Tian Di Hui",
+  "Netburners",
+  "Sector-12",
+  "Chongqing",
+  "New Tokyo",
+  "Ishima",
+  "Aevum",
+  "Volhaven",
+  "NiteSec",
+  "The Black Hand",
+  "BitRunners",
+  "ECorp",
+  "MegaCorp",
+  "KuaiGong International",
+  "Four Sigma",
+  "NWO",
+  "Blade Industries",
+  "OmniTek Incorporated",
+  "Bachman & Associates",
+  "Clarke Incorporated",
+  "Fulcrum Secret Technologies",
+  "Slum Snakes",
+  "Tetrads",
+  "Silhouette",
+  "Speakers for the Dead",
+  "The Dark Army",
+  "The Syndicate",
+  "The Covenant",
+  "Daedalus",
+  "Illuminati",
+  "Bladeburners",
+  "Church of the Machine God",
+]
+
 export function inviteToFaction(faction: Faction): void {
   Player.receiveInvite(faction.name);
   faction.alreadyInvited = true;
@@ -31,6 +67,8 @@ export function joinFaction(faction: Faction): void {
   if (faction.isMember) return;
   faction.isMember = true;
   Player.factions.push(faction.name);
+  Player.factions.sort((a, b) =>
+    factionOrder.indexOf(a) - factionOrder.indexOf(b));
   const factionInfo = faction.getInfo();
 
   //Determine what factions you are banned from now that you have joined this faction
@@ -132,19 +170,19 @@ export function purchaseAugmentation(aug: Augmentation, fac: Faction, sing = fal
       if (!Settings.SuppressBuyAugmentationConfirmation) {
         dialogBoxCreate(
           "You purchased " +
-            aug.name +
-            ". Its enhancements will not take " +
-            "effect until they are installed. To install your augmentations, go to the " +
-            "'Augmentations' tab on the left-hand navigation menu. Purchasing additional " +
-            "augmentations will now be more expensive.",
+          aug.name +
+          ". Its enhancements will not take " +
+          "effect until they are installed. To install your augmentations, go to the " +
+          "'Augmentations' tab on the left-hand navigation menu. Purchasing additional " +
+          "augmentations will now be more expensive.",
         );
       }
     }
   } else {
     dialogBoxCreate(
       "Hmm, something went wrong when trying to purchase an Augmentation. " +
-        "Please report this to the game developer with an explanation of how to " +
-        "reproduce this.",
+      "Please report this to the game developer with an explanation of how to " +
+      "reproduce this.",
     );
   }
   return "";


### PR DESCRIPTION
Each time a player joins a faction, their list of factions will be sorted according to a preset ranking, mostly identical to the one in the documentation.  That way, when the factions are rendered in the UI, they'll appear in that order as well.  This will make it much easier to keep track of which factions players have joined.