### PR TITLE
API: Fix inconsistent return value in `ns.grafting.getAugmentationGraftTime`

### DIFF
--- a/src/NetscriptFunctions/Grafting.ts
+++ b/src/NetscriptFunctions/Grafting.ts
@@ -4,7 +4,7 @@ import { CityName } from "../Locations/data/CityNames";
 import { getRamCost } from "../Netscript/RamCostGenerator";
 import { WorkerScript } from "../Netscript/WorkerScript";
 import { GraftableAugmentation } from "../PersonObjects/Grafting/GraftableAugmentation";
-import { getGraftingAvailableAugs } from "../PersonObjects/Grafting/GraftingHelpers";
+import { getGraftingAvailableAugs, calculateGraftingTimeWithBonus } from "../PersonObjects/Grafting/GraftingHelpers";
 import { IPlayer } from "../PersonObjects/IPlayer";
 import { Grafting as IGrafting } from "../ScriptEditor/NetscriptDefinitions";
 import { Router } from "../ui/GameRoot";
@@ -31,8 +31,8 @@ export function NetscriptGrafting(player: IPlayer, workerScript: WorkerScript, h
       if (!getGraftingAvailableAugs(player).includes(augName) || !Augmentations.hasOwnProperty(augName)) {
         throw helper.makeRuntimeErrorMsg("grafting.getAugmentationGraftPrice", `Invalid aug: ${augName}`);
       }
-      const craftableAug = new GraftableAugmentation(Augmentations[augName]);
-      return craftableAug.cost;
+      const graftableAug = new GraftableAugmentation(Augmentations[augName]);
+      return graftableAug.cost;
     },
 
     getAugmentationGraftTime: (_augName: string): number => {
@@ -42,8 +42,8 @@ export function NetscriptGrafting(player: IPlayer, workerScript: WorkerScript, h
       if (!getGraftingAvailableAugs(player).includes(augName) || !Augmentations.hasOwnProperty(augName)) {
         throw helper.makeRuntimeErrorMsg("grafting.getAugmentationGraftTime", `Invalid aug: ${augName}`);
       }
-      const craftableAug = new GraftableAugmentation(Augmentations[augName]);
-      return craftableAug.time;
+      const graftableAug = new GraftableAugmentation(Augmentations[augName]);
+      return calculateGraftingTimeWithBonus(player, graftableAug);
     },
 
     getGraftableAugmentations: (): string[] => {

--- a/src/PersonObjects/Grafting/GraftingHelpers.ts
+++ b/src/PersonObjects/Grafting/GraftingHelpers.ts
@@ -15,7 +15,11 @@ export const getGraftingAvailableAugs = (player: IPlayer): string[] => {
   return augs.filter((augmentation: string) => !player.hasAugmentation(augmentation));
 };
 
+export const graftingIntBonus = (player: IPlayer): number => {
+  return 1 + (player.getIntelligenceBonus(3) - 1) / 3;
+};
+
 export const calculateGraftingTimeWithBonus = (player: IPlayer, aug: GraftableAugmentation): number => {
   const baseTime = aug.time;
-  return baseTime / (1 + (player.getIntelligenceBonus(3) - 1) / 3);
+  return baseTime / graftingIntBonus(player);
 };

--- a/src/PersonObjects/Grafting/GraftingHelpers.ts
+++ b/src/PersonObjects/Grafting/GraftingHelpers.ts
@@ -1,5 +1,6 @@
 import { Augmentations } from "../../Augmentation/Augmentations";
 import { AugmentationNames } from "../../Augmentation/data/AugmentationNames";
+import { GraftableAugmentation } from "./GraftableAugmentation";
 import { IPlayer } from "../IPlayer";
 
 export const getGraftingAvailableAugs = (player: IPlayer): string[] => {
@@ -12,4 +13,9 @@ export const getGraftingAvailableAugs = (player: IPlayer): string[] => {
   }
 
   return augs.filter((augmentation: string) => !player.hasAugmentation(augmentation));
+};
+
+export const calculateGraftingTimeWithBonus = (player: IPlayer, aug: GraftableAugmentation): number => {
+  const baseTime = aug.time;
+  return baseTime / (1 + (player.getIntelligenceBonus(3) - 1) / 3);
 };

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -15,7 +15,7 @@ import { ConfirmationModal } from "../../../ui/React/ConfirmationModal";
 import { Money } from "../../../ui/React/Money";
 import { convertTimeMsToTimeElapsedString, formatNumber } from "../../../utils/StringHelperFunctions";
 import { IPlayer } from "../../IPlayer";
-import { getGraftingAvailableAugs } from "../GraftingHelpers";
+import { getGraftingAvailableAugs, calculateGraftingTimeWithBonus } from "../GraftingHelpers";
 import { GraftableAugmentation } from "../GraftableAugmentation";
 
 const GraftableAugmentations: IMap<GraftableAugmentation> = {};
@@ -132,7 +132,7 @@ export const GraftingRoot = (): React.ReactElement => {
               <Typography color={Settings.theme.info}>
                 <b>Time to Graft:</b>{" "}
                 {convertTimeMsToTimeElapsedString(
-                  GraftableAugmentations[selectedAug].time / (1 + (player.getIntelligenceBonus(3) - 1) / 3),
+                  calculateGraftingTimeWithBonus(player, GraftableAugmentations[selectedAug]),
                 )}
                 {/* Use formula so the displayed creation time is accurate to player bonus */}
               </Typography>

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -65,6 +65,7 @@ import { SnackbarEvents, ToastVariant } from "../../ui/React/Snackbar";
 import { calculateClassEarnings } from "../formulas/work";
 import { achievements } from "../../Achievements/Achievements";
 import { FactionNames } from "../../Faction/data/FactionNames";
+import { graftingIntBonus } from "../Grafting/GraftingHelpers";
 
 export function init(this: IPlayer): void {
   /* Initialize Player's home computer */
@@ -1350,7 +1351,7 @@ export function craftAugmentationWork(this: IPlayer, numCycles: number): boolean
     focusBonus = this.focus ? 1 : CONSTANTS.BaseFocusBonus;
   }
 
-  let skillMult = 1 + (this.getIntelligenceBonus(3) - 1) / 3;
+  let skillMult = graftingIntBonus(this);
   skillMult *= focusBonus;
 
   this.timeWorked += CONSTANTS._idleSpeed * numCycles;


### PR DESCRIPTION
fixes `ns.grafting.getAugmentationGraftTime` to return a value that's consistent with the value displayed in the UI and used in calculations for actual completion

in doing so, adds a couple helpers functions to provide a reusable access point for the values