### PR TITLE
Allowed ns.singularity.connect to connect to backdoored servers directly

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -580,6 +580,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
           throw _ctx.helper.makeRuntimeErrorMsg(`Invalid hostname: '${hostname}'`);
         }
 
+        //Home case
         if (hostname === "home") {
           player.getCurrentServer().isConnectedTo = false;
           player.currentServer = player.getHomeComputer().hostname;
@@ -588,6 +589,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
           return true;
         }
 
+        //Adjacent server case
         const server = player.getCurrentServer();
         for (let i = 0; i < server.serversOnNetwork.length; i++) {
           const other = getServerOnNetwork(server, i);
@@ -601,6 +603,17 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
           }
         }
 
+        //Backdoor case
+        const other = GetServer(hostname);
+        if (other !== null && other instanceof Server && other.backdoorInstalled) {
+          player.getCurrentServer().isConnectedTo = false;
+          player.currentServer = target.hostname;
+          player.getCurrentServer().isConnectedTo = true;
+          Terminal.setcwd("/");
+          return true;
+        }
+
+        //Failure case
         return false;
       },
     manualHack: (_ctx: NetscriptContext) =>


### PR DESCRIPTION
Added some small comments for readability and added a new case to
ns.singularity.connect that allows connecting to backdoored servers
directly regardless of if the current server is adjacent to them.

Tested by running [singConnect.js](https://pastebin.com/kzvWSaPG) with several hostnames as parameters under several different circumstances. As expected: "home" returned true regardless of current location, while "n00dles", "zer0", and "iron-gym" return true iff the server is either backdoored or adjacent to the current server.

Resolves #3430