### PR TITLE
INFILTRATION: Fix phyzical WKS aug effects being applied before aug is installed

### DIFF
--- a/src/Infiltration/formulas/victory.ts
+++ b/src/Infiltration/formulas/victory.ts
@@ -17,7 +17,7 @@ export function calculateSellInformationCashReward(
     Math.pow(difficulty, 3) *
     3e3 *
     levelBonus *
-    (player.hasAugmentation(AugmentationNames.WKSharmonizer) ? 1.5 : 1) *
+    (player.hasAugmentation(AugmentationNames.WKSharmonizer, true) ? 1.5 : 1) *
     BitNodeMultipliers.InfiltrationMoney
   );
 }
@@ -35,7 +35,7 @@ export function calculateTradeInformationRepReward(
     Math.pow(difficulty, 3) *
     3e3 *
     levelBonus *
-    (player.hasAugmentation(AugmentationNames.WKSharmonizer) ? 1.5 : 1) *
+    (player.hasAugmentation(AugmentationNames.WKSharmonizer, true) ? 1.5 : 1) *
     BitNodeMultipliers.InfiltrationMoney
   );
 }
@@ -47,5 +47,7 @@ export function calculateInfiltratorsRepReward(player: IPlayer, faction: Faction
   }, 0);
   const baseRepGain = (difficulty / maxStartingSecurityLevel) * 5000;
 
-  return baseRepGain * (player.hasAugmentation(AugmentationNames.WKSharmonizer) ? 2 : 1) * (1 + faction.favor / 100);
+  return (
+    baseRepGain * (player.hasAugmentation(AugmentationNames.WKSharmonizer, true) ? 2 : 1) * (1 + faction.favor / 100)
+  );
 }

--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -94,7 +94,7 @@ export function Game(props: IProps): React.ReactElement {
     // it's clear they're not meant to
     const damage = options?.automated
       ? player.hp
-      : props.StartingDifficulty * 3 * (player.hasAugmentation(AugmentationNames.WKSharmonizer) ? 0.5 : 1);
+      : props.StartingDifficulty * 3 * (player.hasAugmentation(AugmentationNames.WKSharmonizer, true) ? 0.5 : 1);
     if (player.takeDamage(damage)) {
       router.toCity();
       return;

--- a/src/Infiltration/ui/GameTimer.tsx
+++ b/src/Infiltration/ui/GameTimer.tsx
@@ -24,7 +24,7 @@ interface IProps {
 export function GameTimer(props: IProps): React.ReactElement {
   const player = use.Player();
   const [v, setV] = useState(100);
-  const totalMillis = (player.hasAugmentation(AugmentationNames.WKSharmonizer) ? 1.3 : 1) * props.millis;
+  const totalMillis = (player.hasAugmentation(AugmentationNames.WKSharmonizer, true) ? 1.3 : 1) * props.millis;
 
   const tick = 200;
   useEffect(() => {


### PR DESCRIPTION
fixes the check to `hasAugmentation` to not include queued augmentations, so that the aug is only in effect once it's been installed