### PR TITLE
fix for dom nesting with elements like ul

### DIFF
--- a/src/ui/React/AlertManager.tsx
+++ b/src/ui/React/AlertManager.tsx
@@ -66,7 +66,7 @@ export function AlertManager(): React.ReactElement {
       {alerts.length > 0 && (
         <Modal open={true} onClose={close}>
           <Box overflow="scroll" sx={{ overflowWrap: "break-word", whiteSpace: "pre-line" }}>
-            <Typography>{alerts[0].text}</Typography>
+            <Typography component={'span'}>{alerts[0].text}</Typography>
           </Box>
         </Modal>
       )}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/5182053/159250554-3b0651e1-cfbc-4d21-99d8-600545d17f10.png)

after:
![image](https://user-images.githubusercontent.com/5182053/159250611-0a4616a5-dc5b-4e8c-a423-082bf9d7840e.png)
