### PR TITLE
Nerf corporation investment fraud

### DIFF
--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -170,7 +170,10 @@ export class Corporation {
     let val;
 
     // take the average over the last ValuationProfitHistoryCycles
-    let profit = this.profitHistory.reduce((sum, val) => sum+val, 0) / this.profitHistory.length;
+    let profit = 0;
+    if (this.profitHistory.length > 0) {
+      profit = this.profitHistory.reduce((sum, val) => sum+val, 0) / this.profitHistory.length;
+    }
 
     if (this.public) {
       // Account for dividends

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -110,7 +110,9 @@ export class Corporation {
         const profit = this.revenue - this.expenses;
 
         this.profitHistory.push(profit);
-        if (this.profitHistory.length > 60) this.profitHistory.shift();
+        if (this.profitHistory.length > CorporationConstants.ValuationProfitHistoryCycles) {
+          this.profitHistory.shift();
+        }
 
         const cycleProfit = profit * (marketCycles * CorporationConstants.SecsPerMarketCycle);
         if (isNaN(this.funds) || this.funds === Infinity || this.funds === -Infinity) {
@@ -167,15 +169,8 @@ export class Corporation {
   determineValuation(): number {
     let val;
 
-    // take the average over the last 60 cycles (10 min)
-    const avgProfit = this.profitHistory.reduce((sum, val) => sum+val, 0) / this.profitHistory.length;
-
-    // // filter out any "anomalies" ;-)
-    // const filtered = this.profitHistory.filter((val) => val < avgProfit * 1.3);
-
-    // // profit is the average of what is left
-    // let profit = filtered.reduce((sum, val) => sum+val, 0) / filtered.length;
-    let profit = avgProfit;
+    // take the average over the last ValuationProfitHistoryCycles
+    let profit = this.profitHistory.reduce((sum, val) => sum+val, 0) / this.profitHistory.length;
 
     if (this.public) {
       // Account for dividends

--- a/src/Corporation/data/Constants.ts
+++ b/src/Corporation/data/Constants.ts
@@ -1,4 +1,4 @@
-import { CityName } from './../../Locations/data/CityNames';
+import { CityName } from "./../../Locations/data/CityNames";
 const CyclesPerMarketCycle = 50;
 const AllCorporationStates = ["START", "PURCHASE", "PRODUCTION", "SALE", "EXPORT"];
 export const CorporationConstants: {
@@ -18,6 +18,7 @@ export const CorporationConstants: {
   OfficeUpgradeBaseCost: number;
   BribeThreshold: number;
   BribeToRepRatio: number;
+  ValuationProfitHistoryCycles: number;
   ProductProductionCostRatio: number;
   DividendMaxPercentage: number;
   EmployeeSalaryMultiplier: number;
@@ -38,7 +39,14 @@ export const CorporationConstants: {
   CyclesPerIndustryStateCycle: CyclesPerMarketCycle / AllCorporationStates.length,
   SecsPerMarketCycle: CyclesPerMarketCycle / 5,
 
-  Cities: [CityName.Aevum, CityName.Chongqing, CityName.Sector12, CityName.NewTokyo, CityName.Ishima, CityName.Volhaven],
+  Cities: [
+    CityName.Aevum,
+    CityName.Chongqing,
+    CityName.Sector12,
+    CityName.NewTokyo,
+    CityName.Ishima,
+    CityName.Volhaven,
+  ],
 
   WarehouseInitialCost: 5e9, //Initial purchase cost of warehouse
   WarehouseInitialSize: 100,
@@ -50,6 +58,8 @@ export const CorporationConstants: {
 
   BribeThreshold: 100e12, //Money needed to be able to bribe for faction rep
   BribeToRepRatio: 1e9, //Bribe Value divided by this = rep gain
+
+  ValuationProfitHistoryCycles: 10, //Number of cycles of profit history to consider in valuations
 
   ProductProductionCostRatio: 5, //Ratio of material cost of a product to its production cost
 
@@ -74,16 +84,6 @@ export const CorporationConstants: {
     "AI Cores",
     "Real Estate",
   ],
-  FundingRoundShares: [
-    0.1,
-    0.35,
-    0.25,
-    0.2
-  ],
-  FundingRoundMultiplier: [
-    4,
-    3,
-    3,
-    2.5
-  ],
+  FundingRoundShares: [0.1, 0.35, 0.25, 0.2],
+  FundingRoundMultiplier: [4, 3, 3, 2.5],
 };

--- a/src/Corporation/data/Constants.ts
+++ b/src/Corporation/data/Constants.ts
@@ -1,4 +1,4 @@
-import { CityName } from "./../../Locations/data/CityNames";
+import { CityName } from './../../Locations/data/CityNames';
 const CyclesPerMarketCycle = 50;
 const AllCorporationStates = ["START", "PURCHASE", "PRODUCTION", "SALE", "EXPORT"];
 export const CorporationConstants: {
@@ -39,14 +39,7 @@ export const CorporationConstants: {
   CyclesPerIndustryStateCycle: CyclesPerMarketCycle / AllCorporationStates.length,
   SecsPerMarketCycle: CyclesPerMarketCycle / 5,
 
-  Cities: [
-    CityName.Aevum,
-    CityName.Chongqing,
-    CityName.Sector12,
-    CityName.NewTokyo,
-    CityName.Ishima,
-    CityName.Volhaven,
-  ],
+  Cities: [CityName.Aevum, CityName.Chongqing, CityName.Sector12, CityName.NewTokyo, CityName.Ishima, CityName.Volhaven],
 
   WarehouseInitialCost: 5e9, //Initial purchase cost of warehouse
   WarehouseInitialSize: 100,
@@ -84,6 +77,16 @@ export const CorporationConstants: {
     "AI Cores",
     "Real Estate",
   ],
-  FundingRoundShares: [0.1, 0.35, 0.25, 0.2],
-  FundingRoundMultiplier: [4, 3, 3, 2.5],
+  FundingRoundShares: [
+    0.1,
+    0.35,
+    0.25,
+    0.2
+  ],
+  FundingRoundMultiplier: [
+    4,
+    3,
+    3,
+    2.5
+  ],
 };


### PR DESCRIPTION
Corporation valuations now look at the average profit over the last `ValuationProfitHistoryCycles` cycles. Currently this is set at 10 which leaves investment fraud still viable, just around 10 times less profitable.

This constant could be tweaked to make the nerf more or less severe. This mainly affects how quickly corps progress, it shouldn't affect dividends or stock price. 

Fixes #2350 

Currently play testing this to see how it compares to before. I can report some numbers here when the results come in.