### PR TITLE
fix netscript function concurrency wrapper doesnt recurs

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -119,13 +119,13 @@ function startNetscript2Script(player: IPlayer, workerScript: WorkerScript): Pro
   function wrapObject(vars: any, ...tree: string[]): void {
     for (const prop of Object.keys(vars)) {
       switch (typeof vars[prop]) {
-        case 'function': {
-          vars[prop] = wrap([...tree, prop].join('.'), vars[prop]);
+        case "function": {
+          vars[prop] = wrap([...tree, prop].join("."), vars[prop]);
           break;
         }
-        case 'object': {
+        case "object": {
           if (Array.isArray(vars[prop])) continue;
-          wrapObject(vars[prop], ...tree, prop)
+          wrapObject(vars[prop], ...tree, prop);
           break;
         }
       }

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -116,11 +116,22 @@ function startNetscript2Script(player: IPlayer, workerScript: WorkerScript): Pro
     };
   }
 
-  for (const prop of Object.keys(workerScript.env.vars)) {
-    if (typeof workerScript.env.vars[prop] !== "function") continue;
-    workerScript.env.vars[prop] = wrap(prop, workerScript.env.vars[prop]);
+  function wrapObject(vars: any, ...tree: string[]): void {
+    for (const prop of Object.keys(vars)) {
+      switch (typeof vars[prop]) {
+        case 'function': {
+          vars[prop] = wrap([...tree, prop].join('.'), vars[prop]);
+          break;
+        }
+        case 'object': {
+          if (Array.isArray(vars[prop])) continue;
+          wrapObject(vars[prop], ...tree, prop)
+          break;
+        }
+      }
+    }
   }
-  workerScript.env.vars.stanek.charge = wrap("stanek.charge", workerScript.env.vars.stanek.charge);
+  wrapObject(workerScript.env.vars);
 
   // Note: the environment that we pass to the JS script only needs to contain the functions visible
   // to that script, which env.vars does at this point.


### PR DESCRIPTION
currently in NetscriptWorker there is an attempt to wrap all functions with a check for concurrent calls
the way it is implemented though actually only wraps the top level of functions
this fixes it to recurs the object and wraps all functions