### PR TITLE
WORK: FIX #3435 Quitting the active job now sets first remaining job as active

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1870,13 +1870,12 @@ export function getNextCompanyPosition(
 
 export function quitJob(this: IPlayer, company: string): void {
   if (this.isWorking == true && this.workType.includes("Working for Company") && this.companyName == company) {
-    this.isWorking = false;
-    this.companyName = "";
-  }
-  if (this.companyName === company) {
-    this.companyName = "";
+    this.finishWork(true);
   }
   delete this.jobs[company];
+  if (this.companyName === company) {
+    this.companyName = this.hasJob() ? Object.keys(this.jobs)[0] : "";
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #3435 .

Quitting a job no longer automatically sets the current company to "". If another job is present, the first job will become the active company for work. Alt-J should no longer lead to a black screen in this case, and the Job menu item will remain visible.

Also changes quitting a job while it is actively being worked, so instead of just setting isWorking to false directly, it does the entire finishWork process.

Performed testing locally and everything seems to work as expected. Open to suggestions on weird edge cases but I think it should just work. See issue #3435 for previous behavior.

https://user-images.githubusercontent.com/84951833/163895723-5bbd627b-8e78-4f41-aab2-f1b16bc16053.mp4
