### PR TITLE
Fixed: purchaseSleeveAug checks shock value

### DIFF
--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -288,11 +288,11 @@ export function NetscriptSleeve(player: IPlayer, workerScript: WorkerScript, hel
       helper.updateDynamicRam("purchaseSleeveAug", getRamCost(player, "sleeve", "purchaseSleeveAug"));
       checkSleeveAPIAccess("purchaseSleeveAug");
       checkSleeveNumber("purchaseSleeveAug", sleeveNumber);
-      
+
       if (player.sleeves[sleeveNumber].shock > 0){
         throw helper.makeRuntimeErrorMsg("sleeve.purchaseSleeveAug", `Sleeve shock too high: Sleeve ${sleeveNumber}`);
       }
-      
+
       const aug = Augmentations[augName];
       if (!aug) {
         throw helper.makeRuntimeErrorMsg("sleeve.purchaseSleeveAug", `Invalid aug: ${augName}`);

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -288,7 +288,11 @@ export function NetscriptSleeve(player: IPlayer, workerScript: WorkerScript, hel
       helper.updateDynamicRam("purchaseSleeveAug", getRamCost(player, "sleeve", "purchaseSleeveAug"));
       checkSleeveAPIAccess("purchaseSleeveAug");
       checkSleeveNumber("purchaseSleeveAug", sleeveNumber);
-
+      
+      if (player.sleeves[sleeveNumber].shock > 0){
+        throw helper.makeRuntimeErrorMsg("sleeve.purchaseSleeveAug", `Sleeve shock too high: Sleeve ${sleeveNumber}`);
+      }
+      
       const aug = Augmentations[augName];
       if (!aug) {
         throw helper.makeRuntimeErrorMsg("sleeve.purchaseSleeveAug", `Invalid aug: ${augName}`);


### PR DESCRIPTION
Edit: cancelled old PR and added this one because it was trying to add multiple commits and I just wanted one commit.

Edited Sleeve.ts to throw an error if a netscript function call tried to buy an augment when the sleeve's shock was higher than 0.

To test that this works I had a simple script try to buy an augment and checked the multipliers to see if any of them changed.

