### PR TITLE
Adds SnackbarVariant enum

### DIFF
--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -2,7 +2,7 @@ import { Player } from "./Player";
 import { Router } from "./ui/GameRoot";
 import { removeLeadingSlash } from "./Terminal/DirectoryHelpers";
 import { Terminal } from "./Terminal";
-import { SnackbarEvents } from "./ui/React/Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "./ui/React/Snackbar";
 import { IMap, IReturnStatus } from "./types";
 import { GetServer } from "./Server/AllServers";
 import { ImportPlayerData, SaveData, saveObject } from "./SaveObject";
@@ -111,8 +111,7 @@ function initAppNotifier(): void {
       if (!fn) fn = Terminal.print;
       fn.bind(Terminal)(message);
     },
-    toast: (message: string, type: "info" | "success" | "warning" | "error", duration = 2000) =>
-      SnackbarEvents.emit(message, type, duration),
+    toast: (message: string, type: SnackbarVariant, duration = 2000) => SnackbarEvents.emit(message, type, duration),
   };
 
   // Will be consumud by the electron wrapper.
@@ -127,7 +126,7 @@ function initSaveFunctions(): void {
         saveObject.exportGame();
       } catch (error) {
         console.log(error);
-        SnackbarEvents.emit("Could not export game.", "error", 2000);
+        SnackbarEvents.emit("Could not export game.", SnackbarVariant.ERROR, 2000);
       }
     },
     triggerScriptsExport: (): void => exportScripts("*", Player.getHomeComputer()),
@@ -176,7 +175,7 @@ function initElectronBridge(): void {
       })
       .catch((error: any) => {
         console.log(error);
-        SnackbarEvents.emit("Could not save game.", "error", 2000);
+        SnackbarEvents.emit("Could not save game.", SnackbarVariant.ERROR, 2000);
       });
   });
   bridge.receive("trigger-game-export", () => {
@@ -184,7 +183,7 @@ function initElectronBridge(): void {
       (window as any).appSaveFns.triggerGameExport();
     } catch (error) {
       console.log(error);
-      SnackbarEvents.emit("Could not export game.", "error", 2000);
+      SnackbarEvents.emit("Could not export game.", SnackbarVariant.ERROR, 2000);
     }
   });
   bridge.receive("trigger-scripts-export", () => {
@@ -192,7 +191,7 @@ function initElectronBridge(): void {
       (window as any).appSaveFns.triggerScriptsExport();
     } catch (error) {
       console.log(error);
-      SnackbarEvents.emit("Could not export scripts.", "error", 2000);
+      SnackbarEvents.emit("Could not export scripts.", SnackbarVariant.ERROR, 2000);
     }
   });
 }

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -24,7 +24,7 @@ import { joinFaction } from "../../Faction/FactionHelpers";
 import { use } from "../../ui/Context";
 
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
-import { SnackbarEvents } from "../../ui/React/Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "../../ui/React/Snackbar";
 import { N00dles } from "../../utils/helpers/N00dles";
 import { Exploit } from "../../Exploits/Exploit";
 import { applyAugmentation } from "../../Augmentation/AugmentationHelpers";
@@ -91,7 +91,7 @@ export function SpecialLocation(props: IProps): React.ReactElement {
 
   function renderNoodleBar(): React.ReactElement {
     function EatNoodles(): void {
-      SnackbarEvents.emit("You ate some delicious noodles and feel refreshed", "success", 2000);
+      SnackbarEvents.emit("You ate some delicious noodles and feel refreshed", SnackbarVariant.SUCCESS, 2000);
       N00dles(); // This is the true power of the noodles.
       if (player.sourceFiles.length > 0) player.giveExploit(Exploit.N00dles);
       if (player.sourceFileLvl(5) > 0 || player.bitNodeN === 5) {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -93,7 +93,8 @@ import { NetscriptSingularity } from "./NetscriptFunctions/Singularity";
 import { toNative } from "./NetscriptFunctions/toNative";
 
 import { dialogBoxCreate } from "./ui/React/DialogBox";
-import { SnackbarEvents } from "./ui/React/Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "./ui/React/Snackbar";
+import { checkEnum } from "./utils/helpers/checkEnum";
 
 import { Flags } from "./NetscriptFunctions/Flags";
 import { calculateIntelligenceBonus } from "./PersonObjects/formulas/intelligence";
@@ -2262,13 +2263,13 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       const message = helper.string("alert", "message", _message);
       dialogBoxCreate(message);
     },
-    toast: function (_message: unknown, _variant: unknown = "success", duration: any = 2000): void {
+    toast: function (_message: unknown, _variant: unknown = SnackbarVariant.SUCCESS, duration: any = 2000): void {
       updateDynamicRam("toast", getRamCost(Player, "toast"));
       const message = helper.string("toast", "message", _message);
       const variant = helper.string("toast", "variant", _variant);
-      if (!["success", "info", "warning", "error"].includes(variant))
-        throw new Error(`variant must be one of "success", "info", "warning", or "error"`);
-      SnackbarEvents.emit(message, variant as any, duration);
+      if (!checkEnum(SnackbarVariant, variant))
+        throw new Error(`variant must be one of ${Object.values(SnackbarVariant).join(", ")}`);
+      SnackbarEvents.emit(message, variant, duration);
     },
     prompt: function (_txt: unknown, options?: { type?: string; options?: string[] }): Promise<boolean | string> {
       updateDynamicRam("prompt", getRamCost(Player, "prompt"));

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -62,7 +62,7 @@ import { Money } from "../../ui/React/Money";
 
 import React from "react";
 import { serverMetadata } from "../../Server/data/servers";
-import { SnackbarEvents } from "../../ui/React/Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "../../ui/React/Snackbar";
 import { calculateClassEarnings } from "../formulas/work";
 import { achievements } from "../../Achievements/Achievements";
 import { FactionNames } from "../../Faction/data/FactionNames";
@@ -1734,7 +1734,11 @@ export function regenerateHp(this: IPlayer, amt: number): void {
 
 export function hospitalize(this: IPlayer): number {
   const cost = getHospitalizationCost(this);
-  SnackbarEvents.emit(`You've been Hospitalized for ${numeralWrapper.formatMoney(cost)}`, "warning", 2000);
+  SnackbarEvents.emit(
+    `You've been Hospitalized for ${numeralWrapper.formatMoney(cost)}`,
+    SnackbarVariant.WARNING,
+    2000,
+  );
 
   this.loseMoney(cost, "hospitalization");
   this.hp = this.max_hp;
@@ -2709,7 +2713,7 @@ export function canAccessGrafting(this: IPlayer): boolean {
 export function giveExploit(this: IPlayer, exploit: Exploit): void {
   if (!this.exploits.includes(exploit)) {
     this.exploits.push(exploit);
-    SnackbarEvents.emit("SF -1 acquired!", "success", 2000);
+    SnackbarEvents.emit("SF -1 acquired!", SnackbarVariant.SUCCESS, 2000);
   }
 }
 
@@ -2718,7 +2722,7 @@ export function giveAchievement(this: IPlayer, achievementId: string): void {
   if (!achievement) return;
   if (!this.achievements.map((a) => a.ID).includes(achievementId)) {
     this.achievements.push({ ID: achievementId, unlockedOn: new Date().getTime() });
-    SnackbarEvents.emit(`Unlocked Achievement: "${achievement.Name}"`, "success", 2000);
+    SnackbarEvents.emit(`Unlocked Achievement: "${achievement.Name}"`, SnackbarVariant.SUCCESS, 2000);
   }
 }
 

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -11,7 +11,7 @@ import { SourceFileFlags } from "./SourceFile/SourceFileFlags";
 import { loadStockMarket, StockMarket } from "./StockMarket/StockMarket";
 import { staneksGift, loadStaneksGift } from "./CotMG/Helper";
 
-import { SnackbarEvents } from "./ui/React/Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "./ui/React/Snackbar";
 
 import * as ExportBonus from "./ExportBonus";
 
@@ -114,7 +114,7 @@ class BitburnerSaveObject {
           pushGameSaved(saveData);
 
           if (emitToastEvent) {
-            SnackbarEvents.emit("Game Saved!", "info", 2000);
+            SnackbarEvents.emit("Game Saved!", SnackbarVariant.INFO, 2000);
           }
           return resolve();
         })

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6183,7 +6183,7 @@ export interface NS extends Singularity {
    * @param variant - Type of toast, must be one of success, info, warning, error. Defaults to success.
    * @param duration - Duration of toast in ms. Can also be `null` to create a persistent toast. Defaults to 2000
    */
-  toast(msg: any, variant?: string, duration?: number | null): void;
+  toast(msg: any, variant?: "success" | "info" | "warning" | "error", duration?: number | null): void;
 
   /**
    * Download a file from the internet.

--- a/src/Themes/ui/ThemeBrowser.tsx
+++ b/src/Themes/ui/ThemeBrowser.tsx
@@ -11,7 +11,7 @@ import { StyleEditorButton } from "./StyleEditorButton";
 import { ThemeEntry } from "./ThemeEntry";
 import { ThemeCollaborate } from "./ThemeCollaborate";
 import { Modal } from "../../ui/React/Modal";
-import { SnackbarEvents } from "../../ui/React/Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "../../ui/React/Snackbar";
 
 interface IProps {
   router: IRouter;
@@ -54,7 +54,7 @@ export function ThemeBrowser({ router }: IProps): React.ReactElement {
           UNDO
         </Button>
       </>,
-      "info",
+      SnackbarVariant.INFO,
       30000,
     );
   }

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -50,7 +50,7 @@ import { calculateAchievements } from "./Achievements/Achievements";
 import React from "react";
 import { setupUncaughtPromiseHandler } from "./UncaughtPromiseHandler";
 import { Button, Typography } from "@mui/material";
-import { SnackbarEvents } from "./ui/React/Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "./ui/React/Snackbar";
 
 const Engine: {
   _lastUpdate: number;
@@ -495,7 +495,7 @@ function warnAutosaveDisabled(): void {
       </Button>
     </>
   );
-  SnackbarEvents.emit(warningToast, "warning", 5000);
+  SnackbarEvents.emit(warningToast, SnackbarVariant.WARNING, 5000);
 }
 
 export { Engine };

--- a/src/ui/React/GameOptionsRoot.tsx
+++ b/src/ui/React/GameOptionsRoot.tsx
@@ -27,7 +27,7 @@ import PaletteIcon from "@mui/icons-material/Palette";
 import { FileDiagnosticModal } from "../../Diagnostic/FileDiagnosticModal";
 import { ConfirmationModal } from "./ConfirmationModal";
 
-import { SnackbarEvents } from "./Snackbar";
+import { SnackbarEvents, SnackbarVariant } from "./Snackbar";
 
 import { Settings } from "../../Settings/Settings";
 import { DeleteGameButton } from "./DeleteGameButton";
@@ -123,7 +123,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
       setImportData(data);
       setImportSaveOpen(true);
     } catch (ex: any) {
-      SnackbarEvents.emit(ex.toString(), "error", 5000);
+      SnackbarEvents.emit(ex.toString(), SnackbarVariant.ERROR, 5000);
     }
   }
 
@@ -133,7 +133,7 @@ export function GameOptionsRoot(props: IProps): React.ReactElement {
     try {
       await saveObject.importGame(importData.base64);
     } catch (ex: any) {
-      SnackbarEvents.emit(ex.toString(), "error", 5000);
+      SnackbarEvents.emit(ex.toString(), SnackbarVariant.ERROR, 5000);
     }
 
     setImportSaveOpen(false);

--- a/src/ui/React/Snackbar.tsx
+++ b/src/ui/React/Snackbar.tsx
@@ -10,6 +10,13 @@ interface IProps {
   children: React.ReactNode | React.ReactNode[];
 }
 
+export enum SnackbarVariant {
+  SUCCESS = "success",
+  WARNING = "warning",
+  ERROR = "error",
+  INFO = "info",
+}
+
 const useStyles = makeStyles(() => ({
   snackbar: {
     // Log popup z-index increments, so let's add a padding to be well above them.
@@ -36,9 +43,7 @@ export function SnackbarProvider(props: IProps): React.ReactElement {
   );
 }
 
-export const SnackbarEvents = new EventEmitter<
-  [string | React.ReactNode, "success" | "warning" | "error" | "info", number]
->();
+export const SnackbarEvents = new EventEmitter<[string | React.ReactNode, SnackbarVariant, number]>();
 
 export function Snackbar(): React.ReactElement {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();

--- a/src/utils/helpers/checkEnum.ts
+++ b/src/utils/helpers/checkEnum.ts
@@ -1,0 +1,6 @@
+export function checkEnum<T extends string, TEnumValue extends string>(
+  enumVariable: { [key in T]: TEnumValue },
+  value: string,
+): value is TEnumValue {
+  return Object.values(enumVariable).includes(value);
+}


### PR DESCRIPTION
This PR converts `ns.toast` and friends to use a `SnackbarVariant` enum. 

Ran test script:

```js
/** @param {NS} ns */
export async function main(ns) {
	ns.toast('message', 'success');
	ns.toast('message', 'warning');
	ns.toast('message', 'error');
	ns.toast('message', 'info');
	ns.toast('message', 'foo');
}
```

Result:

![image](https://user-images.githubusercontent.com/15902166/162555188-d5bf7df1-9cff-401c-a437-0ea72d309f31.png)
