### PR TITLE
Fix unique ip generation

### DIFF
--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -78,12 +78,11 @@ export function ipExists(ip: string): boolean {
 }
 
 export function createUniqueRandomIp(): string {
-  const ip = createRandomIp();
-
-  // If the Ip already exists, recurse to create a new one
-  if (ipExists(ip)) {
-    return createRandomIp();
-  }
+  let ip: string;
+  // Repeat generating ip, until unique one is found
+  do {
+    ip = createRandomIp();
+  } while (ipExists(ip));
 
   return ip;
 }


### PR DESCRIPTION
The previous implementation had a bug in it, where the generated IP
wouldn't be unique, if the generated IP wouldn't be unique two times in
a row.

Conducted tests:
Quick check in the game:
![image](https://user-images.githubusercontent.com/7047377/158028466-0e9c5480-7031-412c-9aef-1033e2342800.png)


Test suite result:
![image](https://user-images.githubusercontent.com/7047377/158028441-050085ce-ad0f-49c4-8df0-d4d33d1cc353.png)

