### PR TITLE
MISC: upgrade to eslint v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,14 +65,14 @@
     "@types/react-beautiful-dnd": "^13.1.2",
     "@types/react-dom": "^17.0.9",
     "@types/react-resizable": "^1.7.3",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "^5.20.0",
+    "@typescript-eslint/parser": "^5.20.0",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.0.5",
     "cypress": "^8.3.1",
     "electron": "^14.2.4",
     "electron-packager": "^15.4.0",
-    "eslint": "^7.24.0",
+    "eslint": "^8.13.0",
     "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "^6.3.3",
     "html-webpack-plugin": "^3.2.0",
@@ -94,7 +94,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "engines": {
-    "node": ">=8 || <=9"
+    "node": ">=14"
   },
   "homepage": "https://github.com/danielyxie/bitburner",
   "repository": {

--- a/test/jest/ui/nFormat.test.js
+++ b/test/jest/ui/nFormat.test.js
@@ -30,17 +30,17 @@ describe("Numeral formatting for positive numbers", () => {
     expect(numeralWrapper.formatReallyBigNumber(987654321)).toEqual("987.654m");
     expect(numeralWrapper.formatReallyBigNumber(987654321987)).toEqual("987.654b");
     expect(numeralWrapper.formatReallyBigNumber(987654321987654)).toEqual("987.654t");
-    expect(numeralWrapper.formatReallyBigNumber(987654321987654321)).toEqual("987.654q");
-    expect(numeralWrapper.formatReallyBigNumber(987654321987654321987)).toEqual("987.654Q");
-    expect(numeralWrapper.formatReallyBigNumber(987654321987654321987654)).toEqual("987.654s");
-    expect(numeralWrapper.formatReallyBigNumber(987654321987654321987654321)).toEqual("987.654S");
-    expect(numeralWrapper.formatReallyBigNumber(987654321987654321987654321987)).toEqual("987.654o");
-    expect(numeralWrapper.formatReallyBigNumber(987654321987654321987654321987654)).toEqual("987.654n");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e3)).toEqual("987.654q");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e6)).toEqual("987.654Q");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e9)).toEqual("987.654s");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e12)).toEqual("987.654S");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e15)).toEqual("987.654o");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e18)).toEqual("987.654n");
   });
   test("should format even bigger really big numbers in scientific format", () => {
-    expect(numeralWrapper.formatReallyBigNumber(987654321987654321987654321987654321)).toEqual("9.877e+35");
-    expect(numeralWrapper.formatReallyBigNumber(9876543219876543219876543219876543219)).toEqual("9.877e+36");
-    expect(numeralWrapper.formatReallyBigNumber(98765432198765432198765432198765432198)).toEqual("9.877e+37");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e21)).toEqual("9.877e+35");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e22)).toEqual("9.877e+36");
+    expect(numeralWrapper.formatReallyBigNumber(987654321987654e23)).toEqual("9.877e+37");
   });
   test("should format percentage", () => {
     expect(numeralWrapper.formatPercentage(1234.56789)).toEqual("123456.79%");
@@ -74,17 +74,17 @@ describe("Numeral formatting for negative numbers", () => {
     expect(numeralWrapper.formatReallyBigNumber(-987654321)).toEqual("-987.654m");
     expect(numeralWrapper.formatReallyBigNumber(-987654321987)).toEqual("-987.654b");
     expect(numeralWrapper.formatReallyBigNumber(-987654321987654)).toEqual("-987.654t");
-    expect(numeralWrapper.formatReallyBigNumber(-987654321987654321)).toEqual("-987.654q");
-    expect(numeralWrapper.formatReallyBigNumber(-987654321987654321987)).toEqual("-987.654Q");
-    expect(numeralWrapper.formatReallyBigNumber(-987654321987654321987654)).toEqual("-987.654s");
-    expect(numeralWrapper.formatReallyBigNumber(-987654321987654321987654321)).toEqual("-987.654S");
-    expect(numeralWrapper.formatReallyBigNumber(-987654321987654321987654321987)).toEqual("-987.654o");
-    expect(numeralWrapper.formatReallyBigNumber(-987654321987654321987654321987654)).toEqual("-987.654n");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e3)).toEqual("-987.654q");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e6)).toEqual("-987.654Q");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e9)).toEqual("-987.654s");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e12)).toEqual("-987.654S");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e15)).toEqual("-987.654o");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e18)).toEqual("-987.654n");
   });
   test("should format even bigger really big numbers in scientific format", () => {
-    expect(numeralWrapper.formatReallyBigNumber(-987654321987654321987654321987654321)).toEqual("-9.877e+35");
-    expect(numeralWrapper.formatReallyBigNumber(-9876543219876543219876543219876543219)).toEqual("-9.877e+36");
-    expect(numeralWrapper.formatReallyBigNumber(-98765432198765432198765432198765432198)).toEqual("-9.877e+37");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e21)).toEqual("-9.877e+35");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e22)).toEqual("-9.877e+36");
+    expect(numeralWrapper.formatReallyBigNumber(-987654321987654e23)).toEqual("-9.877e+37");
   });
   test("should format percentage", () => {
     expect(numeralWrapper.formatPercentage(-1234.56789)).toEqual("-123456.79%");


### PR DESCRIPTION
We need newer typescript parsers, which needs newer eslint.