### PR TITLE
Fix workForFaction invalid worktype case

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1104,6 +1104,7 @@ export function NetscriptSingularity(
           return true;
         default:
           workerScript.log("workForFaction", () => `Invalid work type: '${type}`);
+          return false;
       }
       return true;
     },


### PR DESCRIPTION
## Bug fix

If the work type is invalid, the function should return false instead of true