### PR TITLE
[Improvement] Small grafting tweaks based around Congruity aug, plus some general grafting fixes

### DIFF
--- a/doc/source/advancedgameplay/grafting.rst
+++ b/doc/source/advancedgameplay/grafting.rst
@@ -5,10 +5,10 @@ Grafting
 Grafting is an experimental process through which you can obtain the benefits of
 Augmentations, without needing to reboot your body.
 
-In order to graft, you must first purchase a blueprint for and craft the Augmentation.
-This can be done at VitaLife in New Tokyo, where you'll find a shady researcher with
-questionable connections. Once you purchase a blueprint, you will start crafting the
-Augmentation, and it will be grafted to your body once complete.
+Grafting can be done at VitaLife in New Tokyo, where you'll find a shady researcher with
+questionable connections. From there, you can spend a sum of money to begin grafting
+Augmentations. This will take some time. When done, the Augmentation will be applied to
+your character without needing to install.
 
 Be warned, some who have tested grafting have reported an unidentified malware. Dubbed
 "Entropy", this virus seems to grow in potency as more Augmentations are grafted,

--- a/src/Augmentation/AugmentationCreator.tsx
+++ b/src/Augmentation/AugmentationCreator.tsx
@@ -1488,7 +1488,7 @@ export const initGeneralAugmentations = (): Augmentation[] => [
   // Grafting-exclusive Augmentation
   new Augmentation({
     name: AugmentationNames.CongruityImplant,
-    repCost: 0,
+    repCost: Infinity,
     moneyCost: 50e12,
     info:
       "Developed by a pioneer in Grafting research, this implant " +

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -276,7 +276,7 @@ export const CONSTANTS: {
   CodingContractBaseCompanyRepGain: 4000,
   CodingContractBaseMoneyGain: 75e6,
 
-  // Augmentation crafting multipliers
+  // Augmentation grafting multipliers
   AugmentationGraftingCostMult: 3,
   AugmentationGraftingTimeBase: 3600000,
 

--- a/src/NetscriptFunctions/Grafting.ts
+++ b/src/NetscriptFunctions/Grafting.ts
@@ -54,7 +54,7 @@ export function NetscriptGrafting(player: IPlayer, workerScript: WorkerScript, h
       if (player.city !== CityName.NewTokyo) {
         throw helper.makeRuntimeErrorMsg(
           "grafting.graftAugmentation",
-          "You must be in New Tokyo to begin crafting an Augmentation.",
+          "You must be in New Tokyo to begin grafting an Augmentation.",
         );
       }
       if (!getAvailableAugs(player).includes(augName)) {
@@ -90,7 +90,7 @@ export function NetscriptGrafting(player: IPlayer, workerScript: WorkerScript, h
         Router.toTerminal();
       }
 
-      workerScript.log("grafting.graftAugmentation", () => `Began crafting Augmentation ${augName}.`);
+      workerScript.log("grafting.graftAugmentation", () => `Began grafting Augmentation ${augName}.`);
       return true;
     },
   };

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -130,9 +130,13 @@ export const GraftingRoot = (): React.ReactElement => {
                   <>
                     Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b>{" "}
                     be returned.
-                    <br />
-                    <br />
-                    Additionally, grafting an Augmentation will increase the potency of the Entropy virus.
+                    {!player.hasAugmentation(AugmentationNames.CongruityImplant) && (
+                      <>
+                        <br />
+                        <br />
+                        Additionally, grafting an Augmentation will increase the potency of the Entropy virus.
+                      </>
+                    )}
                   </>
                 }
               />

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1366,16 +1366,17 @@ export function craftAugmentationWork(this: IPlayer, numCycles: number): boolean
 export function finishGraftAugmentationWork(this: IPlayer, cancelled: boolean): string {
   const augName = this.graftAugmentationName;
   if (cancelled === false) {
-    dialogBoxCreate(
-      `You've finished crafting ${augName}.<br>The augmentation has been grafted to your body, but you feel a bit off.`,
-    );
-
     applyAugmentation(Augmentations[augName]);
 
     if (!this.hasAugmentation(AugmentationNames.CongruityImplant)) {
       this.entropy += 1;
       this.applyEntropy(this.entropy);
     }
+
+    dialogBoxCreate(
+      `You've finished crafting ${augName}.<br>The augmentation has been grafted to your body` +
+        (this.hasAugmentation(AugmentationNames.CongruityImplant) ? "." : ", but you feel a bit off."),
+    );
   } else {
     dialogBoxCreate(`You cancelled the crafting of ${augName}.<br>Your money was not returned to you.`);
   }

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1374,11 +1374,11 @@ export function finishGraftAugmentationWork(this: IPlayer, cancelled: boolean): 
     }
 
     dialogBoxCreate(
-      `You've finished crafting ${augName}.<br>The augmentation has been grafted to your body` +
+      `You've finished grafting ${augName}.<br>The augmentation has been applied to your body` +
         (this.hasAugmentation(AugmentationNames.CongruityImplant) ? "." : ", but you feel a bit off."),
     );
   } else {
-    dialogBoxCreate(`You cancelled the crafting of ${augName}.<br>Your money was not returned to you.`);
+    dialogBoxCreate(`You cancelled the grafting of ${augName}.<br>Your money was not returned to you.`);
   }
 
   // Intelligence gain

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -504,7 +504,7 @@ export function WorkInProgressRoot(): React.ReactElement {
       <Grid container direction="column" justifyContent="center" alignItems="center" style={{ minHeight: "100vh" }}>
         <Grid item>
           <Typography>
-            You are currently working on crafting {player.graftAugmentationName}.
+            You are currently working on grafting {player.graftAugmentationName}.
             <br />
             <br />
             You have been working for {convertTimeMsToTimeElapsedString(player.timeWorked)}
@@ -519,7 +519,7 @@ export function WorkInProgressRoot(): React.ReactElement {
         </Grid>
         <Grid item>
           <Button sx={{ mx: 2 }} onClick={cancel}>
-            Cancel work on crafting Augmentation
+            Cancel work on grafting Augmentation
           </Button>
           <Button onClick={unfocus}>Do something else simultaneously</Button>
         </Grid>


### PR DESCRIPTION
This PR makes some small tweaks to Grafting based on whether or not the player has the Congruity augmentation.

In short, it removes the warning and message about increasing the Entropy level in the Grafting confirmation modal, as well as the popup when Grafting is completed (when the Congruity aug is installed, that is)

Update 11/04/22: Also resolves #3396, replacing all references of `crafting` with `grafting`, and updating the documentation page slightly as well.