### PR TITLE
Fixes #3098 missing space in Smart Supply

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -414,8 +414,8 @@ export function NetscriptCorporation(
       const cityName = helper.string("sellProduct", "cityName", acityName);
       const enabled = helper.boolean(aenabled);
       const warehouse = getWarehouse(divisionName, cityName);
-      if (!hasUnlockUpgrade("SmartSupply"))
-        throw helper.makeRuntimeErrorMsg(`corporation.setSmartSupply`, `You have not purchased the SmartSupply upgrade!`);
+      if (!hasUnlockUpgrade("Smart Supply"))
+        throw helper.makeRuntimeErrorMsg(`corporation.setSmartSupply`, `You have not purchased the Smart Supply upgrade!`);
       SetSmartSupply(warehouse, enabled);
     },
     setSmartSupplyUseLeftovers: function (adivisionName: any, acityName: any, amaterialName: any, aenabled: any): void {
@@ -426,8 +426,8 @@ export function NetscriptCorporation(
       const enabled = helper.boolean(aenabled);
       const warehouse = getWarehouse(divisionName, cityName);
       const material = getMaterial(divisionName, cityName, materialName);
-      if (!hasUnlockUpgrade("SmartSupply"))
-        throw helper.makeRuntimeErrorMsg(`corporation.setSmartSupply`, `You have not purchased the SmartSupply upgrade!`);
+      if (!hasUnlockUpgrade("Smart Supply"))
+        throw helper.makeRuntimeErrorMsg(`corporation.setSmartSupply`, `You have not purchased the Smart Supply upgrade!`);
       SetSmartSupplyUseLeftovers(warehouse, material, enabled);
     },
     buyMaterial: function (adivisionName: any, acityName: any, amaterialName: any, aamt: any): void {


### PR DESCRIPTION
Quick fix to stop this from erroring due to the missing space in the upgrade name.