### PR TITLE
Attempt to fix `bladeburner.process()` early routing issue

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1914,6 +1914,9 @@ export class Bladeburner implements IBladeburner {
   }
 
   process(router: IRouter, player: IPlayer): void {
+    // Edge race condition when the engine checks the processing counters and attempts to route before the router is initialized.
+    if (!router.isInitialized) return;
+
     // Edge case condition...if Operation Daedalus is complete trigger the BitNode
     if (router.page() !== Page.BitVerse && this.blackops.hasOwnProperty("Operation Daedalus")) {
       return router.toBitVerse(false, false);

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -111,6 +111,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 export let Router: IRouter = {
+  isInitialized: false,
   page: () => {
     throw new Error("Router called before initialization");
   },
@@ -266,6 +267,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
   }
 
   Router = {
+    isInitialized: true,
     page: () => page,
     allowRouting: (value: boolean) => setAllowRoutingCalls(value),
     toActiveScripts: () => setPage(Page.ActiveScripts),

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -54,6 +54,7 @@ export interface IRouter {
   // toMission(): void;
   // toRedPill(): void;
   // toworkInProgress(): void;
+  isInitialized: boolean;
   page(): Page;
   allowRouting(value: boolean): void;
   toActiveScripts(): void;


### PR DESCRIPTION
### Attempt to fix `bladeburner.process()` issue

For a certain user, it appears that the engine attempts to route to the
bitverse screen before the router is properly initialized. I could not
reproduce the problem on my side and we were not able to extract his
save game, so this is a blind shot if it'll work or not.

I tried to replicate his situation by completing Daedalus blackop, waiting for an autosave and reloading the game, but I don't get the error on my side and I get redirected to the Bitverse screen successfully, both before and after the modification included in the PR.

This is a screenshot from the user, where he can't retrieve the save game and has the `Router called before initialization` error in the console.

![IMG_3347](https://user-images.githubusercontent.com/1521080/157533382-1ced1707-8079-4ee1-881b-64ca8bbec68e.png)
