### PR TITLE
Cancel writing program progress if the same program is bought from darkweb

### DIFF
--- a/src/DarkWeb/DarkWeb.tsx
+++ b/src/DarkWeb/DarkWeb.tsx
@@ -84,6 +84,12 @@ export function buyDarkwebItem(itemName: string): void {
   // Add the newly bought, full .exe
   Player.getHomeComputer().programs.push(item.program);
 
+  // Cancel if the program is in progress of writing
+  if (Player.createProgramName === item.program) {
+    Player.isWorking = false;
+    Player.resetWorkStatus();
+  }
+
   Terminal.print(
     "You have purchased the " + item.program + " program. The new program can be found on your home computer.",
   );

--- a/src/DarkWeb/DarkWeb.tsx
+++ b/src/DarkWeb/DarkWeb.tsx
@@ -14,8 +14,8 @@ export function checkIfConnectedToDarkweb(): void {
   if (server !== null && SpecialServers.DarkWeb == server.hostname) {
     Terminal.print(
       "You are now connected to the dark web. From the dark web you can purchase illegal items. " +
-        "Use the 'buy -l' command to display a list of all the items you can buy. Use 'buy [item-name]' " +
-        "to purchase an item. Use 'buy -a' to purchase all unowned items.",
+      "Use the 'buy -l' command to display a list of all the items you can buy. Use 'buy [item-name]' " +
+      "to purchase an item. Use 'buy -a' to purchase all unowned items.",
     );
   }
 }
@@ -72,6 +72,12 @@ export function buyDarkwebItem(itemName: string): void {
   // buy and push
   Player.loseMoney(item.price, "other");
 
+  // Cancel if the program is in progress of writing
+  if (Player.createProgramName === item.program) {
+    Player.isWorking = false;
+    Player.resetWorkStatus();
+  }
+
   const programsRef = Player.getHomeComputer().programs;
   // Remove partially created program if there is one
   const existingPartialExeIndex = programsRef.findIndex(
@@ -83,12 +89,6 @@ export function buyDarkwebItem(itemName: string): void {
   }
   // Add the newly bought, full .exe
   Player.getHomeComputer().programs.push(item.program);
-
-  // Cancel if the program is in progress of writing
-  if (Player.createProgramName === item.program) {
-    Player.isWorking = false;
-    Player.resetWorkStatus();
-  }
 
   Terminal.print(
     "You have purchased the " + item.program + " program. The new program can be found on your home computer.",

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -555,6 +555,12 @@ export function NetscriptSingularity(
         return true;
       }
 
+      // Cancel if the program is in progress of writing
+      if (player.createProgramName === item.program) {
+        player.isWorking = false;
+        player.resetWorkStatus();
+      }
+
       player.loseMoney(item.price, "other");
       player.getHomeComputer().programs.push(item.program);
       workerScript.log(

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -555,6 +555,12 @@ export function NetscriptSingularity(
         return true;
       }
 
+      // Cancel if the program is in progress of writing
+      if (player.createProgramName === item.program) {
+        player.isWorking = false;
+        player.resetWorkStatus();
+      }
+
       const programsRef = player.getHomeComputer().programs;
       // Remove partially created program if there is one
       const existingPartialExeIndex = programsRef.findIndex(
@@ -563,12 +569,6 @@ export function NetscriptSingularity(
       // findIndex returns -1 if there is no match, we only want to splice on a match
       if (existingPartialExeIndex > -1) {
         programsRef.splice(existingPartialExeIndex, 1);
-      }
-
-      // Cancel if the program is in progress of writing
-      if (player.createProgramName === item.program) {
-        player.isWorking = false;
-        player.resetWorkStatus();
       }
 
       player.loseMoney(item.price, "other");
@@ -1299,7 +1299,7 @@ export function NetscriptSingularity(
         throw helper.makeRuntimeErrorMsg(
           "getDarkwebProgramCost",
           `No such exploit ('${programName}') found on the darkweb! ` +
-            `\nThis function is not case-sensitive. Did you perhaps forget .exe at the end?`,
+          `\nThis function is not case-sensitive. Did you perhaps forget .exe at the end?`,
         );
       }
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -555,6 +555,16 @@ export function NetscriptSingularity(
         return true;
       }
 
+      const programsRef = player.getHomeComputer().programs;
+      // Remove partially created program if there is one
+      const existingPartialExeIndex = programsRef.findIndex(
+        (program) => item?.program && program.startsWith(item?.program),
+      );
+      // findIndex returns -1 if there is no match, we only want to splice on a match
+      if (existingPartialExeIndex > -1) {
+        programsRef.splice(existingPartialExeIndex, 1);
+      }
+
       // Cancel if the program is in progress of writing
       if (player.createProgramName === item.program) {
         player.isWorking = false;


### PR DESCRIPTION
If the player is writing a program and the same program is bought from the darkweb meanwhile, the creation progress cancels.

Fixes #3234 (it doesn't fix already bought programs display, only applies to new)

Also, provides proper fix for #2024 (previous fix only applied if the program was bought via terminal but not via singularity API)
