### PR TITLE
Add shortcut to Faction augmentations page from FactionsRoot

### DIFF
--- a/src/Faction/ui/FactionRoot.tsx
+++ b/src/Faction/ui/FactionRoot.tsx
@@ -24,6 +24,7 @@ import { CovenantPurchasesRoot } from "../../PersonObjects/Sleeve/ui/CovenantPur
 
 type IProps = {
   faction: Faction;
+  augPage: boolean;
 };
 
 // Info text for all options on the UI
@@ -185,7 +186,7 @@ export function FactionRoot(props: IProps): React.ReactElement {
 
   const faction = props.faction;
 
-  const [purchasingAugs, setPurchasingAugs] = useState(false);
+  const [purchasingAugs, setPurchasingAugs] = useState(props.augPage);
 
   return purchasingAugs ? (
     <AugmentationsPage faction={faction} routeToMainPage={() => setPurchasingAugs(false)} />

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -41,6 +41,10 @@ export function FactionsRoot(props: IProps): React.ReactElement {
     props.router.toFaction(faction);
   }
 
+  function openFactionAugPage(faction: Faction): void {
+    props.router.toFaction(faction, true);
+  }
+
   function acceptInvitation(event: React.MouseEvent<HTMLButtonElement, MouseEvent>, faction: string): void {
     if (!event.isTrusted) return;
     joinFaction(Factions[faction]);
@@ -61,7 +65,7 @@ export function FactionsRoot(props: IProps): React.ReactElement {
       </Typography>
       {(props.player.factions.length > 0 && (
         <Paper sx={{ my: 1, p: 1, pb: 0, display: "inline-block" }}>
-          <Table padding="none">
+          <Table padding="none" style={{ width: "fit-content" }}>
             <TableBody>
               {props.player.factions.map((faction: string) => (
                 <TableRow key={faction}>
@@ -76,13 +80,15 @@ export function FactionsRoot(props: IProps): React.ReactElement {
                     </Box>
                   </TableCell>
                   <TableCell align="right">
-                    <Typography noWrap ml={10} mb={1}>
-                      Augmentations Left: {Factions[faction]
-                        .augmentations
-                        .filter((augmentation: string) =>
-                          !props.player.hasAugmentation(augmentation))
-                        .length}
-                    </Typography>
+                    <Box ml={1} mb={1}>
+                      <Button sx={{ width: '100%' }} onClick={() => openFactionAugPage(Factions[faction])}>
+                        Augmentations Left: {Factions[faction]
+                          .augmentations
+                          .filter((augmentation: string) =>
+                            !props.player.hasAugmentation(augmentation))
+                          .length}
+                      </Button>
+                    </Box>
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -590,7 +590,7 @@ export function process(this: IPlayer, router: IRouter, numCycles = 1): void {
   if (this.isWorking) {
     if (this.workType == CONSTANTS.WorkTypeFaction) {
       if (this.workForFaction(numCycles)) {
-        router.toFaction();
+        router.toFaction(Factions[this.currentWorkFactionName]);
       }
     } else if (this.workType == CONSTANTS.WorkTypeCreateProgram) {
       if (this.createProgramWork(numCycles)) {

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -223,6 +223,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
   const [{ files, vim }, setEditorOptions] = useState({ files: {}, vim: false });
   const [page, setPage] = useState(determineStartPage(player));
   const setRerender = useState(0)[1];
+  const [augPage, setAugPage] = useState<boolean>(false);
   const [faction, setFaction] = useState<Faction>(
     player.currentWorkFactionName ? Factions[player.currentWorkFactionName] : (undefined as unknown as Faction),
   );
@@ -275,7 +276,8 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     toCorporation: () => setPage(Page.Corporation),
     toCreateProgram: () => setPage(Page.CreateProgram),
     toDevMenu: () => setPage(Page.DevMenu),
-    toFaction: (faction?: Faction) => {
+    toFaction: (faction: Faction, augPage = false) => {
+      setAugPage(augPage);
       setPage(Page.Faction);
       if (faction) setFaction(faction);
     },
@@ -453,7 +455,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.Faction: {
-      mainPage = <FactionRoot faction={faction} />;
+      mainPage = <FactionRoot faction={faction} augPage={augPage} />;
       break;
     }
     case Page.Milestones: {

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -65,7 +65,7 @@ export interface IRouter {
   toCorporation(): void;
   toCreateProgram(): void;
   toDevMenu(): void;
-  toFaction(faction?: Faction): void; // faction name
+  toFaction(faction: Faction, augPage?: boolean): void; // faction name
   toFactions(): void;
   toGameOptions(): void;
   toGang(): void;


### PR DESCRIPTION
This builds upon the QoL in #3046, turning the "Augmentations Left" text into a button that, when clicked, routes the user directly to the faction's respective augmentations page.

![firefox_wNmW6Gqb8P](https://user-images.githubusercontent.com/60761231/157779648-cc3d9b41-5e88-4c93-b2f2-5547fe429ee5.gif)

This also required a tiny adjustment to `router.toFaction` to allow it to take an argument. To accommodate this, I ended up making the `faction` parameter required, and updated the code where it had not been provided an argument to reflect this.

### Testing
For the UI change, I was able to verify that it worked, and that nothing broke when more factions were added.

For the `router.toFaction` change, I verified it by ensuring that, when `Player.process` is called, the game still properly routes to the expected faction page.