### PR TITLE
UI: Fix the achievement covenant icon was not shown

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -113,7 +113,7 @@ export const achievements: IMap<Achievement> = {
   },
   THE_COVENANT: {
     ...achievementData["THE_COVENANT"],
-    Icon: FactionNames.TheCovenant.toLowerCase(),
+    Icon: FactionNames.TheCovenant.toLowerCase().replace(/ /g, ""),
     Condition: () => Player.factions.includes(FactionNames.TheCovenant),
   },
   [FactionNames.Illuminati.toUpperCase()]: {


### PR DESCRIPTION
The file name of the icon is `thecovenant.svg`, so we need to remove the space.

Before:
<img width="576" alt="before" src="https://user-images.githubusercontent.com/91325858/164012400-eefe0d0e-9526-4481-9bf1-1002983770e6.PNG">
After:
<img width="560" alt="after" src="https://user-images.githubusercontent.com/91325858/164012415-884ca678-14fe-4384-a815-1764eac009fa.PNG">