### PR TITLE
MISC: update @types/numeral and fix type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/escodegen": "^0.0.7",
     "@types/file-saver": "^2.0.3",
     "@types/lodash": "^4.14.168",
-    "@types/numeral": "0.0.25",
+    "@types/numeral": "^2.0.2",
     "@types/react": "^17.0.21",
     "@types/react-beautiful-dnd": "^13.1.2",
     "@types/react-dom": "^17.0.9",

--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -223,19 +223,21 @@ class NumeralFormatter {
     const parsed = parseFloat(s);
     const selfParsed = this.parseCustomLargeNumber(s);
     // Check for one or more NaN values
-    if (isNaN(parsed) && numeralValue === null && isNaN(selfParsed)) {
-      // 3x NaN
-      return NaN;
-    } else if (isNaN(parsed) && isNaN(selfParsed)) {
+    if (isNaN(parsed) && isNaN(selfParsed)) {
+      if (numeralValue === null) {
+        // 3x NaN
+        return NaN;
+      }
       // 2x NaN
       return numeralValue;
     } else if (numeralValue === null && isNaN(selfParsed)) {
       // 2x NaN
       return parsed;
-    } else if (isNaN(parsed) && numeralValue === null) {
-      // 2x NaN
-      return selfParsed;
     } else if (isNaN(parsed)) {
+      if (numeralValue === null) {
+        // 2x NaN
+        return selfParsed;
+      }
       // 1x NaN
       return this.largestAbsoluteNumber(numeralValue, selfParsed);
     } else if (numeralValue === null) {


### PR DESCRIPTION
New typing recognizes that numeral can return null, which then trips up TS because it's not terribly smart about complicated if conditions.