### PR TITLE
AUGMENTATIONS: Fix `isSpecial` filter in helper (Removes NeuroFlux, Stanek's Gift, etc from gangs)

### DIFF
--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -144,7 +144,7 @@ export const getFactionAugmentationsFiltered = (player: IPlayer, faction: Factio
     let augs = Object.values(Augmentations);
 
     // Remove special augs
-    augs = augs.filter((a) => !a.isSpecial || a.name != AugmentationNames.CongruityImplant);
+    augs = augs.filter((a) => !a.isSpecial && a.name !== AugmentationNames.CongruityImplant);
 
     if (player.bitNodeN === 2) {
       // TRP is not available outside of BN2 for Gangs


### PR DESCRIPTION
Fixes the operator in the filter so that augs must meet both criteria