### PR TITLE
FREEZE until after development restarts

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,20 +12,21 @@ on:
       changelog:
         description: "Changelog (url that points to RAW markdown)"
         default: ""
+        required: false
       buildApp:
         description: "Include Application Build"
         type: boolean
-        default: "true"
+        default: true
         required: true
       buildDoc:
         description: "Include Documentation Build"
         type: boolean
-        default: "true"
+        default: true
         required: true
       prepareRelease:
         description: "Prepare Draft Release"
         type: boolean
-        default: "true"
+        default: true
         required: true
 
 jobs:

--- a/.github/workflows/fetch-changes.yml
+++ b/.github/workflows/fetch-changes.yml
@@ -7,6 +7,7 @@ on:
         required: true
       toCommit:
         description: "To Commit SHA (full-length, if omitted will use latest)"
+        required: false
 
 jobs:
   fetchChangelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+    branches: [dev]
+jobs:
+  release:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Version name
+        id: version
+        run: |
+          echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
+      - name: Use Node.js 16.13.1
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.13.1
+          cache: "npm"
+      - name: Install NPM dependencies for version updater
+        run: npm install
+      - name: Build Wrb App
+        run: npm run build
+      - name: Deploy web app
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: dist # The folder the action should deploy.
+      - name: Build Electron App
+        run: npm run electron
+      - name: Upload builds
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.version.outputs.VERSION }}
+          path: |
+            dist/
+            builds/
+      ## for when we have perms to add permissions to handle steam deploy also
+      # - uses: game-ci/steam-deploy@v1
+      #   with:
+      #     username: ${{ secrets.STEAM_USERNAME }}
+      #     password: ${{ secrets.STEAM_PASSWORD }}
+      #     configVdf: ${{ secrets.STEAM_CONFIG_VDF}}
+      #     ssfnFileName: ${{ secrets.STEAM_SSFN_FILE_NAME }}
+      #     ssfnFileContents: ${{ secrets.STEAM_SSFN_FILE_CONTENTS }}
+      #     appId: 1234560
+      #     buildDescription: v1.2.3
+      #     rootPath: build
+      #     depot1Path: StandaloneWindows64
+      #     depot2Path: StandaloneLinux64
+      #     releaseBranch: prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Build Wrb App
         run: npm run build
       - name: Deploy web app
+        if: contains(github.ref, 'tags') ## only deploy web app for tags
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
@@ -50,7 +51,7 @@ jobs:
       #     ssfnFileName: ${{ secrets.STEAM_SSFN_FILE_NAME }}
       #     ssfnFileContents: ${{ secrets.STEAM_SSFN_FILE_CONTENTS }}
       #     appId: 1234560
-      #     buildDescription: v1.2.3
+      #     buildDescription: ${{ steps.version.outputs.VERSION }}
       #     rootPath: build
       #     depot1Path: StandaloneWindows64
       #     depot2Path: StandaloneLinux64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "*"
-    branches: [dev]
+    branches: [dev phyzical/*]
 jobs:
   release:
     name: Bump Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,18 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*"
-    branches: [dev phyzical/*]
+  release:
+    types:
+      - published
+  workflow_run:
+    workflows: ["CI"]
+    branches: [dev]
+    types:
+      - completed
 jobs:
   release:
-    name: Bump Version
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} || ${{ github.event.workflow_run.conclusion == false }}
+    name: Build, release and push artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -18,6 +23,7 @@ jobs:
         id: version
         run: |
           echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
+          echo "::set-output name=SHA_SHORT::$(git rev-parse --short HEAD)"
       - name: Use Node.js 16.13.1
         uses: actions/setup-node@v2
         with:
@@ -25,24 +31,107 @@ jobs:
           cache: "npm"
       - name: Install NPM dependencies for version updater
         run: npm install
-      - name: Build Wrb App
+      - name: Build Web App
         run: npm run build
+      - name: install wine
+        run: . tools/install-wine.sh
+      - name: Build Win Electron App
+        run: . tools/package-electron.sh win
+      - name: Build Mac Electron App
+        run: . tools/package-electron.sh mac
+      - name: Build Linux Electron App
+        run: . tools/package-electron.sh linux
+      - name: Zip up files
+        run: |
+          zip -r dist dist
+          cd .build
+          zip -r win bitburner-win32-x64/*
+          zip -r linux bitburner-linux-x64/*
+          zip -r mac bitburner-darwin-x64/*
+          cd ..
+      - name: Upload Web build artifact
+        if: contains(github.ref, 'dev')
+        uses: actions/upload-artifact@v3
+        with:
+          name: web-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}
+          path: dist.zip
+          retention-days: 10
+      - name: Upload Win build artifact
+        if: contains(github.ref, 'dev')
+        uses: actions/upload-artifact@v3
+        with:
+          name: win-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}
+          path: .build/win.zip
+          retention-days: 10
+      - name: Upload Mac build artifact
+        if: contains(github.ref, 'dev')
+        uses: actions/upload-artifact@v3
+        with:
+          name: mac-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}
+          path: .build/mac.zip
+          retention-days: 10
+      - name: Upload Linux build artifact
+        if: contains(github.ref, 'dev')
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}
+          path: .build/linux.zip
+          retention-days: 10
+      # - name: Deploy docs
+      ## TODO
       - name: Deploy web app
-        if: contains(github.ref, 'tags') ## only deploy web app for tags
+        if: ${{ !contains(github.ref, 'dev') }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: dist # The folder the action should deploy.
-      - name: Build Electron App
-        run: npm run electron
-      - name: Upload builds
-        uses: actions/upload-artifact@v3
+      - name: Get release
+        if: ${{ !contains(github.ref, 'dev') }}
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload Web Release Asset
+        uses: actions/upload-release-asset@v1
+        if: ${{ !contains(github.ref, 'dev') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ steps.version.outputs.VERSION }}
-          path: |
-            dist/
-            builds/
-      ## for when we have perms to add permissions to handle steam deploy also
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: dist.zip
+          asset_name: web-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}.zip
+          asset_content_type: application/zip
+      - name: Upload Win Release Asset
+        uses: actions/upload-release-asset@v1
+        if: ${{ !contains(github.ref, 'dev') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: .build/win.zip
+          asset_name: win-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}.zip
+          asset_content_type: application/zip
+      - name: Upload Mac Release Asset
+        uses: actions/upload-release-asset@v1
+        if: ${{ !contains(github.ref, 'dev') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: .build/mac.zip
+          asset_name: mac-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}.zip
+          asset_content_type: application/zip
+      - name: Upload linux Release Asset
+        uses: actions/upload-release-asset@v1
+        if: ${{ !contains(github.ref, 'dev') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: .build/linux.zip
+          asset_name: linux-${{ steps.version.outputs.VERSION }}.${{ steps.version.outputs.SHA_SHORT }}.zip
+          asset_content_type: application/zip
+      ## for when we have perms to add secrets to handle steam deploy also
       # - uses: game-ci/steam-deploy@v1
       #   with:
       #     username: ${{ secrets.STEAM_USERNAME }}

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "test:watch": "jest --watch",
     "watch": "webpack --watch --mode production",
     "watch:dev": "webpack --watch --mode development",
-    "electron": "sh ./tools/package-electron.sh",
+    "electron": "bash ./tools/package-electron.sh",
     "electron:packager": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png --no-prune",
     "electron:packager-all": "electron-packager .package bitburner --all --out .build --overwrite --icon .package/icon.png",
     "electron:packager-win": "electron-packager .package bitburner --platform win32 --arch x64 --out .build --overwrite --icon .package/icon.png",

--- a/tools/install-wine.sh
+++ b/tools/install-wine.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo dpkg --add-architecture i386
+sudo apt update
+sudo apt install wine

--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
closes #3295

Okay so ill do my best to explain what this is doing

This new workflow will start 
* on dev branch pushes IF the CI workflow is successful
OR
* on a release being published  

>${{ github.event.workflow_run.conclusion == 'success' }} || ${{ github.event.workflow_run.conclusion == false }}

This is just the check to find if the CI was successful OR its the release trigger

The workflow then builds the app as production, installs wine then builds the electorn app for windows,linux and mac

Then zips the assets for smaller download size

Then 
* if the the workflow was triggered via a dev commit it will upload the builds as artifacts see example (https://github.com/phyzical/bitburner/actions/runs/2184141670)
* if its a release then it will find the release that triggered the workflow and attach the build assets to those see example (https://github.com/phyzical/bitburner/releases/tag/v1.22)

Also if its a release it will take the results of the dist folder and push them to a branch named `gh-pages` so it should just be a matter of updating the github pages to use this branch going forward

Given the above we should have auto build for both development and releases (i.e after using the existing bump-version workflow)

The outstanding things in the workflow ATM are
* auto deploy for docs NFI how this is currently handled but can update when i get some info
* auto deploy to steam, have left the 3rd part action commented out until we can get access to secrets for when that time comes

lmk if ive not explained something well enough 


