### PR TITLE
Support setFocus() for augmentation crafting

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -697,7 +697,8 @@ export function NetscriptSingularity(
           player.workType == CONSTANTS.WorkTypeCompany ||
           player.workType == CONSTANTS.WorkTypeCompanyPartTime ||
           player.workType == CONSTANTS.WorkTypeCreateProgram ||
-          player.workType == CONSTANTS.WorkTypeStudyClass
+          player.workType == CONSTANTS.WorkTypeStudyClass ||
+          player.workType == CONSTANTS.WorkTypeGraftAugmentation
         )
       ) {
         throw helper.makeRuntimeErrorMsg("setFocus", "Cannot change focus for current job");


### PR DESCRIPTION
# Bug fix

The `setFocus()` singularity function should support augmentation grafting, as there is a "do something else" button in the UI.