### PR TITLE
SLEEVES: Fix issues with Sleeve UI crashing when Sleeve task faction becomes gang faction

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -519,6 +519,14 @@ export class Sleeve extends Person {
           break;
         }
 
+        // If the player has a gang with the faction the sleeve is working
+        // for, we need to reset the sleeve's task
+        if (p.gang) {
+          if (fac.name === p.gang.facName) {
+            this.resetTaskStatus();
+          }
+        }
+
         fac.playerReputation += this.getRepGain(p) * cyclesUsed;
         break;
       }

--- a/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
+++ b/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
@@ -110,6 +110,8 @@ const tasks: {
       first: factions,
       second: (s1: string) => {
         const faction = Factions[s1];
+        if (!faction) return ["------"];
+
         const facInfo = faction.getInfo();
         const options: string[] = [];
         if (facInfo.offerHackingWork) {
@@ -260,7 +262,7 @@ export function TaskSelector(props: IProps): React.ReactElement {
     const detailsF = tasks[n];
     if (detailsF === undefined) throw new Error(`No function for task '${s0}'`);
     const details = detailsF(props.player, props.sleeve);
-    const details2 = details.second(details.first[0]);
+    const details2 = details.second(details.first[0]) ?? ["------"];
     setS2(details2[0]);
     setS1(details.first[0]);
     setS0(n);


### PR DESCRIPTION
fixes #3553 
fixes #3475 
fixes #3393 
fixes #3556

in the sleeve's `process` method, if the sleeve's current task type is `Faction`, a check will be run to see if the player has a gang, and if that gang is from the faction the sleeve is working for, the sleeve's task will be reset

in addition, a safeguard has been added to the UI to prevent crashes from occurring if the faction becomes a gang whilst the player is viewing the sleeves UI