### PR TITLE
API: FIX #2993 sleeve.travel with invalid city names

### DIFF
--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -16,6 +16,7 @@ import {
   SleeveSkills,
   SleeveTask,
 } from "../ScriptEditor/NetscriptDefinitions";
+import { checkEnum } from "../utils/helpers/checkEnum";
 
 export function NetscriptSleeve(player: IPlayer, workerScript: WorkerScript, helper: INetscriptHelper): ISleeve {
   const checkSleeveAPIAccess = function (func: string): void {
@@ -99,16 +100,10 @@ export function NetscriptSleeve(player: IPlayer, workerScript: WorkerScript, hel
       const cityName = helper.string("travel", "cityName", _cityName);
       checkSleeveAPIAccess("travel");
       checkSleeveNumber("travel", sleeveNumber);
-      switch (cityName) {
-        case CityName.Aevum:
-        case CityName.Chongqing:
-        case CityName.Sector12:
-        case CityName.NewTokyo:
-        case CityName.Ishima:
-        case CityName.Volhaven:
-          return player.sleeves[sleeveNumber].travel(player, cityName as CityName);
-        default:
-          throw helper.makeRuntimeErrorMsg("sleeve.setToCompanyWork", `Invalid city name: '${cityName}'.`);
+      if (checkEnum(CityName, cityName)) {
+        return player.sleeves[sleeveNumber].travel(player, cityName as CityName);
+      } else {
+        throw helper.makeRuntimeErrorMsg("sleeve.setToCompanyWork", `Invalid city name: '${cityName}'.`);
       }
     },
     setToCompanyWork: function (_sleeveNumber: unknown, acompanyName: unknown): boolean {

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -99,7 +99,17 @@ export function NetscriptSleeve(player: IPlayer, workerScript: WorkerScript, hel
       const cityName = helper.string("travel", "cityName", _cityName);
       checkSleeveAPIAccess("travel");
       checkSleeveNumber("travel", sleeveNumber);
-      return player.sleeves[sleeveNumber].travel(player, cityName as CityName);
+      switch (cityName) {
+        case CityName.Aevum:
+        case CityName.Chongqing:
+        case CityName.Sector12:
+        case CityName.NewTokyo:
+        case CityName.Ishima:
+        case CityName.Volhaven:
+          return player.sleeves[sleeveNumber].travel(player, cityName as CityName);
+        default:
+          throw helper.makeRuntimeErrorMsg("sleeve.setToCompanyWork", `Invalid city name: '${cityName}'.`);
+      }
     },
     setToCompanyWork: function (_sleeveNumber: unknown, acompanyName: unknown): boolean {
       updateRam("setToCompanyWork");


### PR DESCRIPTION
fixes #2993 

tested via
```js
/** @param {NS} ns */
export async function main(ns) {
    ns.sleeve.travel(0, 'Aevum');
    ns.sleeve.travel(0, 'sector-12');
    ns.sleeve.travel(0, 'aevum');
    ns.sleeve.travel(0, 'Sector-12');
}
```