### PR TITLE
New coding contract: Shortest Path in a Grid

### DIFF
--- a/doc/source/basicgameplay/codingcontracts.rst
+++ b/doc/source/basicgameplay/codingcontracts.rst
@@ -196,6 +196,23 @@ The list contains the name of (i.e. the value returned by
 |                                    | |                                                                                        |
 |                                    | | Determine how many unique paths there are from start to finish.                        |
 +------------------------------------+------------------------------------------------------------------------------------------+
+| Shortest Path in a Grid            | | You are given a 2D array of numbers (array of array of numbers) representing           |
+|                                    | | a grid. The 2D array contains 1's and 0's, where 1 represents an obstacle and          |
+|                                    | | 0 represents a free space.                                                             |
+|                                    | |                                                                                        |
+|                                    | | Assume you are initially positioned in top-left corner of that grid and that you       |
+|                                    | | are trying to reach the bottom-right corner. In each step, you may move to the up,     |
+|                                    | | down, left or right. Furthermore, you cannot move onto spaces which have obstacles.    |
+|                                    | |                                                                                        |
+|                                    | | Determine if paths exist from start to destination, and find the shortest one.         |
+|                                    | |                                                                                        |
+|                                    | | Examples:                                                                              |
+|                                    | |  [[0,1,0,0,0],                                                                         |
+|                                    | |   [0,0,0,1,0]] -> "DRRURRD"                                                            |
+|                                    | |  [[0,1],                                                                               |
+|                                    | |   [1,0]]       -> ""                                                                   |
+|                                    | |                                                                                        |
++------------------------------------+------------------------------------------------------------------------------------------+
 | Sanitize Parentheses in Expression | | Given a string with parentheses and letters, remove the minimum number of invalid      |
 |                                    | | parentheses in order to validate the string. If there are multiple minimal ways        |
 |                                    | | to validate the string, provide all of the possible results.                           |

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -864,12 +864,12 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         //prev[y] = new Array(width).fill(undefined) as [undefined];
       }
 
-      function validPosition(y: number, x: number) {
+      function validPosition(y: number, x: number): boolean {
         return y >= 0 && y < height && x >= 0 && x < width && data[y][x] == 0;
       }
 
       // List in-bounds and passable neighbors
-      function* neighbors(y: number, x: number) {
+      function* neighbors(y: number, x: number): Generator<[number, number]> {
         if(validPosition(y - 1, x)) yield [y - 1, x]; // Up
         if(validPosition(y + 1, x)) yield [y + 1, x]; // Down
         if(validPosition(y, x - 1)) yield [y, x - 1]; // Left

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -820,8 +820,8 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         "Answer: ''\n\n",
       ].join(" ");
     },
-    difficulty: 5, // TODO: higher, but probably not much more?
-    numTries: 10, // TODO: probably OK?
+    difficulty: 7,
+    numTries: 10,
     gen: (): number[][] => {
       const height = getRandomInt(6, 12);
       const width = getRandomInt(6, 12);

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -838,9 +838,10 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
           if(y == 0 && x == 0) continue; // Don't block start
           if(y == dstY && x == dstX) continue; // Don't block destination
 
-          // Generate more obstacles the farther a position is from start and destination,
-          // with minimum obstacle chance of 15%
-          const distanceFactor = Math.min(y + x, dstY - y + dstX - x) / minPathLength;
+          // Generate more obstacles the farther a position is from start and destination.
+          // Raw distance factor peaks at 50% at half-way mark. Rescale to 40% max.
+          // Obstacle chance range of [15%, 40%] produces ~78% solvable puzzles
+          const distanceFactor = Math.min(y + x, dstY - y + dstX - x) / minPathLength * 0.8;
           if (Math.random() < Math.max(0.15, distanceFactor))
             grid[y][x] = 1;
         }

--- a/src/utils/Heap.ts
+++ b/src/utils/Heap.ts
@@ -1,0 +1,142 @@
+/** Binary heap. */
+abstract class BinHeap<T> {
+  /**
+   * Heap data array consisting of [weight, payload] pairs, arranged by weight
+   * to satisfy heap condition.
+   *
+   * Encodes the binary tree by storing tree root at index 0 and
+   * left child of element i at `i * 2 + 1` and
+   * right child of element i at `i * 2 + 2`.
+   */
+  protected data: [number, T][];
+
+  constructor() {
+    this.data = [];
+  }
+
+  /** Get number of elements in the heap. */
+  public get size() {
+    return this.data.length;
+  }
+
+  /**
+   * Should element with weight `weightA` be closer to root than element with
+   * weight `weightB`?
+   */
+  protected abstract heapOrderABeforeB(weightA: number, weightB: number): boolean;
+
+  /** Restore heap condition, starting at index i and traveling towards root. */
+  protected heapifyUp(i: number): void {
+    // Swap the new element up towards root until it reaches root position or
+    // settles under under a suitable parent
+    while(i > 0) {
+      const p = Math.floor((i - 1) / 2);
+
+      // Reached heap-ordered state already?
+      if(this.heapOrderABeforeB(this.data[p][0], this.data[i][0]))
+         break;
+
+      // Swap
+      const tmp = this.data[p];
+      this.data[p] = this.data[i];
+      this.data[i] = tmp;
+
+      // And repeat at parent index
+      i = p;
+    }
+  }
+
+  /** Restore heap condition, starting at index i and traveling away from root. */
+  protected heapifyDown(i: number): void {
+    // Swap the shifted element down in the heap until it either reaches the
+    // bottom layer or is in correct order relative to it's children
+    while(i < this.data.length) {
+      const l = i * 2 + 1;
+      const r = i * 2 + 2;
+      let toSwap = i;
+
+      // Find which one of element i and it's children should be closest to root
+      if(l < this.data.length && this.heapOrderABeforeB(this.data[l][0], this.data[toSwap][0]))
+        toSwap = l;
+      if(r < this.data.length && this.heapOrderABeforeB(this.data[r][0], this.data[toSwap][0]))
+        toSwap = r;
+
+      // Already in order?
+      if(i == toSwap)
+        break;
+
+      // Not in order. Swap child that should be closest to root up to 'i' and repeat
+      const tmp = this.data[toSwap];
+      this.data[toSwap] = this.data[i];
+      this.data[i] = tmp;
+
+      i = toSwap;
+    }
+  }
+
+  /** Add a new element to the heap. */
+  public push(value: T, weight: number): void {
+    const i = this.data.length;
+    this.data[i] = [weight, value];
+    this.heapifyUp(i);
+  }
+
+  /** Get the value of the root-most element of the heap, without changing the heap. */
+  public peek(): T | undefined {
+    if(this.data.length == 0)
+      return undefined;
+
+    return this.data[0][1];
+  }
+
+  /** Remove the root-most element of the heap and return the removed element's value. */
+  public pop(): T | undefined {
+    if(this.data.length == 0)
+      return undefined;
+
+    const value = this.data[0][1];
+
+    this.data[0] = this.data[this.data.length - 1];
+    this.data.length = this.data.length - 1;
+
+    this.heapifyDown(0);
+
+    return value;
+  }
+
+  /** Change the weight of an element in the heap. */
+  public changeWeight(predicate: (value: T) => boolean, weight: number): void {
+    // Find first element with matching value, if any
+    const i = this.data.findIndex(([_, v]) => predicate(v));
+    if(i == -1)
+      return;
+
+    // Update that element's weight
+    this.data[i][0] = weight;
+
+    // And re-heapify if needed
+    const p = Math.floor((i - 1) / 2);
+    const l = i * 2 + 1;
+    const r = i * 2 + 2;
+
+    if(!this.heapOrderABeforeB(this.data[p][0], this.data[i][0])) // Needs to shift root-wards?
+      this.heapifyUp(i);
+    else // Try shifting deeper
+      this.heapifyDown(i);
+  }
+}
+
+
+/** Binary max-heap. */
+export class MaxHeap<T> extends BinHeap<T> {
+  heapOrderABeforeB(weightA: number, weightB: number): boolean {
+    return weightA > weightB;
+  }
+}
+
+/** Binary min-heap. */
+export class MinHeap<T> extends BinHeap<T> {
+  heapOrderABeforeB(weightA: number, weightB: number): boolean {
+    return weightA < weightB;
+  }
+}

--- a/src/utils/Heap.ts
+++ b/src/utils/Heap.ts
@@ -15,15 +15,58 @@ abstract class BinHeap<T> {
   }
 
   /** Get number of elements in the heap. */
-  public get size() {
+  public get size(): number {
     return this.data.length;
   }
 
-  /**
-   * Should element with weight `weightA` be closer to root than element with
-   * weight `weightB`?
-   */
-  protected abstract heapOrderABeforeB(weightA: number, weightB: number): boolean;
+  /** Add a new element to the heap. */
+  public push(value: T, weight: number): void {
+    const i = this.data.length;
+    this.data[i] = [weight, value];
+    this.heapifyUp(i);
+  }
+
+  /** Get the value of the root-most element of the heap, without changing the heap. */
+  public peek(): T | undefined {
+    if(this.data.length == 0)
+      return undefined;
+
+    return this.data[0][1];
+  }
+
+  /** Remove the root-most element of the heap and return the removed element's value. */
+  public pop(): T | undefined {
+    if(this.data.length == 0)
+      return undefined;
+
+    const value = this.data[0][1];
+
+    this.data[0] = this.data[this.data.length - 1];
+    this.data.length = this.data.length - 1;
+
+    this.heapifyDown(0);
+
+    return value;
+  }
+
+  /** Change the weight of an element in the heap. */
+  public changeWeight(predicate: (value: T) => boolean, weight: number): void {
+    // Find first element with matching value, if any
+    const i = this.data.findIndex(e => predicate(e[1]));
+    if(i == -1)
+      return;
+
+    // Update that element's weight
+    this.data[i][0] = weight;
+
+    // And re-heapify if needed
+    const p = Math.floor((i - 1) / 2);
+
+    if(!this.heapOrderABeforeB(this.data[p][0], this.data[i][0])) // Needs to shift root-wards?
+      this.heapifyUp(i);
+    else // Try shifting deeper
+      this.heapifyDown(i);
+  }
 
   /** Restore heap condition, starting at index i and traveling towards root. */
   protected heapifyUp(i: number): void {
@@ -74,56 +117,11 @@ abstract class BinHeap<T> {
     }
   }
 
-  /** Add a new element to the heap. */
-  public push(value: T, weight: number): void {
-    const i = this.data.length;
-    this.data[i] = [weight, value];
-    this.heapifyUp(i);
-  }
-
-  /** Get the value of the root-most element of the heap, without changing the heap. */
-  public peek(): T | undefined {
-    if(this.data.length == 0)
-      return undefined;
-
-    return this.data[0][1];
-  }
-
-  /** Remove the root-most element of the heap and return the removed element's value. */
-  public pop(): T | undefined {
-    if(this.data.length == 0)
-      return undefined;
-
-    const value = this.data[0][1];
-
-    this.data[0] = this.data[this.data.length - 1];
-    this.data.length = this.data.length - 1;
-
-    this.heapifyDown(0);
-
-    return value;
-  }
-
-  /** Change the weight of an element in the heap. */
-  public changeWeight(predicate: (value: T) => boolean, weight: number): void {
-    // Find first element with matching value, if any
-    const i = this.data.findIndex(([_, v]) => predicate(v));
-    if(i == -1)
-      return;
-
-    // Update that element's weight
-    this.data[i][0] = weight;
-
-    // And re-heapify if needed
-    const p = Math.floor((i - 1) / 2);
-    const l = i * 2 + 1;
-    const r = i * 2 + 2;
-
-    if(!this.heapOrderABeforeB(this.data[p][0], this.data[i][0])) // Needs to shift root-wards?
-      this.heapifyUp(i);
-    else // Try shifting deeper
-      this.heapifyDown(i);
-  }
+  /**
+   * Should element with weight `weightA` be closer to root than element with
+   * weight `weightB`?
+   */
+  protected abstract heapOrderABeforeB(weightA: number, weightB: number): boolean;
 }
 
 


### PR DESCRIPTION
Add a new pathfinding type coding contract: "Shortest Path in a Grid". Uses similar obstacle'd grid terrain as "Unique Paths in a Grid II", but permits movement in all cardinal directions.

![localhost_8000__noscripts](https://user-images.githubusercontent.com/1919571/161361299-eb11aa93-eb54-4e3e-9511-0c1aea4fd11e.png)

