### PR TITLE
Removed BladeburnerSkillCost from skill point cost description

### DIFF
--- a/src/Bladeburner/ui/SkillPage.tsx
+++ b/src/Bladeburner/ui/SkillPage.tsx
@@ -23,8 +23,7 @@ export function SkillPage(props: IProps): React.ReactElement {
         <strong>Skill Points: {formatNumber(props.bladeburner.skillPoints, 0)}</strong>
       </Typography>
       <Typography>
-        You will gain one skill point every{" "}
-        {BladeburnerConstants.RanksPerSkillPoint * BitNodeMultipliers.BladeburnerSkillCost} ranks.
+        You will gain one skill point every {BladeburnerConstants.RanksPerSkillPoint} ranks.
         <br />
         Note that when upgrading a skill, the benefit for that skill is additive. However, the effects of different
         skills with each other is multiplicative.


### PR DESCRIPTION
Reasonably and per the implementation of SP gain
![image](https://user-images.githubusercontent.com/18621228/159387793-eaacd253-a5ac-4d41-9a13-e0e8c58ea06a.png)
`BladeburnerSkillCost` influences skill cost and not the rate of gaining SP