### PR TITLE
UI: FIX #3415 Tweak Manage Gang button visibility

### DIFF
--- a/src/Faction/ui/FactionRoot.tsx
+++ b/src/Faction/ui/FactionRoot.tsx
@@ -104,7 +104,7 @@ function MainPage({ faction, rerender, onAugmentations }: IMainProps): React.Rea
 
   const canPurchaseSleeves = faction.name === FactionNames.TheCovenant && player.bitNodeN === 10;
 
-  // Note : For future-proofing sake, an assumption is made that player is intended to retain access to his gang if his karma were to somehow increases. 
+  // Note : For future-proofing sake, an assumption is made that player is intended to retain access to his gang if his karma were to somehow increases.
   let isManageGangVisible = GangConstants.Names.includes(faction.name) && player.isAwareOfGang();
   // karma threshold is only checked at that point, via canAccessGang(). No further check is made.
   let isManageGangClickable = player.canAccessGang();
@@ -128,20 +128,20 @@ function MainPage({ faction, rerender, onAugmentations }: IMainProps): React.Rea
       {isManageGangVisible && (
         <>
           <Box>
-              <Paper sx={{ my: 1, p: 1 }}>
-                <Tooltip
-                  title={
-                  !isManageGangClickable ? <Typography>Unlocked when reaching -54000 karma</Typography> : ""
-                  }
-                >
-                  <span>
-                    <Button onClick={manageGang} disabled={!isManageGangClickable}>{"Manage Gang"}</Button>
-                    <Typography>{gangInfo}</Typography>
-                  </span>
+            <Paper sx={{ my: 1, p: 1 }}>
+              <Tooltip
+                title={!isManageGangClickable ? <Typography>Unlocked when reaching -54000 karma</Typography> : ""}
+              >
+                <span>
+                  <Button onClick={manageGang} disabled={!isManageGangClickable}>
+                    {"Manage Gang"}
+                  </Button>
+                  <Typography>{gangInfo}</Typography>
+                </span>
               </Tooltip>
-              </Paper>
+            </Paper>
           </Box>
-  
+
           <CreateGangModal facName={faction.name} open={gangOpen} onClose={() => setGangOpen(false)} />
         </>
       )}

--- a/src/Faction/ui/FactionRoot.tsx
+++ b/src/Faction/ui/FactionRoot.tsx
@@ -18,8 +18,7 @@ import { Faction } from "../Faction";
 import { use } from "../../ui/Context";
 import { CreateGangModal } from "./CreateGangModal";
 
-import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
+import { Box, Paper, Typography, Button, Tooltip } from "@mui/material";
 import { CovenantPurchasesRoot } from "../../PersonObjects/Sleeve/ui/CovenantPurchasesRoot";
 import { FactionNames } from "../data/FactionNames";
 import { GangConstants } from "../../Gang/data/Constants";
@@ -105,12 +104,17 @@ function MainPage({ faction, rerender, onAugmentations }: IMainProps): React.Rea
 
   const canPurchaseSleeves = faction.name === FactionNames.TheCovenant && player.bitNodeN === 10;
 
-  let canAccessGang = player.canAccessGang() && GangConstants.Names.includes(faction.name);
+  // Note : For future-proofing sake, an assumption is made that player is intended to retain access to his gang if his karma were to somehow increases. 
+  let isManageGangVisible = GangConstants.Names.includes(faction.name) && player.isAwareOfGang();
+  // karma threshold is only checked at that point, via canAccessGang(). No further check is made.
+  let isManageGangClickable = player.canAccessGang();
   if (player.inGang()) {
     if (player.getGangName() !== faction.name) {
-      canAccessGang = false;
+      isManageGangVisible = false;
     } else if (player.getGangName() === faction.name) {
-      canAccessGang = true;
+      isManageGangVisible = true;
+      // The following line will enable the button, without checking for karma threshold.
+      isManageGangClickable = true;
     }
   }
 
@@ -121,9 +125,23 @@ function MainPage({ faction, rerender, onAugmentations }: IMainProps): React.Rea
         {faction.name}
       </Typography>
       <Info faction={faction} factionInfo={factionInfo} />
-      {canAccessGang && (
+      {isManageGangVisible && (
         <>
-          <Option buttonText={"Manage Gang"} infoText={gangInfo} onClick={manageGang} />
+          <Box>
+              <Paper sx={{ my: 1, p: 1 }}>
+                <Tooltip
+                  title={
+                  !isManageGangClickable ? <Typography>Unlocked when reaching -54000 karma</Typography> : ""
+                  }
+                >
+                  <span>
+                    <Button onClick={manageGang} disabled={!isManageGangClickable}>{"Manage Gang"}</Button>
+                    <Typography>{gangInfo}</Typography>
+                  </span>
+              </Tooltip>
+              </Paper>
+          </Box>
+  
           <CreateGangModal facName={faction.name} open={gangOpen} onClose={() => setGangOpen(false)} />
         </>
       )}

--- a/src/Faction/ui/FactionRoot.tsx
+++ b/src/Faction/ui/FactionRoot.tsx
@@ -130,7 +130,7 @@ function MainPage({ faction, rerender, onAugmentations }: IMainProps): React.Rea
           <Box>
             <Paper sx={{ my: 1, p: 1 }}>
               <Tooltip
-                title={!isManageGangClickable ? <Typography>Unlocked when reaching -54000 karma</Typography> : ""}
+                title={!isManageGangClickable ? <Typography>Unlocked when reaching {GangConstants.GangKarmaRequirement} karma</Typography> : ""}
               >
                 <span>
                   <Button onClick={manageGang} disabled={!isManageGangClickable}>

--- a/src/Gang/data/Constants.ts
+++ b/src/Gang/data/Constants.ts
@@ -6,6 +6,7 @@ export const GangConstants: {
   CyclesPerTerritoryAndPowerUpdate: number;
   AscensionMultiplierRatio: number;
   Names: string[];
+  GangKarmaRequirement: number;
 } = {
   // Respect is divided by this to get rep gain
   GangRespectToReputationRatio: 75,
@@ -23,4 +24,5 @@ export const GangConstants: {
     FactionNames.NiteSec,
     FactionNames.TheBlackHand,
   ],
+  GangKarmaRequirement: -54000,
 };

--- a/src/PersonObjects/IPlayer.ts
+++ b/src/PersonObjects/IPlayer.ts
@@ -208,6 +208,7 @@ export interface IPlayer {
   hasProgram(program: string): boolean;
   inBladeburner(): boolean;
   inGang(): boolean;
+  isAwareOfGang(): boolean;
   isQualified(company: Company, position: CompanyPosition): boolean;
   loseMoney(money: number, source: string): void;
   process(router: IRouter, numCycles?: number): void;

--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -218,6 +218,7 @@ export class PlayerObject implements IPlayer {
   hasProgram: (program: string) => boolean;
   inBladeburner: () => boolean;
   inGang: () => boolean;
+  isAwareOfGang: () => boolean;
   isQualified: (company: Company, position: CompanyPosition) => boolean;
   loseMoney: (money: number, source: string) => void;
   reapplyAllAugmentations: (resetMultipliers?: boolean) => void;
@@ -604,6 +605,7 @@ export class PlayerObject implements IPlayer {
     this.hasCorporation = corporationMethods.hasCorporation;
     this.startCorporation = corporationMethods.startCorporation;
     this.canAccessGang = gangMethods.canAccessGang;
+    this.isAwareOfGang = gangMethods.isAwareOfGang;
     this.getGangFaction = gangMethods.getGangFaction;
     this.getGangName = gangMethods.getGangName;
     this.hasGangWith = gangMethods.hasGangWith;

--- a/src/PersonObjects/Player/PlayerObjectGangMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGangMethods.ts
@@ -17,6 +17,13 @@ export function canAccessGang(this: IPlayer): boolean {
   return this.karma <= GangKarmaRequirement;
 }
 
+export function isAwareOfGang(this: IPlayer): boolean {
+  if (this.bitNodeN === 2 || this.sourceFileLvl(2) >= 1) {
+    return true;
+  }
+  return false;
+}
+
 export function getGangFaction(this: IPlayer): Faction {
   const gang = this.gang;
   if (gang === null) {

--- a/src/PersonObjects/Player/PlayerObjectGangMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGangMethods.ts
@@ -18,10 +18,7 @@ export function canAccessGang(this: IPlayer): boolean {
 }
 
 export function isAwareOfGang(this: IPlayer): boolean {
-  if (this.bitNodeN === 2 || this.sourceFileLvl(2) >= 1) {
-    return true;
-  }
-  return false;
+  return this.bitNodeN === 2 || this.sourceFileLvl(2) >= 1;
 }
 
 export function getGangFaction(this: IPlayer): Faction {

--- a/src/PersonObjects/Player/PlayerObjectGangMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGangMethods.ts
@@ -2,9 +2,9 @@ import { Factions } from "../../Faction/Factions";
 import { Faction } from "../../Faction/Faction";
 import { Gang } from "../../Gang/Gang";
 import { IPlayer } from "../IPlayer";
+import { GangConstants } from "../../Gang/data/Constants"
 
-// Amount of negative karma needed to manage a gang in BitNodes other than 2
-const GangKarmaRequirement = -54000;
+
 
 export function canAccessGang(this: IPlayer): boolean {
   if (this.bitNodeN === 2) {
@@ -14,7 +14,7 @@ export function canAccessGang(this: IPlayer): boolean {
     return false;
   }
 
-  return this.karma <= GangKarmaRequirement;
+  return this.karma <= GangConstants.GangKarmaRequirement;
 }
 
 export function isAwareOfGang(this: IPlayer): boolean {


### PR DESCRIPTION
fixes #3415
![image](https://user-images.githubusercontent.com/104104269/164326063-7059dc0e-1dc6-40b6-83cc-41206cf59277.png)

Testing done :
Ensuring the button stay hidden in the following cases :
- Player not having source-file 2.
- Player not being inside bitnode 2.
- Faction not being Gang-capable.
- Faction being Gang-capable, but player being already  affiliated with another faction.

Ensuring the button is visible but cannot be clicked :
- When the player has the source-file 2, has yet to create a gang, but lack the required karma. 

Ensuring the button is visble and interactable :
- When the player is in bitnode 2.
- When the player has the source-file 2, has yet to create a gang, and has the required karma.
- When the player has created a gang.  