### PR TITLE
take into account max thread needed

### DIFF
--- a/dist/bitburner.d.ts
+++ b/dist/bitburner.d.ts
@@ -2825,9 +2825,10 @@ export declare interface NS extends Singularity {
      * Returns the security increase that would occur if a hack with this many threads happened.
      *
      * @param threads - Amount of threads that will be used.
+     * @param hostname - Hostname of the target server. The number of threads is limited to the number needed to hack the servers maximum amount of money.
      * @returns The security increase.
      */
-    hackAnalyzeSecurity(threads: number): number;
+    hackAnalyzeSecurity(threads: number, hostname?: string): number;
 
     /**
      * Get the chance of successfully hacking a server.

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -585,9 +585,24 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       return calculatePercentMoneyHacked(server, Player);
     },
-    hackAnalyzeSecurity: function (_threads: unknown): number {
+    hackAnalyzeSecurity: function (_threads: unknown, hostname?: string): number {
       updateDynamicRam("hackAnalyzeSecurity", getRamCost(Player, "hackAnalyzeSecurity"));
-      const threads = helper.number("hackAnalyzeSecurity", "threads", _threads);
+      let threads = helper.number("hackAnalyzeSecurity", "threads", _threads);
+      if (hostname) {
+        const server = safeGetServer(hostname, "hackAnalyze");
+        if (!(server instanceof Server)) {
+          workerScript.log("hackAnalyzeSecurity", () => "Cannot be executed on this server.");
+          return 0;
+        }
+
+        const percentHacked = calculatePercentMoneyHacked(server, Player);
+
+        if (percentHacked > 0) {
+          // thread count is limited to the maximum number of threads needed
+          threads = Math.ceil(1 / percentHacked);
+        }
+      }
+
       return CONSTANTS.ServerFortifyAmount * threads;
     },
     hackAnalyzeChance: function (_hostname: unknown): number {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4555,9 +4555,10 @@ export interface NS extends Singularity {
    * Returns the security increase that would occur if a hack with this many threads happened.
    *
    * @param threads - Amount of threads that will be used.
+   * @param hostname - Hostname of the target server. The number of threads is limited to the number needed to hack the servers maximum amount of money.
    * @returns The security increase.
    */
-  hackAnalyzeSecurity(threads: number): number;
+  hackAnalyzeSecurity(threads: number, hostname?: string): number;
 
   /**
    * Get the chance of successfully hacking a server.


### PR DESCRIPTION
fixes #3111 

hackAnalyzeSecurity() has an optional second parameter called "hostname". If a hostname is given, the number of threads for the calculation is limited to the maximum number of threads needed to hack the maximum amount of the server.

- perform the steps in #3111 
- check, that the security level gain now shows the same values (0.184 in my test below).

```
Bitburner v1.6.3 (2d74b493)
[home ~/]> run hack-test.js -t 600
Running script with 600 thread(s), pid 1 and args: [].
Threads: 600 Gain: 0.184
Security Level: 2.632 Gain: 0.000
Security Level: 2.816 Gain: 0.184
```
