### PR TITLE
Add `npm version` support to build releases

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Default "npm version" commit message
+# See: https://stackoverflow.com/a/34606092
+message=":bookmark: Build v%s"

--- a/package.json
+++ b/package.json
@@ -129,6 +129,9 @@
     "electron:packager-win": "electron-packager .package bitburner --platform win32 --arch x64 --out .build --overwrite --icon .package/icon.png",
     "electron:packager-mac": "electron-packager .package bitburner --platform darwin --arch x64 --out .build --overwrite --icon .package/icon.png",
     "electron:packager-linux": "electron-packager .package bitburner --platform linux --arch x64 --out .build --overwrite --icon .package/icon.png",
-    "allbuild": "npm run build && npm run electron && git add --all && git commit -m \"allbuild commit $(git rev-parse --short HEAD)\" && git push -f -u origin dev"
+    "allbuild": "npm run build && npm run electron && git add --all && git commit -m \"allbuild commit $(git rev-parse --short HEAD)\" && git push -f -u origin dev",
+    "preversion": "npm install && npm run test",
+    "version": "sh ./tools/build-release.sh && git add --all",
+    "postversion": "git push -u origin dev && git push --tags"
   }
 }

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# See https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425
+set -euxo pipefail
+
+APP_VERSION=$(npm pkg get version | sed 's/"//g')
+
+echo ''
+echo '|============================================|'
+echo "  Preparing build v$APP_VERSION"
+echo '  Taken from the root ./package.json file.'
+echo '|============================================|'
+echo ''
+sleep 1
+echo 'Do you need to increment the save file version?'
+echo 'If you do, cancel/exit this script now.'
+echo 'Update the following file before running this script: '
+echo '> ./src/Constants.ts'
+echo ''
+sleep 2
+echo 'Do you want to include a changelog with this release?'
+echo 'If you do, cancel/exit this script now.'
+echo 'Update the following file before running this script: '
+echo '> ./src/Constants.ts'
+echo '> ./doc/source/changelog.rst'
+echo ''
+sleep 2
+
+cd ./tools/bump-version
+npm ci
+cd ../../
+node ./tools/bump-version/basic.js --version $APP_VERSION
+echo ''
+
+echo 'Building bundles in 2 seconds...'
+sleep 2
+
+echo ''
+echo 'Starting build...'
+npm run doc && \
+  npm run build && \
+  npm run electron
+
+echo ''
+echo 'Completed!'
+echo ''

--- a/tools/bump-version/basic.js
+++ b/tools/bump-version/basic.js
@@ -1,0 +1,57 @@
+import commandLineArgs from "command-line-args";
+
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// https://github.com/75lb/command-line-args
+const optionDefinitions = [
+  {
+    name: "version",
+    alias: "v",
+    type: String,
+    required: true,
+  },
+];
+
+const cliArgs = commandLineArgs(optionDefinitions);
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const appPaths = {
+  root,
+  electronPackage: path.join(root, "./electron/package.json"),
+  constants: path.join(root, "./src/Constants.ts"),
+  sphinxConf: path.join(root, "./doc/source/conf.py"),
+};
+
+async function main(version) {
+  console.log(`Updating app files to match v${version}`);
+
+  const [major, minor] = version.split(".");
+  const shortVersion = `${major}.${minor}`;
+
+  const modifiedElectronPackage = (await fs.readFile(appPaths.electronPackage, "utf8")).replace(
+    /(^\s*"version":\s)"(.*)",$/m,
+    `$1"${version}",`,
+  );
+  await fs.writeFile(appPaths.electronPackage, modifiedElectronPackage);
+  console.log(`> Modified ${appPaths.electronPackage}`);
+
+  let modifiedConstants = (await fs.readFile(appPaths.constants, "utf8")).replace(
+    /(^\s*?VersionString:\s)"(.*)",/m,
+    `$1"${version}",`,
+  );
+
+  await fs.writeFile(appPaths.constants, modifiedConstants);
+  console.log(`> Modified ${appPaths.constants}`);
+
+  let modifiedSphinxConfig = (await fs.readFile(appPaths.sphinxConf, "utf8")).replace(
+    /(^version = ')(.*)'$/m,
+    `$1${shortVersion}'`,
+  );
+  modifiedSphinxConfig = modifiedSphinxConfig.replace(/(^release = ')(.*)'$/m, `$1${version}'`);
+  await fs.writeFile(appPaths.sphinxConf, modifiedSphinxConfig);
+  console.log(`> Modified ${appPaths.sphinxConf}`);
+}
+
+main(cliArgs.version).then(() => console.log("Done"));


### PR DESCRIPTION
Replaces the `npm run allbuild` script with the `npm version` command.
It creates a new commit with a standardized message & includes the built
app. 

Usage: `npm version [patch | minor | version | 10.0.0 | etc]` ([documentation](https://docs.npmjs.com/cli/v6/commands/npm-version))

If you want to include a changelog and/or increment the save game version for migrations, you need to modify the files before running the command. You'll have to add the force flag to npm version ie: `npm version patch --force` since it'll complain about an unclean repository otherwise.

Will update the package.json & perform a bunch of steps in a row:

- Runs `npm install` in:
  - The root directory
  - The ./electron/ directory
  - The ./tools/bump-version/ directory
- Runs `npm run test`
- Update the version string in:
  - ./electron/package.json (version)
  - ./src/Constants.ts (VersionString)
  - ./doc/source/conf.py (version & release)
- Runs `npm run doc` (build the markdown documentation)
- Runs `npm run build` (production build)
- Runs `npm run electron` (electron build)
- Runs `git add --all`
- Runs `git push -u origin dev && git push --tags`

---

### Testing

Result commit of `npm version major` : https://github.com/MartinFournier/bitburner/commit/2d44fe9a82103afc76adafa14a013e694b2340d0