### PR TITLE
UI: FIX #3341 Enable touch-clicks in react-draggable

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -265,10 +265,10 @@ function LogWindow(props: IProps): React.ReactElement {
               </Typography>
 
               <Box position="absolute" right={0}>
-                {!workerScripts.has(script.pid) && <Button onClick={run}>Run</Button>}
-                {workerScripts.has(script.pid) && <Button onClick={kill}>Kill</Button>}
-                <Button onClick={minimize}>{minimized ? "\u{1F5D6}" : "\u{1F5D5}"}</Button>
-                <Button onClick={props.onClose}>Close</Button>
+                {!workerScripts.has(script.pid) && <Button onClick={run} onTouchEnd={run}>Run</Button>}
+                {workerScripts.has(script.pid) && <Button onClick={kill} onTouchEnd={kill}>Kill</Button>}
+                <Button onClick={minimize} onTouchEnd={minimize}>{minimized ? "\u{1F5D6}" : "\u{1F5D5}"}</Button>
+                <Button onClick={props.onClose} onTouchEnd={props.onClose}>Close</Button>
               </Box>
             </Box>
           </Paper>

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -265,10 +265,22 @@ function LogWindow(props: IProps): React.ReactElement {
               </Typography>
 
               <Box position="absolute" right={0}>
-                {!workerScripts.has(script.pid) && <Button onClick={run} onTouchEnd={run}>Run</Button>}
-                {workerScripts.has(script.pid) && <Button onClick={kill} onTouchEnd={kill}>Kill</Button>}
-                <Button onClick={minimize} onTouchEnd={minimize}>{minimized ? "\u{1F5D6}" : "\u{1F5D5}"}</Button>
-                <Button onClick={props.onClose} onTouchEnd={props.onClose}>Close</Button>
+                {!workerScripts.has(script.pid) && (
+                  <Button onClick={run} onTouchEnd={run}>
+                    Run
+                  </Button>
+                )}
+                {workerScripts.has(script.pid) && (
+                  <Button onClick={kill} onTouchEnd={kill}>
+                    Kill
+                  </Button>
+                )}
+                <Button onClick={minimize} onTouchEnd={minimize}>
+                  {minimized ? "\u{1F5D6}" : "\u{1F5D5}"}
+                </Button>
+                <Button onClick={props.onClose} onTouchEnd={props.onClose}>
+                  Close
+                </Button>
               </Box>
             </Box>
           </Paper>

--- a/src/ui/React/Overview.tsx
+++ b/src/ui/React/Overview.tsx
@@ -130,7 +130,7 @@ export function Overview({ children, mode }: IProps): React.ReactElement {
               size="small"
               className={classes.visibilityToggle}
             >
-              {<CurrentIcon className={classes.icon} color="secondary" onClick={() => setOpen((old) => !old)} />}
+              {<CurrentIcon className={classes.icon} color="secondary" onClick={() => setOpen((old) => !old)} onTouchEnd={() => setOpen((old) => !old)} />}
             </Button>
           </Box>
         </Box>

--- a/src/ui/React/Overview.tsx
+++ b/src/ui/React/Overview.tsx
@@ -130,7 +130,14 @@ export function Overview({ children, mode }: IProps): React.ReactElement {
               size="small"
               className={classes.visibilityToggle}
             >
-              {<CurrentIcon className={classes.icon} color="secondary" onClick={() => setOpen((old) => !old)} onTouchEnd={() => setOpen((old) => !old)} />}
+              {
+                <CurrentIcon
+                  className={classes.icon}
+                  color="secondary"
+                  onClick={() => setOpen((old) => !old)}
+                  onTouchEnd={() => setOpen((old) => !old)}
+                />
+              }
             </Button>
           </Box>
         </Box>


### PR DESCRIPTION
Add onTouchEnd events for click functions inside react-draggable. Necessary because react-draggable prevents default click behavior of touch controls on the drag handle.

Closes #3341 

First attempted fix with just stopPropagation, but that doesn't work due to react-draggable using a non-react event to prevent default on touches. [See here](https://github.com/react-grid-layout/react-draggable/issues/550#issuecomment-947166613)