### PR TITLE
Hide broken Stanek info graphics

### DIFF
--- a/src/CotMG/ui/StaneksGiftRoot.tsx
+++ b/src/CotMG/ui/StaneksGiftRoot.tsx
@@ -7,9 +7,9 @@ import { IStaneksGift } from "../IStaneksGift";
 import { Info } from "@mui/icons-material";
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import Typography from "@mui/material/Typography";
-import { ActiveFragment } from "../ActiveFragment";
-import { Fragments } from "../Fragment";
-import { DummyGrid } from "./DummyGrid";
+// import { ActiveFragment } from "../ActiveFragment";
+// import { Fragments } from "../Fragment";
+// import { DummyGrid } from "./DummyGrid";
 
 type IProps = {
   staneksGift: IStaneksGift;
@@ -67,6 +67,7 @@ export function StaneksGiftRoot({ staneksGift }: IProps): React.ReactElement {
                   charged.
                 </Typography>
 
+                {/*
                 <DummyGrid
                   width={4}
                   height={4}
@@ -160,6 +161,7 @@ export function StaneksGiftRoot({ staneksGift }: IProps): React.ReactElement {
                 <Typography sx={{ fontStyle: "italic" }}>
                   This booster provides bonus to all fragment it touches.
                 </Typography>
+                */}
 
                 <br />
                 <Typography>


### PR DESCRIPTION
Because the ridiculously oversize Stanek info graphics aren't
particularly informative relative to the confusion they're likely
to cause, I believe it pertinent to have commented them out 
temporarily so as not to confuse players.

Intended to reduce the impact of #3417, but does not actually
solve the issue.
