### PR TITLE
STANEK: FIX #3277 Can no longer overlap rotated fragments

### DIFF
--- a/src/CotMG/ActiveFragment.ts
+++ b/src/CotMG/ActiveFragment.ts
@@ -40,8 +40,9 @@ export class ActiveFragment {
     // These 2 variables converts 'this' local coordinates to world to other local.
     const dx: number = other.x - this.x;
     const dy: number = other.y - this.y;
-    for (let j = 0; j < thisFragment.shape.length; j++) {
-      for (let i = 0; i < thisFragment.shape[j].length; i++) {
+    const fragSize = Math.max(thisFragment.shape.length, thisFragment.shape[0].length);
+    for (let j = 0; j < fragSize; j++) {
+      for (let i = 0; i < fragSize; i++) {
         if (thisFragment.fullAt(i, j, this.rotation) && otherFragment.fullAt(i - dx, j - dy, other.rotation))
           return true;
       }


### PR DESCRIPTION
Relaxed some overzealous short-circuiting to ensure fragments
on the Stanek's Gift board properly check for collisions.

Resolves #3277

The following recording was made while clicking on every invalid location: (There is no visual indication when I click in an invalid position, unfortunately)
![Recording 2022-04-14 at 11 11 16](https://user-images.githubusercontent.com/55594961/163431658-30dc450a-9cb7-43a3-ab07-7ba10b23e6c4.gif)
