### PR TITLE
Update RamCostGenerator

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -200,6 +200,7 @@ export const RamCosts: IMap<any> = {
   readPort: 0,
   getPortHandle: 0,
   rm: RamCostConstants.ScriptReadWriteRamCost,
+  mv: RamCostConstants.ScriptReadWriteRamCost,
   scriptRunning: RamCostConstants.ScriptArbScriptRamCost,
   scriptKill: RamCostConstants.ScriptArbScriptRamCost,
   getScriptName: 0,

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -136,6 +136,7 @@ export const RamCosts: IMap<any> = {
   kill: RamCostConstants.ScriptKillRamCost,
   killall: RamCostConstants.ScriptKillRamCost,
   exit: 0,
+  atExit: 0,
   scp: RamCostConstants.ScriptScpRamCost,
   ls: RamCostConstants.ScriptScanRamCost,
   ps: RamCostConstants.ScriptScanRamCost,

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -364,16 +364,16 @@ export const RamCosts: IMap<any> = {
   },
 
   stanek: {
-    width: RamCostConstants.ScriptStanekWidth,
-    height: RamCostConstants.ScriptStanekHeight,
-    charge: RamCostConstants.ScriptStanekCharge,
+    giftWidth: RamCostConstants.ScriptStanekWidth,
+    giftHeight: RamCostConstants.ScriptStanekHeight,
+    chargeFragment: RamCostConstants.ScriptStanekCharge,
     fragmentDefinitions: RamCostConstants.ScriptStanekFragmentDefinitions,
     activeFragments: RamCostConstants.ScriptStanekPlacedFragments,
-    clear: RamCostConstants.ScriptStanekClear,
-    canPlace: RamCostConstants.ScriptStanekCanPlace,
-    place: RamCostConstants.ScriptStanekPlace,
-    get: RamCostConstants.ScriptStanekFragmentAt,
-    remove: RamCostConstants.ScriptStanekDeleteAt,
+    clearGift: RamCostConstants.ScriptStanekClear,
+    canPlaceFragment: RamCostConstants.ScriptStanekCanPlace,
+    placeFragment: RamCostConstants.ScriptStanekPlace,
+    getFragment: RamCostConstants.ScriptStanekFragmentAt,
+    removeFragment: RamCostConstants.ScriptStanekDeleteAt,
   },
 
   ui: {

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -389,8 +389,8 @@ export const RamCosts: IMap<any> = {
   },
 
   grafting: {
-    getAugmentationCraftPrice: 3.75,
-    getAugmentationCraftTime: 3.75,
+    getAugmentationGraftPrice: 3.75,
+    getAugmentationGraftTime: 3.75,
     graftAugmentation: 7.5,
   },
 


### PR DESCRIPTION
# Fill in missing values in RamCostGenerator

In Bitburner v1.6, I see a lot of console messages
```
Unexpected type (undefined) for value [stanek,chargeFragment]
```

This PR fixes the values for renamed stanek functions, fixes the spelling of grafting functions, and fills in missing values for other netscript functions.