### PR TITLE
MISC: Update logic for stats page BitNode level

### DIFF
--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -82,13 +82,12 @@ function CurrentBitNode(): React.ReactElement {
   const player = use.Player();
   if (player.sourceFiles.length > 0) {
     const index = "BitNode" + player.bitNodeN;
-    const currentSourceFile = player.sourceFiles.find((sourceFile) => sourceFile.n == player.bitNodeN);
-    const lvl = currentSourceFile ? currentSourceFile.lvl : 0;
+    const lvl = player.sourceFileLvl(player.bitNodeN) + 1;
     return (
       <Box>
         <Paper sx={{ p: 1 }}>
           <Typography variant="h5">
-            BitNode {player.bitNodeN}: {BitNodes[index].name} (Level {lvl + 1})
+            BitNode {player.bitNodeN}: {BitNodes[index].name} (Level {lvl})
           </Typography>
           <Typography sx={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>{BitNodes[index].info}</Typography>
         </Paper>


### PR DESCRIPTION
The logic for fetching the current BitNode level is updated to use the same code that is used in generating save files names.

Note: This does not address another relevant issue wherein the BitVerse page incorrectly shows the next BitNode level as being available when accessed via flume