### PR TITLE
MISC: fix typing conflict between jest and cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/bcryptjs": "^2.4.2",
     "@types/escodegen": "^0.0.7",
     "@types/file-saver": "^2.0.3",
+    "@types/jest": "^27.4.1",
     "@types/jquery": "^3.5.14",
     "@types/lodash": "^4.14.168",
     "@types/numeral": "^2.0.2",

--- a/test/cypress/tsconfig.json
+++ b/test/cypress/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": true,
+    "target": "es6",
+    "types": ["cypress", "@testing-library/cypress"]
+  }
+}

--- a/test/jest/Netscript/DynamicRamCalculation.test.js
+++ b/test/jest/Netscript/DynamicRamCalculation.test.js
@@ -1,5 +1,3 @@
-import { jest, describe, expect } from "@jest/globals";
-
 import { Player } from "../../../src/Player";
 import { NetscriptFunctions } from "../../../src/NetscriptFunctions";
 import { getRamCost, RamCostConstants } from "../../../src/Netscript/RamCostGenerator";

--- a/test/jest/Netscript/StaticRamCalculation.test.js
+++ b/test/jest/Netscript/StaticRamCalculation.test.js
@@ -1,5 +1,3 @@
-import { jest, describe, expect } from "@jest/globals";
-
 import { Player } from "../../../src/Player";
 import { getRamCost, RamCostConstants } from "../../../src/Netscript/RamCostGenerator";
 import { calculateRamUsage } from "../../../src/Script/RamCalculations";

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.js
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { describe, expect, jest } from "@jest/globals";
-
 // Player is needed for calculating costs like Singularity functions, that depend on acquired source files
 import { Player } from "../../../src/Player";
 

--- a/test/jest/Script/Script.test.ts
+++ b/test/jest/Script/Script.test.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { jest, describe, expect, test } from "@jest/globals";
-
 import { Script } from "../../../src/Script/Script";
 import { Player } from "../../../src/Player";
 

--- a/test/jest/StockMarket.test.ts
+++ b/test/jest/StockMarket.test.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { jest, describe, expect, test } from "@jest/globals";
-
 import { CONSTANTS } from "../../src/Constants";
 import { Player } from "../../src/Player";
 import { IMap } from "../../src/types";

--- a/test/jest/StringHelperFunctions.test.ts
+++ b/test/jest/StringHelperFunctions.test.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { jest, describe, expect, test } from "@jest/globals";
 import { convertTimeMsToTimeElapsedString } from "../../src/utils/StringHelperFunctions";
 
 describe("StringHelperFunctions Tests", function () {

--- a/test/jest/Terminal/Directory.test.js
+++ b/test/jest/Terminal/Directory.test.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { jest, describe, expect, test } from "@jest/globals";
 import * as dirHelpers from "../../../src/Terminal/DirectoryHelpers";
 
 describe("Terminal Directory Tests", function () {

--- a/test/jest/Terminal/determineAllPossibilitiesForTabCompletion.test.ts
+++ b/test/jest/Terminal/determineAllPossibilitiesForTabCompletion.test.ts
@@ -1,7 +1,5 @@
 import { CityName } from "./../../../src/Locations/data/CityNames";
 /* eslint-disable no-await-in-loop */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { jest, describe, expect, test } from "@jest/globals";
 
 import { Player } from "../../../src/Player";
 import { determineAllPossibilitiesForTabCompletion } from "../../../src/Terminal/determineAllPossibilitiesForTabCompletion";

--- a/test/jest/ui/nFormat.test.js
+++ b/test/jest/ui/nFormat.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "@jest/globals";
 import { numeralWrapper } from "../../../src/ui/numeralFormat";
 
 let decimalFormat = "0.[000000]";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,15 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "react",
-    "lib": ["es2016", "dom", "es2017.object", "es2019"],
     "module": "commonjs",
-    "target": "es6",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "resolveJsonModule": true,
-    "types": ["cypress", "@testing-library/cypress", "node"]
+    "target": "es2019",
+    "types": ["jest", "node"]
   },
-  "exclude": ["node_modules"]
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["test/cypress/**/*"]
 }


### PR DESCRIPTION
Cypress and Jest both define "expect", but they come from different
libraries (Cypress uses Chai, Jest uses its own thing). So we can't
include both of them in the tsconfig.json. Conveniently, however, we
don't need any of the test code to be part of the main project, so
it suffices to give cypress its own tsconfig.json file.

That being done, adding "jest" to the global types lets us remove all
those imports.