### PR TITLE
purchaseTor() should returns true if player already has Tor

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -499,7 +499,7 @@ export function NetscriptSingularity(
 
       if (player.hasTorRouter()) {
         workerScript.log("purchaseTor", () => "You already have a TOR router!");
-        return false;
+        return true;
       }
 
       if (player.money < CONSTANTS.TorRouterCost) {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1597,7 +1597,7 @@ export interface Singularity {
    * purchasing a TOR router using this function is the same as if you were to
    * manually purchase one.
    *
-   * @returns True if actions is successful, false otherwise.
+   * @returns True if actions is successful or you already own TOR router, false otherwise.
    */
   purchaseTor(): boolean;
 


### PR DESCRIPTION
Change `purchaseTor` to return `true` if the player already has purchased Tor. Previously it would return `false`

Changing this to true puts the behavior inline with the already existing behavior of `purchaseProgram`, which returns true if you have already purchased the program. Additionally this lets us call `purcahseTor` with the same logic that we use to call `purchaseProgram`

