### PR TITLE
Removed redundant repetitions of | in alias regex

### DIFF
--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -36,7 +36,7 @@ export function printAliases(): void {
 
 // Returns true if successful, false otherwise
 export function parseAliasDeclaration(dec: string, global = false): boolean {
-  const re = /^([\w|!|%|,|@|-]+)=(("(.+)")|('(.+)'))$/;
+  const re = /^([\w|!%,@-]+)=(("(.+)")|('(.+)'))$/;
   const matches = dec.match(re);
   if (matches == null || matches.length != 7) {
     return false;


### PR DESCRIPTION
Repeating `|` makes no sense inside `[]` as it is treated like any other character and not a meta one. Probably it shouldn't have ended in the regex in the first place but by now it should probably be kept not to break interface
