### PR TITLE
Bugfix/3111 growthAnalyzeSecurity thread limit

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -189,7 +189,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       throw makeRuntimeRejectMsg(
         workerScript,
         `Invalid scriptArgs argument passed into getRunningScript() from ${callingFnName}(). ` +
-        `This is probably a bug. Please report to game developer`,
+          `This is probably a bug. Please report to game developer`,
       );
     }
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -633,7 +633,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
         if (percentHacked > 0) {
           // thread count is limited to the maximum number of threads needed
-          threads = Math.ceil(1 / percentHacked);
+          threads = Math.min(threads, Math.ceil(1 / percentHacked));
         }
       }
 

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1735,11 +1735,7 @@ export function regenerateHp(this: IPlayer, amt: number): void {
 
 export function hospitalize(this: IPlayer): number {
   const cost = getHospitalizationCost(this);
-  SnackbarEvents.emit(
-    `You've been Hospitalized for ${numeralWrapper.formatMoney(cost)}`,
-    ToastVariant.WARNING,
-    2000,
-  );
+  SnackbarEvents.emit(`You've been Hospitalized for ${numeralWrapper.formatMoney(cost)}`, ToastVariant.WARNING, 2000);
 
   this.loseMoney(cost, "hospitalization");
   this.hp = this.max_hp;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4635,9 +4635,11 @@ export interface NS {
    * Returns the security increase that would occur if a grow with this many threads happened.
    *
    * @param threads - Amount of threads that will be used.
+   * @param hostname - Hostname of the target server. The number of threads is limited to the number needed to hack the servers maximum amount of money.
+   * @param cores - Optional. The number of cores of the server that would run grow.
    * @returns The security increase.
    */
-  growthAnalyzeSecurity(threads: number): number;
+  growthAnalyzeSecurity(threads: number, hostname: string, cores?: number): number;
 
   /**
    * Suspends the script for n milliseconds.


### PR DESCRIPTION
fixes #3111 

growthAnalyzeSecurity() has to optional second parameters called "hostname" and "cores". If a hostname is given, the number of threads for the calculation is limited to the maximum number of threads needed to grow the server to the maximum money.

- create a `hack-test.js`:
```javascript
/** @param {NS} ns **/
export async function main(ns) {
    let target = ns.args.length >= 1 ? ns.args[0] : "n00dles"
    let threads = ns.getRunningScript().threads
    let securityLevelGain = ns.growthAnalyzeSecurity(threads, target, ns.getServer("home").cpuCores)
    
    ns.tprintf("Threads: %d, expected gain: %.03f", threads, securityLevelGain)

    let secLevel = ns.getServerSecurityLevel(target);
    ns.tprintf("Security Level: %.03f", secLevel)
    let prevSecLevel = secLevel

    await ns.grow(target);

    secLevel = ns.getServerSecurityLevel(target);
    ns.tprintf("Security Level: %.03f Gain: %.03f", secLevel, secLevel - prevSecLevel)
}
```

- test run it in the terminal:
```
[home ~/]> run grow-test.js n00dles -t 10000
Running script with 10000 thread(s), pid 6 and args: ["n00dles"].
Threads: 10000, expected gain: 0.004
Security Level: 1.002
Security Level: 1.006 Gain: 0.004
[home ~/]> run grow-test.js n00dles -t 10000
Running script with 10000 thread(s), pid 7 and args: ["n00dles"].
Threads: 10000, expected gain: 0.000
Security Level: 1.006
Security Level: 1.006 Gain: 0.000
```

- check, that the expected gain corresponds to the actual gain of security