### PR TITLE
expose the inBladeburner on the player object

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -2273,6 +2273,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
         jobs: {},
         factions: Player.factions.slice(),
         tor: Player.hasTorRouter(),
+        inBladeburner: Player.inBladeburner(),
         hasCorporation: Player.hasCorporation(),
       };
       Object.assign(data.jobs, Player.jobs);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -94,6 +94,7 @@ interface Player {
   factions: string[];
   tor: boolean;
   hasCorporation: boolean;
+  inBladeburner: boolean;
 }
 
 /**


### PR DESCRIPTION
closes #3122 

![Mar-12-2022 12-31-45](https://user-images.githubusercontent.com/5182053/158003850-e87a387d-7e54-4cba-bdfb-45482cd0519e.gif)


note: i exposed this on the player object to match the logic for hasCorporation.

If we feel it should still be a blasdeburn api function instead let me know and i can remove the corperation one too to be an corporation api function too

do we not want these exposed on player for spoilers maybe?
