### PR TITLE
fix #3395 donating to special factions possible via singularity

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -49,6 +49,7 @@ import { FactionInfos } from "../Faction/FactionInfo";
 import { InternalAPI, NetscriptContext } from "src/Netscript/APIWrapper";
 import { BlackOperationNames } from "../Bladeburner/data/BlackOperationNames";
 import { enterBitNode } from "../RedPill";
+import { FactionNames } from "../Faction/data/FactionNames";
 
 export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript): InternalAPI<ISingularity> {
   const getAugmentation = function (_ctx: NetscriptContext, name: string): Augmentation {
@@ -1165,6 +1166,13 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
           workerScript.log(
             "donateToFaction",
             () => `You can't donate to '${facName}' because youre managing a gang for it`,
+          );
+          return false;
+        }
+        if (faction.name === FactionNames.ChurchOfTheMachineGod || faction.name === FactionNames.Bladeburners) {
+          workerScript.log(
+            "donateToFaction",
+            () => `You can't donate to '${facName}' because they do not accept donations`,
           );
           return false;
         }


### PR DESCRIPTION
fixes #3395 
tested via
```js
/** @param {NS} ns **/
export async function main(ns) {
    ns.singularity.donateToFaction('ECorp', 1e15); // works fine
    ns.singularity.donateToFaction('The Dark Army', 1e15);  // fails because running their gang
    ns.singularity.donateToFaction('Church of the Machine God', 1e15); // fails because is the church
    ns.singularity.donateToFaction('Bladeburners', 1e15); // fails because is bladeburners
}
```