### PR TITLE
UI: FIX #2256 Hacknet server's upgrade tooltip  were not handling RAM…

### DIFF
--- a/src/Hacknet/ui/HacknetServerElem.tsx
+++ b/src/Hacknet/ui/HacknetServerElem.tsx
@@ -60,15 +60,17 @@ export function HacknetServerElem(props: IProps): React.ReactElement {
       multiplier = Math.min(levelsToMax, purchaseMult as number);
     }
 
-    const increase =
-      calculateHashGainRate(node.level + multiplier, 0, node.maxRam, node.cores, props.player.hacknet_node_money_mult) -
-      node.hashRate;
+    const base_increase = calculateHashGainRate(node.level + multiplier, 0, node.maxRam, node.cores, props.player.hacknet_node_money_mult) 
+    - calculateHashGainRate(node.level, 0, node.maxRam, node.cores, props.player.hacknet_node_money_mult);
+    let modded_increase = base_increase * (node.maxRam - node.ramUsed) / node.maxRam;
+
     const upgradeLevelCost = node.calculateLevelUpgradeCost(multiplier, props.player.hacknet_node_level_cost_mult);
     upgradeLevelButton = (
       <Tooltip
         title={
           <Typography>
-            +<HashRate hashes={increase} />
+          +<HashRate hashes={base_increase} /> (base increase, attained when no script is running) <br />
+          +<HashRate hashes={modded_increase} /> (effective increase, taking current RAM usage into account)
           </Typography>
         }
       >
@@ -109,20 +111,43 @@ export function HacknetServerElem(props: IProps): React.ReactElement {
       multiplier = Math.min(levelsToMax, purchaseMult as number);
     }
 
-    const increase =
+    const base_increase =
       calculateHashGainRate(
         node.level,
         0,
         node.maxRam * Math.pow(2, multiplier),
         node.cores,
         props.player.hacknet_node_money_mult,
-      ) - node.hashRate;
+      ) - calculateHashGainRate(
+        node.level,
+        0,
+        node.maxRam,
+        node.cores,
+        props.player.hacknet_node_money_mult,
+      );
+      
+      let modded_increase = 
+      calculateHashGainRate(
+        node.level,
+        node.ramUsed,
+        node.maxRam * Math.pow(2, multiplier),
+        node.cores,
+        props.player.hacknet_node_money_mult,
+      ) - calculateHashGainRate(
+        node.level,
+        node.ramUsed,
+        node.maxRam,
+        node.cores,
+        props.player.hacknet_node_money_mult,
+      );
+
     const upgradeRamCost = node.calculateRamUpgradeCost(multiplier, props.player.hacknet_node_ram_cost_mult);
     upgradeRamButton = (
       <Tooltip
         title={
           <Typography>
-            +<HashRate hashes={increase} />
+            +<HashRate hashes={base_increase} /> (base increase, attained when no script is running) <br />
+            +<HashRate hashes={modded_increase} /> (effective increase, taking current RAM usage into account)
           </Typography>
         }
       >
@@ -155,15 +180,17 @@ export function HacknetServerElem(props: IProps): React.ReactElement {
       multiplier = Math.min(levelsToMax, purchaseMult as number);
     }
 
-    const increase =
-      calculateHashGainRate(node.level, 0, node.maxRam, node.cores + multiplier, props.player.hacknet_node_money_mult) -
-      node.hashRate;
+    const base_increase = calculateHashGainRate(node.level, 0, node.maxRam, node.cores + multiplier, props.player.hacknet_node_money_mult)
+    - calculateHashGainRate(node.level, 0, node.maxRam, node.cores, props.player.hacknet_node_money_mult);
+    let modded_increase = base_increase * (node.maxRam - node.ramUsed) / node.maxRam;
+
     const upgradeCoreCost = node.calculateCoreUpgradeCost(multiplier, props.player.hacknet_node_core_cost_mult);
     upgradeCoresButton = (
       <Tooltip
         title={
           <Typography>
-            +<HashRate hashes={increase} />
+            +<HashRate hashes={base_increase} /> (base increase, attained when no script is running) <br />
+            +<HashRate hashes={modded_increase} /> (effective increase, taking current RAM usage into account)
           </Typography>
         }
       >
@@ -232,9 +259,25 @@ export function HacknetServerElem(props: IProps): React.ReactElement {
               <Typography>Production:</Typography>
             </TableCell>
             <TableCell colSpan={2}>
-              <Typography>
-                <Hashes hashes={node.totalHashesGenerated} /> (<HashRate hashes={node.hashRate} />)
-              </Typography>
+              <Tooltip
+                title={
+                  <Typography>
+                    <Hashes hashes={node.totalHashesGenerated} /> hashes producted by this server since last augment installation.
+                    <br />
+                    <HashRate hashes={node.hashRate} /> current production rate.
+                    <br />
+                    <HashRate hashes={node.hashRate * node.maxRam / (node.maxRam - node.ramUsed)} /> max production rate. (achieved when 100% Ram is allocated to it)
+                    <br />
+                    {numeralWrapper.formatRAM(node.ramUsed)} / {numeralWrapper.formatRAM(node.maxRam)} ({Math.round(100 * node.ramUsed / node.maxRam)}%) Ram allocated to script.
+                    <br />
+                    {numeralWrapper.formatRAM(node.maxRam - node.ramUsed)} / {numeralWrapper.formatRAM(node.maxRam)} ({Math.round(100 * (node.maxRam - node.ramUsed) / node.maxRam)}%) Ram allocated to hash production.                    
+                  </Typography>
+                }
+              >
+                <Typography>    
+                  <Hashes hashes={node.totalHashesGenerated} /> (<HashRate hashes={node.hashRate} />)
+                </Typography>
+              </Tooltip>
             </TableCell>
           </TableRow>
           <TableRow>


### PR DESCRIPTION
Fixes #2256 by using the correct formula to calculate the hashrate increase.

Slightly revamp tooltip to display both theoric and effective increase.
Add a discreet tooltip to the Production line which display details about hashrate and ram usage.

Tested by running two script by intermittence on a loop on the hacknet server.
Value displayed stay coherent all along.

Revamped tooltip :
![image](https://user-images.githubusercontent.com/104104269/164506204-84611d25-1002-438a-8b25-029a359dad71.png)

New tooltip :
![image](https://user-images.githubusercontent.com/104104269/164506115-3e063794-9bcd-4509-81c2-a33558a6ff50.png)

