### PR TITLE
UI: lightweight description update on "increase maximum money" hash spending option.

### DIFF
--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -44,7 +44,7 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
       "Use hashes to increase the maximum amount of money on a single server by 2%. " +
       "Note that a server's maximum money is soft capped above $10t. " +
       "This effect persists until you install Augmentations (since servers " +
-      "are reset at that time). ",
+      "are reset at that time).",
     hasTargetServer: true,
     name: "Increase Maximum Money",
     value: 1.02,

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -42,7 +42,7 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
     costPerLevel: 50,
     desc:
       "Use hashes to increase the maximum amount of money on a single server by 2%. " +
-      "Note that a server's maximum money is soft capped above $1t. " +
+      "Note that a server's maximum money is soft capped above $10t. " +
       "This effect persists until you install Augmentations (since servers " +
       "are reset at that time). ",
     hasTargetServer: true,

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -42,8 +42,9 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
     costPerLevel: 50,
     desc:
       "Use hashes to increase the maximum amount of money on a single server by 2%. " +
+      "Note that a server's maximum money is soft capped above $1t. " +
       "This effect persists until you install Augmentations (since servers " +
-      "are reset at that time).",
+      "are reset at that time). ",
     hasTargetServer: true,
     name: "Increase Maximum Money",
     value: 1.02,


### PR DESCRIPTION
Update "Increase maximum money" description to document a change made in v0.56.0 : adding a soft cap on max money increase above the $10t mark.

![image](https://user-images.githubusercontent.com/104104269/164894226-57978c59-4ade-45da-b498-1de2f0264c29.png)

