### PR TITLE
Fix #3198: give player code a copy of Division.upgrades instead of the live object

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -291,7 +291,7 @@ export function NetscriptCorporation(
       lastCycleExpenses: division.lastCycleExpenses,
       thisCycleRevenue: division.thisCycleRevenue,
       thisCycleExpenses: division.thisCycleExpenses,
-      upgrades: division.upgrades,
+      upgrades: division.upgrades.slice(),
       cities: cities,
       products: division.products === undefined ? [] : Object.keys(division.products),
     };


### PR DESCRIPTION
Fixed by making a `slice()` copy, rather than giving the live game state object to player code. Sample exploit from #3198 no longer works:

```js
/** @param {NS} ns **/
export async function main(ns) {
	const divisionName = ns.args[0];
	const division = ns.corporation.getCorporation().divisions.find(division => division.name == divisionName);

	division.upgrades[1] = 0; // Reset AdVert.Inc to initial 1b cost

	ns.corporation.hireAdVert(divisionName); // Buy one AdVert.Inc, this should raise cost

	division.upgrades[1] = 0; // Reset again
	if (ns.corporation.getHireAdVertCost(divisionName) != 1e9) // Check if exploit still worked
		throw new Error("Exploit: fixed");
}
```

![localhost_8000__noscripts (3)](https://user-images.githubusercontent.com/1919571/159164387-9138c619-5994-477e-af0b-6e927aa3890b.png)