### PR TITLE
Fix extra space on editor tabs

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -811,7 +811,6 @@ export function Root(props: IProps): React.ReactElement {
                           {...provided.dragHandleProps}
                           style={{
                             ...provided.draggableProps.style,
-                            minWidth: '200px',
                             maxWidth: `${tabMaxWidth}px`,
                             marginRight: `${tabMargin}px`,
                             flexShrink: 0,


### PR DESCRIPTION
Removes the minWidth attribute of editor tabs so that the border doesn't extend beyond the tab

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/60761231/157136532-f4e92108-3d53-4135-af1c-df7c8ebef108.png" />
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/60761231/157136451-5ebb8ff7-89e2-4f25-b4fe-33eabad1751d.png" />
    </td>
  </tr>
</table>