### PR TITLE
🐛  (Bug: Corp) Fixes sufficient player money check to buy back shares.

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -291,7 +291,7 @@ export function BuyBackShares(corporation: ICorporation, player: IPlayer, numSha
   if (numShares > corporation.issuedShares) throw new Error("You don't have that many shares to buy!");
   if (!corporation.public) throw new Error("You haven't gone public!");
   const buybackPrice = corporation.sharePrice * 1.1;
-  if (corporation.funds < (numShares * buybackPrice)) throw new Error("You cant afford that many shares!");
+  if (player.money < (numShares * buybackPrice)) throw new Error("You cant afford that many shares!");
   corporation.numShares += numShares;
   corporation.issuedShares -= numShares;
   player.loseMoney(numShares * buybackPrice, "corporation");


### PR DESCRIPTION
`BuyBackShares()` checks the corp for sufficient funds, but since shares are purchased with player money, it should be checking the player's money instead.

Sorry no screenshot... having trouble setting up a save file for good testing here.  I'm pretty sure this works and is pretty simple bug fix.