### PR TITLE
CODINGCONTRACT: Typo & clarity fixes to description of Encoded Binary to Integer contract

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -1281,14 +1281,15 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
     numTries: 10,
     desc: (n: string): string => {
       return [
-        "You are given the following encoded binary String: \n",
+        "You are given the following encoded binary string: \n",
         `'${n}' \n`,
-        "Treat it as a Hammingcode with 1 'possible' error on an random Index.\n",
-        "Find the 'possible' wrong bit, fix it and extract the decimal value, which is hidden inside the string.\n\n",
-        "Note: The length of the binary string is dynamic, but it's encoding/decoding is following Hammings 'rule'\n",
-        "Note 2: Index 0 is an 'overall' parity bit. Watch the Hammingcode-video from 3Blue1Brown for more information\n",
-        "Note 3: There's a ~55% chance for an altered Bit. So... MAYBE there is an altered Bit 😉\n",
-        "Extranote for automation: return the decimal value as a string",
+        "The string is a Hamming code with 1 'possible' error on a random index.\n",
+        "If there is an error, find the bit that is an error and fix it.\n",
+        "Extract the encoded decimal value and return a string with that value.\n\n",
+        "NOTE: The length of the binary string is dynamic.\n",
+        "NOTE 2: Index 0 is an 'overall' parity bit. Watch the Hamming code video from 3Blue1Brown for more information.\n",
+        "NOTE 3: There's approximately a 55% chance for an altered bit. So... MAYBE there is an altered bit 😉\n",
+        "NOTE 4: Return the decimal value as a string.",
       ].join(" ");
     },
     gen: (): string => {


### PR DESCRIPTION
Various capitalization and punctuation fixes
Changed "Note" to "NOTE" to match other coding contracts. 
Removed "encoded/decoded following hamming's rule" because I couldn't find references to hamming's rule (there are various things called Hamming's Rule, but they didn't seem relevant here). I believe that clause was just emphasizing that the binary string encoded as a hamming code, which we already know?
Rewrote the "return" text to include that it should be a string. 
*NOTE 4 could be removed, or kept for redundancy's sake
*"So MAYBE there is an altered bit" is also redundant, since note 3 already says a 55% chance, which means "maybe." Left, but could be removed.
