### PR TITLE
Escape forward slashes in regex

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -91,7 +91,7 @@ export function SellMaterial(mat: Material, amt: string, price: string): void {
   if (price === "") price = "0";
   if (amt === "") amt = "0";
   let cost = price.replace(/\s+/g, "");
-  cost = cost.replace(/[^-()\d/*+.MPe]/g, ""); //Sanitize cost
+  cost = cost.replace(/[^-()\d\/*+.MPe]/g, ""); //Sanitize cost
   let temp = cost.replace(/MP/g, mat.bCost + "");
   try {
     temp = eval(temp);
@@ -113,7 +113,7 @@ export function SellMaterial(mat: Material, amt: string, price: string): void {
   amt = amt.toUpperCase();
   if (amt.includes("MAX") || amt.includes("PROD")) {
     let q = amt.replace(/\s+/g, "");
-    q = q.replace(/[^-()\d/*+.MAXPROD]/g, "");
+    q = q.replace(/[^-()\d\/*+.MAXPROD]/g, "");
     let tempQty = q.replace(/MAX/g, mat.maxsll.toString());
     tempQty = tempQty.replace(/PROD/g, mat.prd.toString());
     try {
@@ -151,7 +151,7 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
     //Dynamically evaluated quantity. First test to make sure its valid
     //Sanitize input, then replace dynamic variables with arbitrary numbers
     price = price.replace(/\s+/g, "");
-    price = price.replace(/[^-()\d/*+.MP]/g, "");
+    price = price.replace(/[^-()\d\/*+.MP]/g, "");
     let temp = price.replace(/MP/g, "1");
     try {
       temp = eval(temp);
@@ -178,7 +178,7 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
   if (amt.includes("MAX") || amt.includes("PROD")) {
     //Dynamically evaluated quantity. First test to make sure its valid
     let qty = amt.replace(/\s+/g, "");
-    qty = qty.replace(/[^-()\d/*+.MAXPROD]/g, "");
+    qty = qty.replace(/[^-()\d\/*+.MAXPROD]/g, "");
     let temp = qty.replace(/MAX/g, product.maxsll.toString());
     temp = temp.replace(/PROD/g, product.data[city][1].toString());
     try {
@@ -447,7 +447,7 @@ export function Research(division: IIndustry, researchName: string): void {
 export function ExportMaterial(divisionName: string, cityName: string, material: Material, amt: string, division?: Industry): void {
   // Sanitize amt
   let sanitizedAmt = amt.replace(/\s+/g, "").toUpperCase();
-  sanitizedAmt = sanitizedAmt.replace(/[^-()\d/*+.MAX]/g, "");
+  sanitizedAmt = sanitizedAmt.replace(/[^-()\d\/*+.MAX]/g, "");
   let temp = sanitizedAmt.replace(/MAX/g, "1");
   try {
     temp = eval(temp);

--- a/src/Terminal/commands/expr.ts
+++ b/src/Terminal/commands/expr.ts
@@ -17,7 +17,7 @@ export function expr(
   const expr = args.join("");
 
   // Sanitize the math expression
-  const sanitizedExpr = expr.replace(/s+/g, "").replace(/[^-()\d/*+.%]/g, "");
+  const sanitizedExpr = expr.replace(/s+/g, "").replace(/[^-()\d\/*+.%]/g, "");
   let result;
   try {
     result = eval(sanitizedExpr);


### PR DESCRIPTION
All documentation and regex testers I have found state that forward slashes ("/") inside regex patterns should be escaped, since the forward slash is used to define the start and end of the pattern.
The [ECMA standard](https://262.ecma-international.org/12.0/#sec-escaperegexppattern) only states that it "shall be escaped as necessary" for it to parse correctly, but I think the better practice is to always escape it, even inside a character class like it is here.
Other posts I have seen about it say it has to be escaped when in the /pattern/ notation but not in the RegExp constructor, but again, I think the best practice is to always escape it.
If there are regex patterns containing "/" elsewhere in the code they may yet need to also be corrected.