### PR TITLE
UI FIX #3485 - Allow bulk purchasing when smart supply is enabled

### DIFF
--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -162,11 +162,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
           <Tooltip
             title={tutorial ? <Typography>Purchase your required materials to get production started!</Typography> : ""}
           >
-            <Button
-              color={tutorial ? "error" : "primary"}
-              onClick={() => setPurchaseMaterialOpen(true)}
-              disabled={props.warehouse.smartSupplyEnabled && Object.keys(division.reqMats).includes(props.mat.name)}
-            >
+            <Button color={tutorial ? "error" : "primary"} onClick={() => setPurchaseMaterialOpen(true)}>
               {purchaseButtonText}
             </Button>
           </Tooltip>
@@ -174,6 +170,9 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
             mat={mat}
             warehouse={warehouse}
             open={purchaseMaterialOpen}
+            disablePurchaseLimit={
+              props.warehouse.smartSupplyEnabled && Object.keys(division.reqMats).includes(props.mat.name)
+            }
             onClose={() => setPurchaseMaterialOpen(false)}
           />
 

--- a/src/Corporation/ui/modals/PurchaseMaterialModal.tsx
+++ b/src/Corporation/ui/modals/PurchaseMaterialModal.tsx
@@ -106,6 +106,7 @@ interface IProps {
   onClose: () => void;
   mat: Material;
   warehouse: Warehouse;
+  disablePurchaseLimit: boolean;
 }
 
 // Create a popup that lets the player purchase a Material
@@ -143,6 +144,7 @@ export function PurchaseMaterialModal(props: IProps): React.ReactElement {
         <Typography>
           Enter the amount of {props.mat.name} you would like to purchase per second. This material's cost changes
           constantly.
+          {props.disablePurchaseLimit ? "Note: Purchase amount is disabled as smart supply is enabled" : ""}
         </Typography>
         <TextField
           value={buyAmt}
@@ -150,10 +152,15 @@ export function PurchaseMaterialModal(props: IProps): React.ReactElement {
           autoFocus={true}
           placeholder="Purchase amount"
           type="number"
+          disabled={props.disablePurchaseLimit}
           onKeyDown={onKeyDown}
         />
-        <Button onClick={purchaseMaterial}>Confirm</Button>
-        <Button onClick={clearPurchase}>Clear Purchase</Button>
+        <Button disabled={props.disablePurchaseLimit} onClick={purchaseMaterial}>
+          Confirm
+        </Button>
+        <Button disabled={props.disablePurchaseLimit} onClick={clearPurchase}>
+          Clear Purchase
+        </Button>
         {division.hasResearch("Bulk Purchasing") && (
           <BulkPurchaseSection onClose={props.onClose} mat={props.mat} warehouse={props.warehouse} />
         )}


### PR DESCRIPTION
closes #3485
* moved the disabled button over to the buy material modal to allow bulk purchasing while smart supply is on

![Apr-17-2022 10-51-45](https://user-images.githubusercontent.com/5182053/163698409-cbb2c4c8-737e-4424-bea4-f93c5646976e.gif)

