### PR TITLE
Singularity: Fix #3489 Disable checkTixApiAccess for purchase4SMarketData

### DIFF
--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -358,7 +358,6 @@ export function NetscriptStockMarket(player: IPlayer, workerScript: WorkerScript
     },
     purchase4SMarketData: function (): boolean {
       updateRam("purchase4SMarketData");
-      checkTixApiAccess("purchase4SMarketData");
 
       if (player.has4SData) {
         workerScript.log("stock.purchase4SMarketData", () => "Already purchased 4S Market Data.");


### PR DESCRIPTION
Closes #3489 
This restriction doesn't apply on UI. It doesn't make sense to apply it to singularity api.