### PR TITLE
Fix #3194: include all division employees in small town achievement calc

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -458,10 +458,12 @@ export const achievements: IMap<Achievement> = {
     Condition: (): boolean => {
       if (Player.corporation === null) return false;
       for (const d of Player.corporation.divisions) {
+        let employeeCount = 0;
         for (const o of Object.values(d.offices)) {
           if (o === 0) continue;
-          if (o.employees.length >= 3000) return true;
+          employeeCount += o.employees.length;
         }
+        if (employeeCount >= 3000) return true;
       }
       return false;
     },


### PR DESCRIPTION
fixes #3194 

Quick and easy fix to this achievement calc that wasn't including all employees in the division in the calc.  Now it sums up the combined division employee count.