### PR TITLE
Refresh "Create Programs" page UI

### DIFF
--- a/src/Programs/ui/ProgramsRoot.tsx
+++ b/src/Programs/ui/ProgramsRoot.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import _ from "lodash";
+import { find } from "lodash";
 
 import {
   Box,
@@ -57,7 +57,7 @@ export function ProgramsRoot(): React.ReactElement {
   }
 
   const getProgCompletion = (name: string): number => {
-    const programFile = _.find(player.getHomeComputer().programs, p => {
+    const programFile = find(player.getHomeComputer().programs, p => {
       return (p.startsWith(name) && p.endsWith("%-INC"));
     });
     if (!programFile) return -1;

--- a/src/Programs/ui/ProgramsRoot.tsx
+++ b/src/Programs/ui/ProgramsRoot.tsx
@@ -1,9 +1,19 @@
 import React, { useState, useEffect } from "react";
-import { use } from "../../ui/Context";
-import { getAvailableCreatePrograms } from "../ProgramHelpers";
+import _ from "lodash";
 
-import { Box, Tooltip, Typography } from "@mui/material";
-import Button from "@mui/material/Button";
+import {
+  Box,
+  Typography,
+  Button,
+  Container,
+  Paper
+} from "@mui/material";
+import { Check, Lock, Create } from "@mui/icons-material";
+
+import { use } from "../../ui/Context";
+import { Settings } from "../../Settings/Settings";
+
+import { Programs } from "../Programs";
 
 export const ProgramsSeen: string[] = [];
 
@@ -15,7 +25,20 @@ export function ProgramsRoot(): React.ReactElement {
     setRerender((old) => !old);
   }
 
-  const programs = getAvailableCreatePrograms(player);
+  const programs = [...Object.values(Programs)]
+    .filter(prog => {
+      const create = prog.create;
+      if (create === null) return false;
+      if (prog.name === "b1t_flum3.exe") {
+        return create.req(player);
+      }
+      return true;
+    })
+    .sort((a, b) => {
+      if (player.hasProgram(a.name)) return 1;
+      if (player.hasProgram(b.name)) return -1;
+      return (a.create?.level ?? 0) - (b.create?.level ?? 0);
+    })
 
   useEffect(() => {
     programs.forEach((p) => {
@@ -29,8 +52,27 @@ export function ProgramsRoot(): React.ReactElement {
     return () => clearInterval(id);
   }, []);
 
+  const getHackingLevelRemaining = (lvl: number): number => {
+    return Math.ceil(Math.max(lvl - (player.hacking + player.intelligence / 2), 0));
+  }
+
+  const getProgCompletion = (name: string): number => {
+    const programFile = _.find(player.getHomeComputer().programs, p => {
+      return (p.startsWith(name) && p.endsWith("%-INC"));
+    });
+    if (!programFile) return -1;
+
+    const res = programFile.split("-");
+    if (res.length != 3) return -1;
+    const percComplete = Number(res[1].slice(0, -1));
+    if (isNaN(percComplete) || percComplete < 0 || percComplete >= 100) {
+      return -1;
+    }
+    return percComplete;
+  }
+
   return (
-    <>
+    <Container disableGutters maxWidth="lg" sx={{ mx: 0, mb: 10 }}>
       <Typography variant="h4">Create program</Typography>
       <Typography>
         This page displays any programs that you are able to create. Writing the code for a program takes time, which
@@ -38,30 +80,45 @@ export function ProgramsRoot(): React.ReactElement {
         time. Your progress will be saved and you can continue later.
       </Typography>
 
-      <Box sx={{ display: 'grid', width: 'fit-content' }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: "repeat(3, 1fr)", my: 1 }}>
         {programs.map((program) => {
           const create = program.create;
           if (create === null) return <></>;
+          const curCompletion = getProgCompletion(program.name);
 
           return (
-            <React.Fragment key={program.name}>
-              <Tooltip title={create.tooltip}>
-                <Button
-                  sx={{ my: 1 }}
-                  onClick={(event) => {
-                    if (!event.isTrusted) return;
-                    player.startCreateProgramWork(program.name, create.time, create.level);
-                    player.startFocusing();
-                    router.toWork();
-                  }}
-                >
-                  {program.name}
-                </Button>
-              </Tooltip>
-            </React.Fragment>
+            <Box component={Paper} sx={{ p: 1, opacity: player.hasProgram(program.name) ? 0.75 : 1 }} key={program.name}>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                {player.hasProgram(program.name) && <Check sx={{ mr: 1 }} /> ||
+                  (create.req(player) && <Create sx={{ mr: 1 }} /> || <Lock sx={{ mr: 1 }} />)}
+                {program.name}
+              </Typography>
+              {(!player.hasProgram(program.name) && create.req(player)) && <Button
+                sx={{ my: 1, width: '100%' }}
+                onClick={(event) => {
+                  if (!event.isTrusted) return;
+                  player.startCreateProgramWork(program.name, create.time, create.level);
+                  player.startFocusing();
+                  router.toWork();
+                }}
+              >
+                Create program
+              </Button>}
+              {(player.hasProgram(program.name) || getHackingLevelRemaining(create.level) === 0) ||
+                <Typography color={Settings.theme.hack}>
+                  <b>Unlocks in:</b> {getHackingLevelRemaining(create.level)} hacking levels
+                </Typography>}
+              {(curCompletion !== -1) &&
+                <Typography color={Settings.theme.infolight}>
+                  <b>Current completion:</b> {curCompletion}%
+                </Typography>}
+              <Typography>
+                {create.tooltip}
+              </Typography>
+            </Box>
           );
         })}
       </Box>
-    </>
+    </Container>
   );
 }

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -143,11 +143,6 @@ export function SidebarRoot(props: IProps): React.ReactElement {
   const augmentationCount = props.player.queuedAugmentations.length;
   const invitationsCount = props.player.factionInvitations.filter((f) => !InvitationsSeen.includes(f)).length;
   const programCount = getAvailableCreatePrograms(props.player).length - ProgramsSeen.length;
-  const canCreateProgram =
-    getAvailableCreatePrograms(props.player).length > 0 ||
-    props.player.augmentations.length > 0 ||
-    props.player.queuedAugmentations.length > 0 ||
-    props.player.sourceFiles.length > 0;
 
   const canOpenFactions =
     props.player.factionInvitations.length > 0 ||
@@ -439,29 +434,27 @@ export function SidebarRoot(props: IProps): React.ReactElement {
                 </Typography>
               </ListItemText>
             </ListItem>
-            {canCreateProgram && (
-              <ListItem
-                button
-                key={"Create Program"}
-                className={clsx({
-                  [classes.active]: props.page === Page.CreateProgram,
-                })}
-                onClick={clickCreateProgram}
-              >
-                <ListItemIcon>
-                  <Badge badgeContent={programCount > 0 ? programCount : undefined} color="error">
-                    <Tooltip title={!open ? "Create Program" : ""}>
-                      <BugReportIcon color={props.page !== Page.CreateProgram ? "secondary" : "primary"} />
-                    </Tooltip>
-                  </Badge>
-                </ListItemIcon>
-                <ListItemText>
-                  <Typography color={props.page !== Page.CreateProgram ? "secondary" : "primary"}>
-                    Create Program
-                  </Typography>
-                </ListItemText>
-              </ListItem>
-            )}
+            <ListItem
+              button
+              key={"Create Program"}
+              className={clsx({
+                [classes.active]: props.page === Page.CreateProgram,
+              })}
+              onClick={clickCreateProgram}
+            >
+              <ListItemIcon>
+                <Badge badgeContent={programCount > 0 ? programCount : undefined} color="error">
+                  <Tooltip title={!open ? "Create Program" : ""}>
+                    <BugReportIcon color={props.page !== Page.CreateProgram ? "secondary" : "primary"} />
+                  </Tooltip>
+                </Badge>
+              </ListItemIcon>
+              <ListItemText>
+                <Typography color={props.page !== Page.CreateProgram ? "secondary" : "primary"}>
+                  Create Program
+                </Typography>
+              </ListItemText>
+            </ListItem>
             {canStaneksGift && (
               <ListItem
                 button


### PR DESCRIPTION
This PR updates the UI for the program creation page with a couple of goals:
- Display more information at a glance
- Waste less screen space

<table>
  <th>Before</th>
  <th>After</th>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/60761231/158030327-22385e09-86ba-4f8f-b082-536136115b24.png" />
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/60761231/158030167-df481a4d-c995-4cdd-bc46-2486b2954885.png" />
    </td>
  </tr>
</table>

*Note: "Before" is shown with higher hacking level for comparison's sake*

The entire page is now wrapped in a `<Container>` to improve readability of the top paragraph.

The "Unlocks in:" value is found via the calculation used to determine if a program can be created, which takes `Player.intelligence` into account. Note: this shows a value rounded by `Math.ceil` for the sake of simplicity.

The "Current completion:" value is found in the same way that it's found when program work is being resumed, by parsing the value of the incomplete file on the user's computer.

By continuing to show program info, even after creation, it's easier for players to quickly remind themselves of what that program does, in the event they've forgotten. Completed programs are shown with 75% opacity, and a checkmark icon.

Programs are sorted by level requirement, and completed programs are always sorted to the end of the list.

Additionally, the `Create Programs` tab will now be available immediately, instead of being hidden until a program is available. **Rationale:** The dark web's `buy -l` already provides a list of all available programs for purchase, so it seems perfectly reasonable to provide the same information here.

Also, when the user doesn't meet the requirements for `BitFlume` (they're in BN 1.1), the `b1t_flum3.exe` program will not be shown.

**In BN1.1**
![image](https://user-images.githubusercontent.com/60761231/158030186-073d6e10-1da0-419e-87e2-68237c5775a3.png)

### Testing

- [x] I have tested that `b1t_flum3.exe` is properly hidden when it should be
- [x] I have tested that programs are locked until they are allowed to be created (the `Create program` button will not be shown)
- [x] I have verified that the page is properly reset upon prestige