### PR TITLE
add box showing remaining augments per faction

### DIFF
--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -75,6 +75,15 @@ export function FactionsRoot(props: IProps): React.ReactElement {
                       <Button onClick={() => openFaction(Factions[faction])}>Details</Button>
                     </Box>
                   </TableCell>
+                  <TableCell align="right">
+                    <Typography noWrap ml={2} mb={1}>
+                      Augmentations Left: {Factions[faction]
+                        .augmentations
+                        .filter((augmentation: string) =>
+                          !props.player.hasAugmentation(augmentation))
+                        .length}
+                    </Typography>
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -76,7 +76,7 @@ export function FactionsRoot(props: IProps): React.ReactElement {
                     </Box>
                   </TableCell>
                   <TableCell align="right">
-                    <Typography noWrap ml={2} mb={1}>
+                    <Typography noWrap ml={10} mb={1}>
                       Augmentations Left: {Factions[faction]
                         .augmentations
                         .filter((augmentation: string) =>


### PR DESCRIPTION
On the "Factions" page next to the "Details" button, the player will see a box containing how many Augmentations a faction offers that they haven't purchased.  Neuroflux won't count as long as they have at least one level.

![Screenshot from 2022-02-28 07-05-54](https://user-images.githubusercontent.com/7646835/155980735-cad4af5e-efc2-41e8-b7a6-830118598529.png)
 