### PR TITLE
BITNODE: FIX #3546 BitVerse now shows proper BN level when accessed via flume

### DIFF
--- a/src/BitNode/ui/BitverseRoot.tsx
+++ b/src/BitNode/ui/BitverseRoot.tsx
@@ -163,7 +163,9 @@ export function BitverseRoot(props: IProps): React.ReactElement {
       return lvl;
     }
     const max = n === 12 ? Infinity : 3;
-    return Math.min(max, lvl + 1);
+
+    // If accessed via flume, display the current BN level, else the next
+    return Math.min(max, lvl + Number(!props.flume));
   };
 
   if (Settings.DisableASCIIArt) {


### PR DESCRIPTION
Fixes #3546

when accessed via flume, the bitverse will now show the correct level for the bitnode that was flumed from, rather than wrongly showing the next bitnode level

when accessed by hacking world daemon, the behavior remains unchanged