### PR TITLE
Add 0xDEADBEEF exploit (SF-1)

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -746,6 +746,16 @@ export const achievements: IMap<Achievement> = {
     Secret: true,
     Condition: () => Player.exploits.includes(Exploit.TrueRecursion),
   },
+  DEADBEEF: {
+    // Replace the ID, Name & Description by the line below once the achievement is added to Steam.
+    // ...achievementData["DEADBEEF"],
+    ID: "DEADBEEF",
+    Name: "Exploit: 0xDEADBEEF",
+    Description: "Overpowered the obfuscated.",
+    Icon: "SF-1",
+    Secret: true,
+    Condition: () => Player.exploits.includes(Exploit.DEADBEEF),
+  },
 };
 
 // Steam has a limit of 100 achievement. So these were planned but commented for now.

--- a/src/DevMenu/ui/General.tsx
+++ b/src/DevMenu/ui/General.tsx
@@ -10,6 +10,7 @@ import Button from "@mui/material/Button";
 import { Money } from "../../ui/React/Money";
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { IRouter } from "../../ui/Router";
+import { getExploitServerPassphrase } from "../../Server/SecretServer";
 
 interface IProps {
   player: IPlayer;
@@ -18,6 +19,8 @@ interface IProps {
 
 export function General(props: IProps): React.ReactElement {
   const [error, setError] = useState(false);
+
+  const exploitPassphrase = getExploitServerPassphrase(props.player);
 
   function addMoney(n: number) {
     return function () {
@@ -88,6 +91,11 @@ export function General(props: IProps): React.ReactElement {
         <Button onClick={quickHackW0r1dD43m0n}>Quick w0rld_d34m0n</Button>
         <Button onClick={hackW0r1dD43m0n}>Hack w0rld_d34m0n</Button>
         <Button onClick={() => setError(true)}>Throw Error</Button>
+
+        <br />
+        <Typography sx={{ mt: 2 }}>
+          Exploit Passphrase: <strong>{exploitPassphrase}</strong>
+        </Typography>
       </AccordionDetails>
     </Accordion>
   );

--- a/src/Exploits/Exploit.ts
+++ b/src/Exploits/Exploit.ts
@@ -21,6 +21,7 @@ export enum Exploit {
   YoureNotMeantToAccessThis = "YoureNotMeantToAccessThis",
   TrueRecursion = "TrueRecursion",
   INeedARainbow = "INeedARainbow",
+  DEADBEEF = "DEADBEEF",
   // To the players reading this. Yes you're supposed to add EditSaveFile by
   // editing your save file, yes you could add them all, no we don't care
   // that's not the point.
@@ -41,6 +42,7 @@ const names: {
   YoureNotMeantToAccessThis: "by accessing the dev menu.",
   TrueRecursion: "by truly recursing.",
   INeedARainbow: "by using the power of the rainbow.",
+  DEADBEEF: "by overpowering the obfuscated.",
 };
 
 export function ExploitName(exploit: string): string {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -504,6 +504,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       for (let i = 0; i < server.serversOnNetwork.length; i++) {
         const s = getServerOnNetwork(server, i);
         if (s === null) continue;
+        if (s.hidden) continue;
         const entry = s.hostname;
         if (entry === null) continue;
         out.push(entry);

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -111,6 +111,7 @@ interface IServerParams {
   organizationName: string;
   requiredHackingSkill?: number;
   serverGrowth?: number;
+  hidden?: boolean;
 
   [key: string]: any;
 }
@@ -148,6 +149,7 @@ export function initForeignServers(homeComputer: Server): void {
       ip: createUniqueRandomIp(),
       numOpenPortsRequired: metadata.numOpenPortsRequired,
       organizationName: metadata.organizationName,
+      hidden: metadata.hidden,
     };
 
     if (metadata.maxRamExponent !== undefined) {

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -95,6 +95,9 @@ export class BaseServer {
   // Flag indicating wehther this is a purchased server
   purchasedByPlayer = false;
 
+  // Flag indicating whether this server should be hidden from scans
+  hidden = false;
+
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {
     this.ip = params.ip ? params.ip : createRandomIp();
 

--- a/src/Server/SecretServer.ts
+++ b/src/Server/SecretServer.ts
@@ -1,0 +1,95 @@
+import { GetServer, AddToAllServers } from "./AllServers";
+import { IPlayer } from "../PersonObjects/IPlayer";
+import { cyrb53 } from "../utils/StringHelperFunctions";
+import { hash } from "../hash/hash";
+import { safetlyCreateUniqueServer } from "./ServerHelpers";
+import { SpecialServers } from "./data/SpecialServers";
+
+/**
+ * Mapping for hexadecimal character to military names
+ */
+const hexaToMilitary = {
+  a: "alpha",
+  b: "beta",
+  c: "charlie",
+  d: "delta",
+  e: "echo",
+  f: "foxtrot",
+  "0": "zero",
+  "1": "one",
+  "2": "two",
+  "3": "three",
+  "4": "four",
+  "5": "five",
+  "6": "six",
+  "7": "seven",
+  "8": "eight",
+  "9": "nine",
+  "10": "ten",
+};
+
+/**
+ * Attempts to create the exploit server and attaches it the the dark army network
+ * @returns Will return true if the server was created at this time.
+ */
+function createExploitServer(): boolean {
+  const s = GetServer(SpecialServers.ExploitServer);
+  if (s !== null) return false; // already created, let's get out of here.
+
+  const server = safetlyCreateUniqueServer({
+    hostname: SpecialServers.ExploitServer,
+    organizationName: "fsociety",
+    maxRam: 8,
+    numOpenPortsRequired: 5,
+    requiredHackingSkill: 9001,
+    hidden: true,
+  });
+  AddToAllServers(server);
+
+  const darkArmyServer = GetServer(SpecialServers.TheDarkArmyServer);
+  if (!darkArmyServer) throw new Error("Dark Army Server does not exist"); // this should not happen.
+  darkArmyServer.serversOnNetwork.push(server.hostname);
+  server.serversOnNetwork.push(darkArmyServer.hostname);
+
+  return true;
+}
+
+/**
+ * Gets the current passphrase required to unlock the exploit server
+ * It will change every reset since it's seeded from data in the player's save
+ * @param player Player data is required to get the seed
+ * @returns The passphrase that will unlock the server
+ */
+export function getExploitServerPassphrase(player: IPlayer): string {
+  // Fixed seed per augmentation/soft-reset
+  const timestamp = player.playtimeSinceLastBitnode - player.playtimeSinceLastAug;
+  const seed = timestamp + ((0xdeadbeef * 69) % 420); // nice.
+
+  // Salted with the current commit hash so it'll change every game version
+  const hashedHost = cyrb53(`${SpecialServers.ExploitServer}_${hash()}`, seed);
+
+  // Our hashed passphrase is an hexadecimal string, so we can map it to the dictionary above
+  const passphrase = [...hashedHost]
+    .map((character) => hexaToMilitary[character as keyof typeof hexaToMilitary])
+    .join("-");
+
+  return passphrase;
+}
+
+/**
+ * Compares the attempted passphrase with the current exploit server passphrase.
+ * If they match, it'll create the server on the network.
+ * @param player Player data is required to get the seed
+ * @param attemptPassphrase The unlock attempt
+ * @returns Will return true if the passphrase matches
+ */
+export function attemptToUnlockExploitServer(player: IPlayer, attemptPassphrase: string): boolean {
+  const secretPassphrase = getExploitServerPassphrase(player);
+  const success = attemptPassphrase === secretPassphrase;
+
+  if (success) {
+    createExploitServer();
+  }
+
+  return success;
+}

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -20,6 +20,7 @@ export interface IConstructorParams {
   purchasedByPlayer?: boolean;
   requiredHackingSkill?: number;
   serverGrowth?: number;
+  hidden?: boolean;
 }
 
 export class Server extends BaseServer {
@@ -55,6 +56,9 @@ export class Server extends BaseServer {
   // be increased using the grow() Netscript function
   serverGrowth = 1;
 
+  // Flag indicating whether this server should be hidden from scans
+  hidden = false;
+
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {
     super(params);
 
@@ -83,6 +87,8 @@ export class Server extends BaseServer {
 
     //Port information, required for porthacking servers to get admin rights
     this.numOpenPortsRequired = params.numOpenPortsRequired != null ? params.numOpenPortsRequired : 5;
+
+    this.hidden = params.hidden ?? false;
   }
 
   /**

--- a/src/Server/data/SpecialServers.ts
+++ b/src/Server/data/SpecialServers.ts
@@ -12,6 +12,7 @@ export const SpecialServers: {
   DaedalusServer: string;
   WorldDaemon: string;
   DarkWeb: string;
+  ExploitServer: string;
 } = {
   Home: "home",
   FulcrumSecretTechnologies: "fulcrumassets",
@@ -23,4 +24,5 @@ export const SpecialServers: {
   DaedalusServer: "The-Cave",
   WorldDaemon: "w0r1d_d43m0n",
   DarkWeb: "darkweb",
+  ExploitServer: "0xDEADBEEF",
 };

--- a/src/Server/data/servers.ts
+++ b/src/Server/data/servers.ts
@@ -23,6 +23,11 @@ interface IServerMetadata {
   hostname: string;
 
   /**
+   * If true, the server won't show in the scans
+   */
+  hidden?: boolean;
+
+  /**
    * When populated, the files will be added to the server when created.
    */
   literature?: string[];

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -71,7 +71,9 @@ import { unalias } from "./commands/unalias";
 import { vim } from "./commands/vim";
 import { weaken } from "./commands/weaken";
 import { wget } from "./commands/wget";
+import { unlock } from "./commands/unlock";
 import { hash } from "../hash/hash";
+import { Exploit } from "../Exploits/Exploit";
 
 export class Terminal implements ITerminal {
   // Flags to determine whether the player is currently running a hack or an analyze
@@ -301,6 +303,9 @@ export class Terminal implements ITerminal {
         }
         router.toBitVerse(false, false);
         return;
+      } else if (server.hidden && server.hostname.startsWith(SpecialServers.ExploitServer)) {
+        // We want to compare with .startsWith in case a player already created that server name, in that case there will be a -0 suffixed.
+        player.giveExploit(Exploit.DEADBEEF);
       }
       this.print(`Backdoor on '${server.hostname}' successful!`);
     }
@@ -812,6 +817,7 @@ export class Terminal implements ITerminal {
       vim: vim,
       weaken: weaken,
       wget: wget,
+      unlock: unlock,
     };
 
     const f = commands[commandName.toLowerCase()];

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -516,6 +516,8 @@ export class Terminal implements ITerminal {
         continue; // Already visited or out-of-depth
       } else if (!all && isHacknet) {
         continue; // Hacknet Server
+      } else if (s.hidden) {
+        continue; // Hidden server that we don't want to expose
       } else {
         visited[s.hostname] = 1;
       }

--- a/src/Terminal/commands/scan.ts
+++ b/src/Terminal/commands/scan.ts
@@ -25,17 +25,20 @@ export function scan(
       hostname: server.hostname,
       ip: server.ip,
       hasRoot: server.hasAdminRights ? "Y" : "N",
+      hidden: server.hidden,
     };
   });
   servers.unshift({
     hostname: "Hostname",
     ip: "IP",
     hasRoot: "Root Access",
+    hidden: false,
   });
   const maxHostname = Math.max(...servers.map((s) => s.hostname.length));
   const maxIP = Math.max(...servers.map((s) => s.ip.length));
   for (const server of servers) {
     if (!server) continue;
+    if (server.hidden) continue;
     let entry = server.hostname;
     entry += " ".repeat(maxHostname - server.hostname.length + 1);
     entry += server.ip;

--- a/src/Terminal/commands/unlock.tsx
+++ b/src/Terminal/commands/unlock.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { ITerminal } from "../ITerminal";
+import { IRouter } from "../../ui/Router";
+import { IPlayer } from "../../PersonObjects/IPlayer";
+import { BaseServer } from "../../Server/BaseServer";
+import { attemptToUnlockExploitServer } from "../../Server/SecretServer";
+import { CorruptableText } from "../../ui/React/CorruptableText";
+
+export function unlock(
+  terminal: ITerminal,
+  router: IRouter,
+  player: IPlayer,
+  server: BaseServer,
+  args: (string | number | boolean)[],
+): void {
+  if (args.length !== 1) {
+    terminal.error("Incorrect usage of unlock command. Usage: unlock [passphrase]");
+    return;
+  }
+
+  const passphrase = args[0] + "";
+
+  // We'll try to see if the passphrase works to access the exploit server
+  if (attemptToUnlockExploitServer(player, passphrase)) {
+    // Great! Let's spam the terminal a bit...
+    let n = 0;
+    const max = 10;
+    terminal.printRaw("=".repeat(20));
+    const spam = (): void => {
+      n++;
+      if (n < 10) {
+        terminal.printRaw(
+          <span>
+            {max - n}
+            {" >>> "}
+            <CorruptableText content={"0xDEADBEEF "} />
+          </span>,
+        );
+        setTimeout(spam, 200);
+      } else {
+        terminal.printRaw("=".repeat(20));
+        const spamLine = (): React.ReactNode[] =>
+          [...Array(4)].map((_, index) => <CorruptableText key={index} content={"|0xDEADBEEF| "} />);
+        terminal.printRaw(spamLine());
+        terminal.printRaw(spamLine());
+        terminal.printRaw(spamLine());
+        terminal.printRaw("=".repeat(20));
+      }
+    };
+    spam();
+    return;
+  }
+}

--- a/src/Terminal/determineAllPossibilitiesForTabCompletion.ts
+++ b/src/Terminal/determineAllPossibilitiesForTabCompletion.ts
@@ -243,6 +243,8 @@ export async function determineAllPossibilitiesForTabCompletion(
       const serv = GetServer(currServ.serversOnNetwork[i]);
       if (serv == null) {
         continue;
+      } else if (serv.hidden) {
+        continue;
       }
       allPos.push(serv.hostname);
     }


### PR DESCRIPTION
Adds a new exploit that requires the player to bruteforce a passphrase through the terminal
(or most likely read the source to reverse the seed method since bruteforce would take forever).

Adds a new `unlock` terminal command that adds a new server to the network once a
passphrase was successfully matched. This needs to be done from the
terminal, no direct ns script access.

Once created, the server is added as a hidden server which hides it from
scan, scan-analyze, autocomplete, ns.scan. This server is still able to be
connected to given the proper route.

Since the hostname is hex, it trips the connect method and
requires the player to wrap its hostname in quotes.
Once that server is backdoored, the exploit will be awarded and
the achievement unlocked.

---

### Unlocking the server

![firefox_wQcyZMtA5i](https://user-images.githubusercontent.com/1521080/159744553-6211ebfa-bed8-43e5-a1c1-9c84708073f3.gif)

### Accessing the server

![firefox_oJ8n9UqMmy](https://user-images.githubusercontent.com/1521080/159744548-355956ef-b744-46d6-8ab0-e396a6e63b8e.gif)

### Backdooring the server
![firefox_daJfpB6AcF](https://user-images.githubusercontent.com/1521080/159744545-c40941b7-b400-4ed8-8a33-2867d60ba605.gif)

### Server not visible in scans

![firefox_FcjYCfqhh1](https://user-images.githubusercontent.com/1521080/159744547-fff7abf2-c355-41d7-971b-139e0fd6ad79.png)

### Direct connect works

![firefox_WExl1wtZmL](https://user-images.githubusercontent.com/1521080/159744551-8e26fcc9-289d-4301-b870-d615e36b8c65.png)

### Backdooring the server

![firefox_rVyUO4P3f6](https://user-images.githubusercontent.com/1521080/159744550-3c12d930-a099-4486-b94d-161f77b3a3c0.png)

### Current passphrase in dev menu

![firefox_hVC9N6GIAs](https://user-images.githubusercontent.com/1521080/159745437-53725280-513d-4daa-b04c-d2225f7c2c72.png)

### Achievement
![firefox_b0T9ulf5A9](https://user-images.githubusercontent.com/1521080/159744541-fad1fc42-452e-4753-b3ea-3b4e0b757a92.png)
