### PR TITLE
INFILTRATION: Fix rep reward being substantially higher than intended

### DIFF
--- a/src/Infiltration/formulas/victory.ts
+++ b/src/Infiltration/formulas/victory.ts
@@ -31,9 +31,9 @@ export function calculateTradeInformationRepReward(
   const levelBonus = maxLevel * Math.pow(1.01, maxLevel);
 
   return (
-    Math.pow(reward + 1, 2) *
-    Math.pow(difficulty, 3) *
-    3e3 *
+    Math.pow(reward + 1, 1.1) *
+    Math.pow(difficulty, 1.2) *
+    30 *
     levelBonus *
     (player.hasAugmentation(AugmentationNames.WKSharmonizer, true) ? 1.5 : 1) *
     BitNodeMultipliers.InfiltrationMoney


### PR DESCRIPTION
Fixes the infiltration rep reward formula to no longer mirror the money formula

*old*
![image](https://user-images.githubusercontent.com/60761231/165196628-36154e6a-8d21-4063-bfc0-317405a803c7.png)

*new*
![image](https://user-images.githubusercontent.com/60761231/165196641-91381c3e-e996-4445-b80a-207d1363f4b1.png)
