### PR TITLE
[Feature] Add `ns.grafting.getGraftableAugmentations` function

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -299,6 +299,7 @@ const ui: IMap<any> = {
 const grafting: IMap<any> = {
   getAugmentationGraftPrice: 3.75,
   getAugmentationGraftTime: 3.75,
+  getGraftableAugmentations: 5,
   graftAugmentation: 7.5,
 };
 

--- a/src/NetscriptFunctions/Grafting.ts
+++ b/src/NetscriptFunctions/Grafting.ts
@@ -4,7 +4,7 @@ import { CityName } from "../Locations/data/CityNames";
 import { getRamCost } from "../Netscript/RamCostGenerator";
 import { WorkerScript } from "../Netscript/WorkerScript";
 import { GraftableAugmentation } from "../PersonObjects/Grafting/GraftableAugmentation";
-import { getAvailableAugs } from "../PersonObjects/Grafting/ui/GraftingRoot";
+import { getGraftingAvailableAugs } from "../PersonObjects/Grafting/GraftingHelpers";
 import { IPlayer } from "../PersonObjects/IPlayer";
 import { Grafting as IGrafting } from "../ScriptEditor/NetscriptDefinitions";
 import { Router } from "../ui/GameRoot";
@@ -28,7 +28,7 @@ export function NetscriptGrafting(player: IPlayer, workerScript: WorkerScript, h
       updateRam("getAugmentationGraftPrice");
       const augName = helper.string("getAugmentationGraftPrice", "augName", _augName);
       checkGraftingAPIAccess("getAugmentationGraftPrice");
-      if (!Augmentations.hasOwnProperty(augName)) {
+      if (!getGraftingAvailableAugs(player).includes(augName) || !Augmentations.hasOwnProperty(augName)) {
         throw helper.makeRuntimeErrorMsg("grafting.getAugmentationGraftPrice", `Invalid aug: ${augName}`);
       }
       const craftableAug = new GraftableAugmentation(Augmentations[augName]);
@@ -39,11 +39,18 @@ export function NetscriptGrafting(player: IPlayer, workerScript: WorkerScript, h
       updateRam("getAugmentationGraftTime");
       const augName = helper.string("getAugmentationGraftTime", "augName", _augName);
       checkGraftingAPIAccess("getAugmentationGraftTime");
-      if (!Augmentations.hasOwnProperty(augName)) {
+      if (!getGraftingAvailableAugs(player).includes(augName) || !Augmentations.hasOwnProperty(augName)) {
         throw helper.makeRuntimeErrorMsg("grafting.getAugmentationGraftTime", `Invalid aug: ${augName}`);
       }
       const craftableAug = new GraftableAugmentation(Augmentations[augName]);
       return craftableAug.time;
+    },
+
+    getGraftableAugmentations: (): string[] => {
+      updateRam("getGraftableAugmentations");
+      checkGraftingAPIAccess("getGraftableAugmentations");
+      const graftableAugs = getGraftingAvailableAugs(player);
+      return graftableAugs;
     },
 
     graftAugmentation: (_augName: string, _focus: unknown = true): boolean => {
@@ -57,7 +64,7 @@ export function NetscriptGrafting(player: IPlayer, workerScript: WorkerScript, h
           "You must be in New Tokyo to begin grafting an Augmentation.",
         );
       }
-      if (!getAvailableAugs(player).includes(augName)) {
+      if (!getGraftingAvailableAugs(player).includes(augName) || !Augmentations.hasOwnProperty(augName)) {
         workerScript.log("grafting.graftAugmentation", () => `Invalid aug: ${augName}`);
         return false;
       }

--- a/src/PersonObjects/Grafting/GraftingHelpers.ts
+++ b/src/PersonObjects/Grafting/GraftingHelpers.ts
@@ -1,0 +1,15 @@
+import { Augmentations } from "../../Augmentation/Augmentations";
+import { AugmentationNames } from "../../Augmentation/data/AugmentationNames";
+import { IPlayer } from "../IPlayer";
+
+export const getGraftingAvailableAugs = (player: IPlayer): string[] => {
+  const augs: string[] = [];
+
+  for (const [augName, aug] of Object.entries(Augmentations)) {
+    if (augName === AugmentationNames.NeuroFluxGovernor || augName === AugmentationNames.TheRedPill || aug.isSpecial)
+      continue;
+    augs.push(augName);
+  }
+
+  return augs.filter((augmentation: string) => !player.hasAugmentation(augmentation));
+};

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -15,21 +15,10 @@ import { ConfirmationModal } from "../../../ui/React/ConfirmationModal";
 import { Money } from "../../../ui/React/Money";
 import { convertTimeMsToTimeElapsedString, formatNumber } from "../../../utils/StringHelperFunctions";
 import { IPlayer } from "../../IPlayer";
+import { getGraftingAvailableAugs } from "../GraftingHelpers";
 import { GraftableAugmentation } from "../GraftableAugmentation";
 
 const GraftableAugmentations: IMap<GraftableAugmentation> = {};
-
-export const getAvailableAugs = (player: IPlayer): string[] => {
-  const augs: string[] = [];
-
-  for (const [augName, aug] of Object.entries(Augmentations)) {
-    if (augName === AugmentationNames.NeuroFluxGovernor || augName === AugmentationNames.TheRedPill || aug.isSpecial)
-      continue;
-    augs.push(augName);
-  }
-
-  return augs.filter((augmentation: string) => !player.hasAugmentation(augmentation));
-};
 
 const canGraft = (player: IPlayer, aug: GraftableAugmentation): boolean => {
   if (player.money < aug.cost) {
@@ -71,7 +60,7 @@ export const GraftingRoot = (): React.ReactElement => {
     GraftableAugmentations[name] = graftableAug;
   }
 
-  const [selectedAug, setSelectedAug] = useState(getAvailableAugs(player)[0]);
+  const [selectedAug, setSelectedAug] = useState(getGraftingAvailableAugs(player)[0]);
   const [graftOpen, setGraftOpen] = useState(false);
 
   return (
@@ -92,10 +81,10 @@ export const GraftingRoot = (): React.ReactElement => {
 
       <Box sx={{ my: 3 }}>
         <Typography variant="h5">Graft Augmentations</Typography>
-        {getAvailableAugs(player).length > 0 ? (
+        {getGraftingAvailableAugs(player).length > 0 ? (
           <Paper sx={{ my: 1, width: "fit-content", display: "grid", gridTemplateColumns: "1fr 3fr" }}>
             <List sx={{ height: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
-              {getAvailableAugs(player).map((k, i) => (
+              {getGraftingAvailableAugs(player).map((k, i) => (
                 <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
                   <Typography>{k}</Typography>
                 </ListItemButton>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3785,6 +3785,18 @@ export interface Grafting {
   getAugmentationGraftTime(augName: string): number;
 
   /**
+   * Retrieves a list of Augmentations that can be grafted.
+   * @remarks
+   * RAM cost: 5 GB
+   * 
+   * Note that this function returns a list of currently graftable Augmentations,
+   * based off of the Augmentations that you already own.
+   * 
+   * @returns An array of graftable Augmentations.
+   */
+  getGraftableAugmentations(): string[];
+
+  /**
    * Begins grafting the named aug. You must be in New Tokyo to use this.
    * @remarks
    * RAM cost: 7.5 GB


### PR DESCRIPTION
Adds a function to get a list of currently graftable Augmentations.

```ts
  /**
   * Retrieves a list of Augmentations that can be grafted.
   * @remarks
   * RAM cost: 5 GB
   * 
   * Note that this function returns a list of currently graftable Augmentations,
   * based off of the Augmentations that you already own.
   * 
   * @returns An array of graftable Augmentations.
   */
  getGraftableAugmentations(): string[];
```

Fixes #3427 

Also, grafting-related functions will properly error when provided a non-graftable Augmentation now.