### PR TITLE
Reject cd to invalid folders

### DIFF
--- a/src/Terminal/DirectoryServerHelpers.ts
+++ b/src/Terminal/DirectoryServerHelpers.ts
@@ -51,3 +51,14 @@ export function getSubdirectories(serv: BaseServer, dir: string): string[] {
 
   return res;
 }
+
+/**
+ * Returns true, if the server's directory itself or one of its subdirectory contains files.
+ */
+export function containsFiles(server: BaseServer, dir: string): boolean {
+  const dirWithTrailingSlash = dir + (dir.slice(-1) === "/" ? "" : "/");
+
+  return [...server.scripts.map((s) => s.filename), ...server.textFiles.map((t) => t.fn)].some((filename) =>
+    filename.startsWith(dirWithTrailingSlash),
+  );
+}

--- a/src/Terminal/commands/cd.ts
+++ b/src/Terminal/commands/cd.ts
@@ -4,6 +4,7 @@ import { IPlayer } from "../../PersonObjects/IPlayer";
 import { BaseServer } from "../../Server/BaseServer";
 
 import { evaluateDirectoryPath, removeTrailingSlash } from "../DirectoryHelpers";
+import { containsFiles } from "../DirectoryServerHelpers";
 
 export function cd(
   terminal: ITerminal,
@@ -31,10 +32,7 @@ export function cd(
       }
 
       const server = player.getCurrentServer();
-      if (
-        !server.scripts.some((script) => script.filename.startsWith(evaledDir + "")) &&
-        !server.textFiles.some((file) => file.fn.startsWith(evaledDir + ""))
-      ) {
+      if (!containsFiles(server, evaledDir)) {
         terminal.error("Invalid path. Failed to change directories");
         return;
       }


### PR DESCRIPTION
fixes #2367

This PR fixes the incorrect behaviour of the cd terminal command described in #2367.

- move a file to /sub1/sub2/
- navigation to folders like "/su" or "/sub/s" is no longer possible

Example:
![image](https://user-images.githubusercontent.com/14816381/163200467-9cae732d-81e0-40a0-9eb0-4c7783a0f350.png)

