### PR TITLE
UI: Change text color of Augmentations page backup button

### DIFF
--- a/src/Augmentation/ui/AugmentationsRoot.tsx
+++ b/src/Augmentation/ui/AugmentationsRoot.tsx
@@ -172,7 +172,7 @@ export function AugmentationsRoot(props: IProps): React.ReactElement {
               </span>
             </Tooltip>
             <Tooltip title={<Typography>It's always a good idea to backup/export your save!</Typography>}>
-              <Button sx={{ width: "100%" }} onClick={doExport} color="error">
+              <Button sx={{ width: "100%", color: Settings.theme.successlight }} onClick={doExport}>
                 Backup Save {exportBonusStr()}
               </Button>
             </Tooltip>


### PR DESCRIPTION
Better contrast improves readability and lack of red makes it seem less like a danger button

![image](https://user-images.githubusercontent.com/60761231/164032280-78ffac90-262b-4181-afd0-69cdb507cabb.png)
