### PR TITLE
Made getBonusTime return miliseconds

### DIFF
--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -365,7 +365,7 @@ export function NetscriptBladeburner(
       checkBladeburnerAccess("getBonusTime");
       const bladeburner = player.bladeburner;
       if (bladeburner === null) throw new Error("Should not be called without Bladeburner");
-      return Math.round(bladeburner.storedCycles / 5);
+      return (Math.round(bladeburner.storedCycles / 5))*1000;
     },
   };
 }


### PR DESCRIPTION
Fixes getBonusTime to properly return milliseconds instead of seconds.
fixes #3050 
