### PR TITLE
Fix handling for UpArrow in bladeburner console #3215

### DIFF
--- a/src/Bladeburner/ui/Console.tsx
+++ b/src/Bladeburner/ui/Console.tsx
@@ -89,7 +89,7 @@ export function Console(props: IProps): React.ReactElement {
 
     const consoleHistory = props.bladeburner.consoleHistory;
 
-    if (event.key === KEY.S) {
+    if (event.key === KEY.UPARROW) {
       // up
       let i = consoleHistoryIndex;
       const len = consoleHistory.length;


### PR DESCRIPTION
Fixes incorrect keymapping for Bladeburner console. Keymapping for "up" was originally (erroneously) set to `38`, which corresponds to `S` key, not `83`, which would be the `UpArrow`. After refactoring the code `38` has just been translated, and started to "work", since S keypresses were now interpreted after some fixes to key handling, which led to surfacing of this bug.

This PR fixes #3215 by allowing to type the letter `s` again without triggering history navigation, and enabling both `UpArrow` and `DownArrow` to correctly navigate history.

Additional info:
- Tested via local dev-server
- I can't include gifs of keypresses :)
