### PR TITLE
Quick fix to prevent division by 0

### DIFF
--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -167,7 +167,7 @@ export function ls(
 
   function postSegments(segments: string[], style?: any, linked?: boolean): void {
     const maxLength = Math.max(...segments.map((s) => s.length)) + 1;
-    const filesPerRow = Math.floor(80 / maxLength);
+    const filesPerRow = Math.ceil(80 / maxLength);
     for (let i = 0; i < segments.length; i++) {
       let row = "";
       for (let col = 0; col < filesPerRow; col++) {


### PR DESCRIPTION
`Math.floor()` caused division by 0, which caused a fatal error.
Replaced this with `Math.ceil()`, which fixes the issue.

![image](https://user-images.githubusercontent.com/566429/158841011-0a31d529-80fb-457f-b5a2-edc11c856114.png)

Fixes #2462