### PR TITLE
Present offline message as list

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -405,9 +405,7 @@ const Engine: {
               <ul>
                 <li>Your scripts generated{" "} <Money money={offlineHackingIncome} /></li>
                 <li>Your Hacknet Nodes generated {hacknetProdInfo}</li>
-                {offlineReputation != 0 &&
-                  <li>You gained{" "} <Reputation reputation={offlineReputation} /> reputation divided amongst your factions
-                  </li>}
+                <li>You gained{" "} <Reputation reputation={offlineReputation} /> reputation divided amongst your factions</li>
               </ul>
             </>,
           ),

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -401,9 +401,14 @@ const Engine: {
         () =>
           AlertEvents.emit(
             <>
-              Offline for {timeOfflineString}. While you were offline, your scripts generated{" "}
-              <Money money={offlineHackingIncome} />, your Hacknet Nodes generated {hacknetProdInfo} and you gained{" "}
-              <Reputation reputation={offlineReputation} /> reputation divided amongst your factions.
+              Offline for {timeOfflineString}. While you were offline:
+              <ul>
+                <li>Your scripts generated{" "} <Money money={offlineHackingIncome} /></li>
+                <li>Your Hacknet Nodes generated {hacknetProdInfo}</li>
+                {offlineReputation != 0 &&
+                  <li>You gained{" "} <Reputation reputation={offlineReputation} /> reputation divided amongst your factions
+                  </li>}
+              </ul>
             </>,
           ),
         250,


### PR DESCRIPTION
I just recently started playing. After taking a quick break and starting the game again, I got this message:

![image](https://user-images.githubusercontent.com/1078569/156906296-c46cf4ba-2893-4e0e-9008-c16f3d822b3c.png)

The info's great, but the bit about the unchanged reputation is redundant, and irrelevant to new players that already have a bunch of new concepts to wrap their heads around. I think showing this info as a list would solve a bunch of little problems here.

![image](https://user-images.githubusercontent.com/1078569/156906474-ee1e9a3a-6d06-43b2-895b-936891bd2ffd.png)

- More glanceable
- ~Conditionally shows reputation~
  - Scrapped this. Could cause confusion of its own.
- Fewer changes needed if/when another element is added

Awesome game by the way!