### PR TITLE
[Doc] Update Injecting HTML guide

### DIFF
--- a/doc/source/netscript/advancedfunctions/inject_html.rst
+++ b/doc/source/netscript/advancedfunctions/inject_html.rst
@@ -21,7 +21,7 @@ To automatically enter commands in the terminal (only works if looking at the te
     terminalInput[handler].onChange({target:terminalInput});
 
     // Simulate an enter press
-    terminalInput[handler].onKeyDown({keyCode:13,preventDefault:()=>null});
+    terminalInput[handler].onKeyDown({key:'Enter',preventDefault:()=>null});
 
 
 To add lines to the terminal (only works if looking at the terminal):


### PR DESCRIPTION
keyCode is deprecated, method in doc doesn't work
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

Updating with "modern" method
key:'Enter'

related discord discussions
https://discord.com/channels/415207508303544321/931147989307764786/956158606246572062
https://discord.com/channels/415207508303544321/895204896788328448/956120087323082792
https://discord.com/channels/415207508303544321/928919860891750410/956024950626586734
