### PR TITLE
Fix for work in progress modal when augmenting

### DIFF
--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -34,6 +34,18 @@ export function WorkInProgressRoot(): React.ReactElement {
   const player = use.Player();
   const router = use.Router();
   const faction = Factions[player.currentWorkFactionName];
+  if (!faction) {
+    return (
+      <Grid container direction="column" justifyContent="center" alignItems="center" style={{ minHeight: "100vh" }}>
+        <Grid item>
+          <Typography>
+            Sorry, Something has gone wrong you cannot work for {player.currentWorkFactionName || "(Faction not found)"} at this time
+          </Typography>
+        </Grid>
+      </Grid>
+    )
+  }
+
   if (player.workType == CONSTANTS.WorkTypeFaction) {
     function cancel(): void {
       router.toFaction(faction);


### PR DESCRIPTION
* added an early out to turns a basic error for the work modal when the current work faction to show the faction or faction not found

closes #2902
closes #2931
closes #3008

( will add a gif when i can find a save file to replicate the issue)