### PR TITLE
Properly expand gang equipment cards to fill entire screen

### DIFF
--- a/src/Gang/ui/EquipmentsSubpage.tsx
+++ b/src/Gang/ui/EquipmentsSubpage.tsx
@@ -273,7 +273,7 @@ export function EquipmentsSubpage(): React.ReactElement {
         sx={{ m: 1, width: '15%' }}
       />
 
-      <Box display="grid" sx={{ gridTemplateColumns: '1fr 1fr', width: 'fit-content' }}>
+      <Box display="grid" sx={{ gridTemplateColumns: '1fr 1fr', width: '100%' }}>
         {members.map((member: GangMember) => (
           <GangMemberUpgradePanel key={member.name} member={member} />
         ))}


### PR DESCRIPTION
Fixes an oversight on the gang equipment page, allowing individual elements to properly expand to the entire page.

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/60761231/157803991-c8bdf5e8-0d99-4620-bd55-cc57d38783e4.png" />
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/60761231/157804045-f4e864e2-0eb3-4e7d-a976-a21bf6a52223.png" />
    </td>
  </tr>
</table>