### PR TITLE
Implement getBonusTime in Corporation API

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -846,5 +846,9 @@ export function NetscriptCorporation(
       const amountShares = helper.number("bribe", "amountShares", aamountShares);
       return bribe(factionName, amountCash, amountShares);
     },
+    getBonusTime: function (): number {
+      checkAccess("getBonusTime");
+      return Math.round(getCorporation().storedCycles / 5) * 1000;
+    }
   };
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6651,6 +6651,17 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    *
    */
   sellShares(amount: number): void;
+  /**
+   * Get bonus time.
+   * 
+   * “Bonus time” is accumulated when the game is offline or if the game is inactive in the browser.
+   *
+   * “Bonus time” makes the game progress faster.
+   *
+   * @returns Bonus time for the Corporation mechanic in milliseconds.
+   */
+   getBonusTime(): number;
+  
 }
 
 /**


### PR DESCRIPTION
This simply implements a `getBonusTime` method for the Corporation API, similar to the ones for the bladeburner and gang APIs.

Usage example:

```javascript
export async function main(ns) {
	while (true) {
		let btime = ns.corporation.getBonusTime();
		console.log(ns.nFormat(btime, "00:00:00"));
		await ns.sleep(50);
	}
}
```

Resulting in:

![bb-corp-api-demo-optimz](https://user-images.githubusercontent.com/40703071/159139309-9cd49b82-d55d-433c-9591-c0059ec6a15c.gif)
