### PR TITLE
Fix typo (await ed => awaited)

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4098,7 +4098,7 @@ interface UserInterface {
  *  ns.getHostname();
  *  // Some related functions are gathered under a sub-property of the ns object
  *  ns.stock.getPrice();
- *  // Some functions need to be await ed
+ *  // Some functions need to be awaited
  *  await ns.hack('n00dles');
  * }
  * ```


### PR DESCRIPTION
I saw a typo in the markdown, so I fixed it in the netscript definitions.