### PR TITLE
UI: Improve tail window buttons

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -96,6 +96,9 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "flex",
       flexDirection: "column-reverse",
     },
+    titleButton: {
+      padding: "1px 6px",
+    },
     success: {
       color: theme.colors.success,
     },
@@ -260,28 +263,26 @@ function LogWindow(props: IProps): React.ReactElement {
             }}
           >
             <Box className="drag" display="flex" alignItems="center" ref={draggableRef}>
-              <Typography color="primary" variant="h6" title={title(true)}>
+              <Typography color="primary" variant="h6" sx={{ marginRight: "auto" }} title={title(true)}>
                 {title()}
               </Typography>
 
-              <Box position="absolute" right={0}>
-                {!workerScripts.has(script.pid) && (
-                  <Button onClick={run} onTouchEnd={run}>
-                    Run
-                  </Button>
-                )}
-                {workerScripts.has(script.pid) && (
-                  <Button onClick={kill} onTouchEnd={kill}>
-                    Kill
-                  </Button>
-                )}
-                <Button onClick={minimize} onTouchEnd={minimize}>
-                  {minimized ? "\u{1F5D6}" : "\u{1F5D5}"}
+              {!workerScripts.has(script.pid) && (
+                <Button className={classes.titleButton} onClick={run} onTouchEnd={run}>
+                  Run
                 </Button>
-                <Button onClick={props.onClose} onTouchEnd={props.onClose}>
-                  Close
+              )}
+              {workerScripts.has(script.pid) && (
+                <Button className={classes.titleButton} onClick={kill} onTouchEnd={kill}>
+                  Kill
                 </Button>
-              </Box>
+              )}
+              <Button className={classes.titleButton} onClick={minimize} onTouchEnd={minimize}>
+                {minimized ? "\u{1F5D6}" : "\u{1F5D5}"}
+              </Button>
+              <Button className={classes.titleButton} onClick={props.onClose} onTouchEnd={props.onClose}>
+                Close
+              </Button>
             </Box>
           </Paper>
           <Paper sx={{ overflow: "scroll", overflowWrap: "break-word", whiteSpace: "pre-wrap" }}>


### PR DESCRIPTION
Tail window buttons have been moved properly inside of the tail window titlebar, previously the buttons clipped out, and would behave oddly if the titlebar was shrunk too small in the X direction. See video.

https://user-images.githubusercontent.com/84951833/164945581-a0100aea-9c6f-4db9-b400-249912f623b3.mp4


