### PR TITLE
Check before unlocking corp upgrade

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -64,6 +64,9 @@ export function UnlockUpgrade(corporation: ICorporation, upgrade: CorporationUnl
   if (corporation.funds < upgrade[1]) {
     throw new Error("Insufficient funds");
   }
+  if(corporation.unlockUpgrades[upgrade[0]] === 1){
+    throw new Error(`You have already unlocked the ${upgrade[2]} upgrade!`);
+  }
   corporation.unlock(upgrade);
 }
 


### PR DESCRIPTION
# Bug fix

Can be tested by trying to call 'ns.corporation.unlockUpgrade' twice:

Ex:
```
ns.corporation.unlockUpgrade("Smart Supply")
ns.corporation.unlockUpgrade("Smart Supply")
```

This used to remove funds twice. Now it throws an error in the second try, similar to how `NewIndustry` works.

Tested by running locally.

Was unsure about whether to put this in 'Actions.ts' (where we have some checks) or in 'Corporation.tsx', do you have a preference?