### PR TITLE
UI: FIX #3313 Streamline the GraftingRoot page by making it rerender.

### DIFF
--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -1,6 +1,6 @@
 import { Construction, CheckBox, CheckBoxOutlineBlank } from "@mui/icons-material";
 import { Box, Button, Container, List, ListItemButton, Paper, Typography } from "@mui/material";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Augmentation } from "../../../Augmentation/Augmentation";
 import { Augmentations } from "../../../Augmentation/Augmentations";
 import { AugmentationNames } from "../../../Augmentation/data/AugmentationNames";
@@ -62,6 +62,16 @@ export const GraftingRoot = (): React.ReactElement => {
 
   const [selectedAug, setSelectedAug] = useState(getGraftingAvailableAugs(player)[0]);
   const [graftOpen, setGraftOpen] = useState(false);
+
+  const setRerender = useState(false)[1];
+  function rerender(): void {
+    setRerender((old) => !old);
+  }
+
+  useEffect(() => {
+    const id = setInterval(rerender, 200);
+    return () => clearInterval(id);
+  }, []);
 
   return (
     <Container disableGutters maxWidth="lg" sx={{ mx: 0 }}>


### PR DESCRIPTION
Fixes #3313 (Grafting UI allowed the player to go in-debt)
Also fix discomfort due to  button not enabling dynamically when the player reached the required amount of money.

Solution implemented :
Added re-rendering to the GraftingRoot page.

Testing : 
Graft button now dynamically enable/disable when player's money update above/below aug's price. (checked by running script in background)