### PR TITLE
Add calculateFavorToRep and calculateRepToFavor to Formulas.exe

### DIFF
--- a/src/NetscriptFunctions/Formulas.ts
+++ b/src/NetscriptFunctions/Formulas.ts
@@ -37,6 +37,10 @@ import {
   calculateAscensionMult,
   calculateAscensionPointsGain,
 } from "../Gang/formulas/formulas";
+import { 
+  favorToRep as calculateFavorToRep, 
+  repToFavor as calculateRepToFavor,
+} from "../Faction/formulas/favor";
 
 export function NetscriptFormulas(player: IPlayer, workerScript: WorkerScript, helper: INetscriptHelper): IFormulas {
   const checkFormulasAccess = function (func: string): void {
@@ -45,6 +49,18 @@ export function NetscriptFormulas(player: IPlayer, workerScript: WorkerScript, h
     }
   };
   return {
+   factions: {
+      calculateFavorToRep: function (_favor: unknown): number {
+        const favor = helper.number("calculateFavorToRep", "favor", _favor);
+        checkFormulasAccess("factions.calculateFavorToRep");
+        return calculateFavorToRep(favor);
+      },
+      calculateRepToFavor: function (_rep: unknown): number {
+        const rep = helper.number("calculateRepToFavor", "rep", _rep);
+        checkFormulasAccess("factions.calculateRepToFavor");
+        return calculateRepToFavor(rep);
+      },
+    },
     skills: {
       calculateSkill: function (_exp: unknown, _mult: unknown = 1): number {
         const exp = helper.number("calculateSkill", "exp", _exp);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3798,6 +3798,26 @@ interface SkillsFormulas {
 }
 
 /**
+ * Factions formulas
+ * @public
+ */
+ interface FactionsFormulas {
+  /**
+   * Calculate the total required amount of faction reputation to reach a target favor.
+   * @param favor - target faction favor.
+   * @returns The calculated faction reputation required.
+   */
+   calculateFavorToRep(favor: number): number;
+  /**
+   * Calculate the resulting faction favor of a total amount of reputation.
+   * (Faction favor is gained whenever you install an Augmentation.)
+   * @param rep - amount of reputation.
+   * @returns The calculated faction favor.
+   */
+   calculateRepToFavor(rep: number): number;
+}
+
+/**
  * Hacking formulas
  * @public
  */
@@ -4039,6 +4059,8 @@ interface GangFormulas {
  * @public
  */
 export interface Formulas {
+  /** Factions formulas */
+  factions: FactionsFormulas;
   /** Skills formulas */
   skills: SkillsFormulas;
   /** Hacking formulas */


### PR DESCRIPTION
The favorToRep and repToFavor formulas (used internally) are shown to the player in the factions pages but were not available in Formulas.exe. This change adds a FactionsFormulas interface with the calculateFavorToRep and calculateRepToFavor as new functions.

![1](https://user-images.githubusercontent.com/61438810/161134515-32a4176d-484a-4a03-9266-5b66a29ca9b3.PNG)
![2](https://user-images.githubusercontent.com/61438810/161134521-dac06e49-7edd-4201-adaa-065d50b2d087.PNG)
![3](https://user-images.githubusercontent.com/61438810/161134522-7be2f6a3-dcb6-4a50-8287-4e004079d2f6.PNG)

