### PR TITLE
Move main bundle output to ./dist subfolder

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "test:watch": "jest --watch",
     "watch": "webpack --watch --mode production",
     "watch:dev": "webpack --watch --mode development",
-    "electron": "sh ./package.sh",
+    "electron": "sh ./tools/package-electron.sh",
     "electron:packager": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png --no-prune",
     "electron:packager-all": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png",
     "electron:packager-win": "electron-packager .package bitburner --platform win32 --arch x64 --out .build --overwrite --icon .package/icon.png",

--- a/package.sh
+++ b/package.sh
@@ -3,23 +3,12 @@
 # Clear out any files remaining from old builds
 rm -rf .package
 
-mkdir -p .package/dist/src/ThirdParty || true
-mkdir -p .package/src/ThirdParty || true
-mkdir -p .package/node_modules || true
+mkdir -p .package/dist/ || true
 
 cp index.html .package
+cp favicon.ico .package
 cp -r electron/* .package
-cp -r dist/ext .package/dist
-cp -r dist/icons .package/dist
-cp -r dist/images .package/dist
-
-# The js files.
-cp dist/vendor.bundle.js .package/dist/vendor.bundle.js
-cp main.bundle.js .package/main.bundle.js
-
-# Source maps
-cp dist/vendor.bundle.js.map .package/dist/vendor.bundle.js.map
-cp main.bundle.js.map .package/main.bundle.js.map
+cp -r dist .package
 
 # Install electron sub-dependencies
 cd electron

--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euxo pipefail
+
 # Clear out any files remaining from old builds
 rm -rf .package
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,7 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         title: "Bitburner",
         template: "src/index.html",
+        filename: "../index.html",
         favicon: "favicon.ico",
         googleAnalytics: {
           trackingId: "UA-100157497-1",
@@ -136,7 +137,7 @@ module.exports = (env, argv) => {
     // },
     entry: entry,
     output: {
-      path: path.resolve(__dirname, "./"),
+      path: path.resolve(__dirname, outputDirectory),
       filename: "[name].bundle.js",
     },
     module: {
@@ -161,7 +162,7 @@ module.exports = (env, argv) => {
           loader: "file-loader",
           options: {
             name: "[contenthash].[ext]",
-            outputPath: "dist/images",
+            outputPath: "images",
           },
         },
       ],
@@ -184,7 +185,7 @@ module.exports = (env, argv) => {
         cacheGroups: {
           vendor: {
             test: /[\\/]node_modules[\\/]/,
-            name: `${outputDirectory}/vendor`,
+            name: `vendor`,
             chunks: "all",
           },
         },


### PR DESCRIPTION
Excludes the index.html so that the github page can still work as is.
This will help ensure contributors don't commit the built bundles.

It's the same PR content as #2825 that's been merged before, but reverted. I think it was reverted by mistake?

If merged, once built you'll need to manually delete the root's bundles for the first time like so:
![ConEmu64_jNPa4cri0q](https://user-images.githubusercontent.com/1521080/159258908-84c57859-0be9-421a-8383-8856e80b0f16.png)


- Tested while using `npm run start:dev`
- Tested with `npm run build && npm run start`
- Tested with `npm run build && npm run electron && .build/bitburner-win32-x64/bitburner.exe`
