### PR TITLE
Fix editor "close" naming

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -892,8 +892,8 @@ export function Root(props: IProps): React.ReactElement {
             {ram}
           </Button>
           <Button onClick={save}>Save (Ctrl/Cmd + s)</Button>
-          <Button onClick={props.router.toTerminal}>Close (Ctrl/Cmd + b)</Button>
-          <Typography sx={{ mx: 1 }}>
+          <Button sx={{ mx: 1 }} onClick={props.router.toTerminal}>Terminal (Ctrl/Cmd + b)</Button>
+          <Typography>
             {" "}
             Documentation:{" "}
             <Link target="_blank" href="https://bitburner.readthedocs.io/en/latest/index.html">


### PR DESCRIPTION
* evened out spacing of buttons
* renamed close to Terminal

closes #2961 

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/5182053/156867531-8a744d26-84a2-4517-8498-6098122441cb.png">

