### PR TITLE
[Fix] Grafting crash when all Augmentations owned

### DIFF
--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -64,74 +64,78 @@ export const GraftingRoot = (): React.ReactElement => {
 
       <Box sx={{ my: 3 }}>
         <Typography variant="h5">Graft Augmentations</Typography>
-        <Paper sx={{ my: 1, width: "fit-content", display: "grid", gridTemplateColumns: "1fr 3fr" }}>
-          <List sx={{ maxHeight: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
-            {getAvailableAugs(player).map((k, i) => (
-              <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
-                <Typography>{k}</Typography>
-              </ListItemButton>
-            ))}
-          </List>
-          <Box sx={{ m: 1 }}>
-            <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
-              <Construction sx={{ mr: 1 }} /> {selectedAug}
-            </Typography>
-            <Button
-              onClick={() => setGraftOpen(true)}
-              sx={{ width: "100%" }}
-              disabled={player.money < GraftableAugmentations[selectedAug].cost}
-            >
-              Graft Augmentation (
-              <Typography>
-                <Money money={GraftableAugmentations[selectedAug].cost} player={player} />
+        {getAvailableAugs(player).length > 0 ? (
+          <Paper sx={{ my: 1, width: "fit-content", display: "grid", gridTemplateColumns: "1fr 3fr" }}>
+            <List sx={{ maxHeight: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
+              {getAvailableAugs(player).map((k, i) => (
+                <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
+                  <Typography>{k}</Typography>
+                </ListItemButton>
+              ))}
+            </List>
+            <Box sx={{ m: 1 }}>
+              <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
+                <Construction sx={{ mr: 1 }} /> {selectedAug}
               </Typography>
-              )
-            </Button>
-            <ConfirmationModal
-              open={graftOpen}
-              onClose={() => setGraftOpen(false)}
-              onConfirm={() => {
-                const graftableAug = GraftableAugmentations[selectedAug];
-                player.loseMoney(graftableAug.cost, "augmentations");
-                player.startGraftAugmentationWork(selectedAug, graftableAug.time);
-                player.startFocusing();
-                router.toWork();
-              }}
-              confirmationText={
-                <>
-                  Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b> be
-                  returned.
-                  <br />
-                  <br />
-                  Additionally, grafting an Augmentation will increase the potency of the Entropy virus.
-                </>
-              }
-            />
-            <Typography color={Settings.theme.info}>
-              <b>Time to Graft:</b>{" "}
-              {convertTimeMsToTimeElapsedString(
-                GraftableAugmentations[selectedAug].time / (1 + (player.getIntelligenceBonus(3) - 1) / 3),
-              )}
-              {/* Use formula so the displayed creation time is accurate to player bonus */}
-            </Typography>
-            <Typography sx={{ maxHeight: 305, overflowY: "scroll" }}>
-              {(() => {
-                const aug = Augmentations[selectedAug];
-
-                const info = typeof aug.info === "string" ? <span>{aug.info}</span> : aug.info;
-                const tooltip = (
+              <Button
+                onClick={() => setGraftOpen(true)}
+                sx={{ width: "100%" }}
+                disabled={player.money < GraftableAugmentations[selectedAug].cost}
+              >
+                Graft Augmentation (
+                <Typography>
+                  <Money money={GraftableAugmentations[selectedAug].cost} player={player} />
+                </Typography>
+                )
+              </Button>
+              <ConfirmationModal
+                open={graftOpen}
+                onClose={() => setGraftOpen(false)}
+                onConfirm={() => {
+                  const graftableAug = GraftableAugmentations[selectedAug];
+                  player.loseMoney(graftableAug.cost, "augmentations");
+                  player.startGraftAugmentationWork(selectedAug, graftableAug.time);
+                  player.startFocusing();
+                  router.toWork();
+                }}
+                confirmationText={
                   <>
-                    {info}
+                    Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b>{" "}
+                    be returned.
                     <br />
                     <br />
-                    {aug.stats}
+                    Additionally, grafting an Augmentation will increase the potency of the Entropy virus.
                   </>
-                );
-                return tooltip;
-              })()}
-            </Typography>
-          </Box>
-        </Paper>
+                }
+              />
+              <Typography color={Settings.theme.info}>
+                <b>Time to Graft:</b>{" "}
+                {convertTimeMsToTimeElapsedString(
+                  GraftableAugmentations[selectedAug].time / (1 + (player.getIntelligenceBonus(3) - 1) / 3),
+                )}
+                {/* Use formula so the displayed creation time is accurate to player bonus */}
+              </Typography>
+              <Typography sx={{ maxHeight: 305, overflowY: "scroll" }}>
+                {(() => {
+                  const aug = Augmentations[selectedAug];
+
+                  const info = typeof aug.info === "string" ? <span>{aug.info}</span> : aug.info;
+                  const tooltip = (
+                    <>
+                      {info}
+                      <br />
+                      <br />
+                      {aug.stats}
+                    </>
+                  );
+                  return tooltip;
+                })()}
+              </Typography>
+            </Box>
+          </Paper>
+        ) : (
+          <Typography>All Augmentations owned</Typography>
+        )}
       </Box>
 
       <Box sx={{ my: 3 }}>


### PR DESCRIPTION
Fixes #3284

Adds a check for whether the player owns all Augmentations when entering the Grafting UI.

![image](https://user-images.githubusercontent.com/60761231/160905722-e543844f-e587-4eb7-920d-6dddddf69745.png)