### PR TITLE
[Fix] Theme browser assets not loading

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -167,6 +167,7 @@ module.exports = (env, argv) => {
           options: {
             name: "[contenthash].[ext]",
             outputPath: "images",
+            publicPath: `${outputDirectory}/images`,
           },
         },
       ],


### PR DESCRIPTION
Issue found in Discord:
![image](https://user-images.githubusercontent.com/60761231/163308715-3156a5eb-2194-4e02-b62a-5eda67a49ff1.png)

Due to files being moved around a bit, theme browser assets could no longer be properly loaded in the electron app. By adding a `publicPath` attribute, this is resolved.