### PR TITLE
DOCUMENTATION: FIX #3516 "cannot" misspelled as "cannnot"

### DIFF
--- a/doc/source/guidesandtips/recommendedbitnodeorder.rst
+++ b/doc/source/guidesandtips/recommendedbitnodeorder.rst
@@ -280,7 +280,7 @@ Description
     In this BitNode:
 
     * Your stats are significantly decreased
-    * You cannnot purchase additional servers
+    * You cannot purchase additional servers
     * Hacking is significantly less profitable
 
 Source-File


### PR DESCRIPTION
The page the typo is on needs an overhaul anyway, but I don't see any reason to leave the typo just cause the page needs to be rewritten. The other instance of the typo, ingame, has been removed entirely by changes to the way bitnode multipliers are displayed.

Wholly untested, because I have no idea how one would "test" the docs