### PR TITLE
Tabelize linked output of `ls`

### DIFF
--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -139,10 +139,12 @@ export function ls(
       }),
     )();
 
-    const rowSplit = row
-      .split(" ")
-      .map((x) => x.trim())
-      .filter((x) => !!x);
+    console.log(row);
+
+    const rowSplit = row.split("~");
+    let rowSplitArray = rowSplit.map((x) => [x.trim(), x.replace(x.trim(), "")]);
+    console.log(rowSplitArray);
+    rowSplitArray = rowSplitArray.filter((x) => !!x);
 
     function onScriptLinkClick(filename: string): void {
       if (player.getCurrentServer().hostname !== hostname) {
@@ -156,9 +158,14 @@ export function ls(
 
     return (
       <span className={classes.scriptLinksWrap}>
-        {rowSplit.map((rowItem) => (
-          <span key={rowItem} className={classes.scriptLink} onClick={() => onScriptLinkClick(rowItem)}>
-            {rowItem}
+        {rowSplitArray.map((rowItem) => (
+          <span>
+            <span key={rowItem[0]} className={classes.scriptLink} onClick={() => onScriptLinkClick(rowItem[0])}>
+              {rowItem[0]}
+            </span>
+            <span key={'s'+rowItem[0]}>
+              {rowItem[1]}
+            </span>
           </span>
         ))}
       </span>
@@ -174,16 +181,19 @@ export function ls(
         if (!(i < segments.length)) break;
         row += segments[i];
         row += " ".repeat(maxLength * (col + 1) - row.length);
+        if(linked) {
+          row += "~";
+        }
         i++;
       }
       i--;
       if (!style) {
         terminal.print(row);
       } else if (linked) {
-          terminal.printRaw(<ClickableScriptRow row={row} prefix={prefix} hostname={server.hostname} />);
-        } else {
-          terminal.printRaw(<span style={style}>{row}</span>);
-        }
+        terminal.printRaw(<ClickableScriptRow row={row} prefix={prefix} hostname={server.hostname} />);
+      } else {
+        terminal.printRaw(<span style={style}>{row}</span>);
+      }
     }
   }
 

--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -139,12 +139,9 @@ export function ls(
       }),
     )();
 
-    console.log(row);
-
     const rowSplit = row.split("~");
     let rowSplitArray = rowSplit.map((x) => [x.trim(), x.replace(x.trim(), "")]);
-    console.log(rowSplitArray);
-    rowSplitArray = rowSplitArray.filter((x) => !!x);
+    rowSplitArray = rowSplitArray.filter((x) => !!x[0]);
 
     function onScriptLinkClick(filename: string): void {
       if (player.getCurrentServer().hostname !== hostname) {


### PR DESCRIPTION
Undocumented bug:
The clickable files in `ls` were not put in table form, even though it was expected them to be.
The other files and folders were correctly formatted.

![image](https://user-images.githubusercontent.com/566429/158852701-9ee25e91-4e48-4d2c-bde5-513e3664074b.png)

The new setup does correctly form "tables":

![image](https://user-images.githubusercontent.com/566429/158852777-afe36f97-b00e-46be-a3a3-8c1b6940482e.png)
