### PR TITLE
Add an id to script LogWindow instance

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -40,7 +40,7 @@ export function LogBoxManager(): React.ReactElement {
   useEffect(
     () =>
       LogBoxEvents.subscribe((script: RunningScript) => {
-        const id = script.server + "-" + script.filename + script.args.map((x: any): string => `${x}`).join("-");
+        const id = [script.server, script.filename, ...script.args.map((x: any): string => `${x}`)].join("-");
         if (logs.find((l) => l.id === id)) return;
         logs.push({
           id: id,
@@ -177,7 +177,7 @@ function LogWindow(props: IProps): React.ReactElement {
 
   function title(full = false): string {
     const maxLength = 30;
-    const t = `${script.filename} ${script.args.map((x: any): string => `${x}`).join(" ")}`;
+    const t = [ script.filename, ...script.args.map((x: any): string => `${x}`) ].join(" ");
     if (full || t.length <= maxLength) {
       return t;
     }
@@ -241,7 +241,7 @@ function LogWindow(props: IProps): React.ReactElement {
   };
 
   return (
-    <Draggable handle=".drag" onDrag={boundToBody} ref={rootRef}>
+    <Draggable id={props.id} handle=".drag" onDrag={boundToBody} ref={rootRef}>
       <Paper
         style={{
           display: "flex",
@@ -284,7 +284,7 @@ function LogWindow(props: IProps): React.ReactElement {
                 </span>
               }
             >
-              <Box>
+              <Box id={props.id + "-logs"}>
                 {script.logs.map(
                   (line: string, i: number): JSX.Element => (
                     <Typography key={i} className={lineClass(line)}>


### PR DESCRIPTION
mostly solves #3355

Added an id to both the top element of the LogWindow instance and the parent element of the actual log entries, since that's most like to what's targeted.

I also slightly changed how the IDs and titles are concatenated so that they're a little more consistent. e.g. Titles with no args would still have a space at the end, and IDs didn't have a hyphen after the script name. Happy to revert that bit if there's a reason they're like that.