### PR TITLE
UI: FIX #3457 autocomplete suggestions no longer require hovering terminal input

### DIFF
--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -4,7 +4,7 @@ import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
 import TextField from "@mui/material/TextField";
-import Tooltip from "@mui/material/Tooltip";
+import Popper from "@mui/material/Popper";
 
 import { KEY } from "../../utils/helpers/keyCodes";
 import { ITerminal } from "../ITerminal";
@@ -376,46 +376,38 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
 
   return (
     <>
-      <Tooltip
-        title={
-          possibilities.length > 0 ? (
-            <>
-              <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
-                Possible autocomplete candidate:
-              </Typography>
-              <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
-                {possibilities.join(" ")}
-              </Typography>
-            </>
-          ) : (
-            ""
-          )
-        }
-      >
-        <TextField
-          fullWidth
-          color={terminal.action === null ? "primary" : "secondary"}
-          autoFocus
-          disabled={terminal.action !== null}
-          autoComplete="off"
-          value={value}
-          classes={{ root: classes.textfield }}
-          onChange={handleValueChange}
-          inputRef={terminalInput}
-          InputProps={{
-            // for players to hook in
-            id: "terminal-input",
-            className: classes.input,
-            startAdornment: (
-              <Typography color={terminal.action === null ? "primary" : "secondary"} flexShrink={0}>
-                [{player.getCurrentServer().hostname}&nbsp;~{terminal.cwd()}]&gt;&nbsp;
-              </Typography>
-            ),
-            spellCheck: false,
-            onKeyDown: onKeyDown,
-          }}
-        ></TextField>
-      </Tooltip>
+      <TextField
+        fullWidth
+        color={terminal.action === null ? "primary" : "secondary"}
+        autoFocus
+        disabled={terminal.action !== null}
+        autoComplete="off"
+        value={value}
+        classes={{ root: classes.textfield }}
+        onChange={handleValueChange}
+        inputRef={terminalInput}
+        InputProps={{
+          // for players to hook in
+          id: "terminal-input",
+          className: classes.input,
+          startAdornment: (
+            <Typography color={terminal.action === null ? "primary" : "secondary"} flexShrink={0}>
+              [{player.getCurrentServer().hostname}&nbsp;~{terminal.cwd()}]&gt;&nbsp;
+            </Typography>
+          ),
+          spellCheck: false,
+          onBlur: ()=>setPossibilities([]),
+          onKeyDown: onKeyDown,
+        }}
+      ></TextField>
+      <Popper open={possibilities.length > 0} anchorEl={terminalInput.current} placement={"top-end"}>
+        <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
+          Possible autocomplete candidate:
+        </Typography>
+        <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
+          {possibilities.join(" ")}
+        </Typography>
+      </Popper>
     </>
   );
 }

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -3,8 +3,9 @@ import Typography from "@mui/material/Typography";
 import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
-import TextField from "@mui/material/TextField";
+import Paper from "@mui/material/Paper";
 import Popper from "@mui/material/Popper";
+import TextField from "@mui/material/TextField";
 
 import { KEY } from "../../utils/helpers/keyCodes";
 import { ITerminal } from "../ITerminal";
@@ -396,17 +397,19 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
             </Typography>
           ),
           spellCheck: false,
-          onBlur: ()=>setPossibilities([]),
+          onBlur: () => setPossibilities([]),
           onKeyDown: onKeyDown,
         }}
       ></TextField>
       <Popper open={possibilities.length > 0} anchorEl={terminalInput.current} placement={"top-end"}>
-        <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
-          Possible autocomplete candidate:
-        </Typography>
-        <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
-          {possibilities.join(" ")}
-        </Typography>
+        <Paper sx={{ m: 1, p: 2 }}>
+          <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
+            Possible autocomplete candidates:
+          </Typography>
+          <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
+            {possibilities.join(" ")}
+          </Typography>
+        </Paper>
       </Popper>
     </>
   );


### PR DESCRIPTION
# Documentation
Closes #3457 
Changed autocomplete suggestions from a tooltip (requires hovering) to a popper.
Clicking somewhere other than the terminal input will still remove the autocomplete popper (onBlur event on input field).

# Bug fix
Issue #3457 shows previous functionality for comparison.

https://user-images.githubusercontent.com/84951833/163805512-56fa12cc-e274-4ae7-b262-a896f9c8760f.mp4
