### PR TITLE
Fix bug with missing ramcost for tFormat

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -208,6 +208,7 @@ export const RamCosts: IMap<any> = {
   getScriptExpGain: RamCostConstants.ScriptGetScriptRamCost,
   getRunningScript: RamCostConstants.ScriptGetRunningScriptRamCost,
   nFormat: 0,
+  tFormat: 0,
   getTimeSinceLastAug: RamCostConstants.ScriptGetHackTimeRamCost,
   prompt: 0,
   wget: 0,


### PR DESCRIPTION
fixes #3177

```js
/** @param {NS} ns **/
export async function main(ns) {
  while(true){
    ns.tFormat(300000000);
    await ns.sleep(10000);
  }
}
```