### PR TITLE
dialogBox+stop on NS1 async function throw

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -144,7 +144,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
   const safeGetServer = function (hostname: string, callingFnName: string): BaseServer {
     const server = GetServer(hostname);
     if (server == null) {
-      throw makeRuntimeErrorMsg(callingFnName, `Invalid hostname or IP: ${hostname}`);
+      throw makeRuntimeErrorMsg(callingFnName, `Invalid hostname: ${hostname}`);
     }
     return server;
   };

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -178,7 +178,7 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<WorkerScript
       const entry = ns[name];
       if (typeof entry === "function") {
         //Async functions need to be wrapped. See JS-Interpreter documentation
-        if (["hack", "grow", "weaken", "sleep", "prompt", "manualHack", "scp", "write", "share"].includes(name)) {
+        if (["hack", "grow", "weaken", "sleep", "prompt", "manualHack", "scp", "write", "share", "wget"].includes(name)) {
           const tempWrapper = function (...args: any[]): void {
             const fnArgs = [];
 
@@ -199,7 +199,21 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<WorkerScript
               })
               .catch(function (err: any) {
                 // workerscript is when you cancel a delay
-                if (!(err instanceof WorkerScript)) console.error(err);
+                if (!(err instanceof WorkerScript)) {
+                  console.error(err);
+                  const errorTextArray = err.split("|DELIMITER|");
+                  const hostname = errorTextArray[1];
+                  const scriptName = errorTextArray[2];
+                  const errorMsg = errorTextArray[3];
+                  let msg = `${scriptName}@${hostname}<br>`;
+                  msg += "<br>";
+                  msg += errorMsg;
+                  dialogBoxCreate(msg);
+                  workerScript.env.stopFlag = true;
+                  workerScript.running = false;
+                  killWorkerScript(workerScript);
+                  return Promise.resolve(workerScript);
+                }
               });
           };
           int.setProperty(scope, name, int.createAsyncFunction(tempWrapper));


### PR DESCRIPTION
Creates a dialogBox and stops the script if any of the async NS1 functions throws an error.
Fixes #2725

![image](https://user-images.githubusercontent.com/566429/159131606-99ffbef3-2276-4202-9c37-f10532caef69.png)
