### PR TITLE
GRAFTING: Fix Grafting not being handled in singularity stop work

### DIFF
--- a/src/PersonObjects/IPlayer.ts
+++ b/src/PersonObjects/IPlayer.ts
@@ -291,6 +291,6 @@ export interface IPlayer {
   sourceFileLvl(n: number): number;
   startGraftAugmentationWork(augmentationName: string, time: number): void;
   graftAugmentationWork(numCycles: number): boolean;
-  finishGraftAugmentationWork(cancelled: boolean): string;
+  finishGraftAugmentationWork(cancelled: boolean, singularity?: boolean): string;
   applyEntropy(stacks?: number): void;
 }

--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -302,7 +302,7 @@ export class PlayerObject implements IPlayer {
   sourceFileLvl: (n: number) => number;
   startGraftAugmentationWork: (augmentationName: string, time: number) => void;
   graftAugmentationWork: (numCycles: number) => boolean;
-  finishGraftAugmentationWork: (cancelled: boolean) => string;
+  finishGraftAugmentationWork: (cancelled: boolean, singularity?: boolean) => string;
   applyEntropy: (stacks?: number) => void;
 
   constructor() {

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1364,7 +1364,7 @@ export function craftAugmentationWork(this: IPlayer, numCycles: number): boolean
   return false;
 }
 
-export function finishGraftAugmentationWork(this: IPlayer, cancelled: boolean): string {
+export function finishGraftAugmentationWork(this: IPlayer, cancelled: boolean, singularity = false): string {
   const augName = this.graftAugmentationName;
   if (cancelled === false) {
     applyAugmentation(Augmentations[augName]);
@@ -1378,7 +1378,7 @@ export function finishGraftAugmentationWork(this: IPlayer, cancelled: boolean): 
       `You've finished grafting ${augName}.<br>The augmentation has been applied to your body` +
         (this.hasAugmentation(AugmentationNames.CongruityImplant) ? "." : ", but you feel a bit off."),
     );
-  } else {
+  } else if (cancelled && singularity === false) {
     dialogBoxCreate(`You cancelled the grafting of ${augName}.<br>Your money was not returned to you.`);
   }
 
@@ -1699,6 +1699,9 @@ export function singularityStopWork(this: IPlayer): string {
       break;
     case CONSTANTS.WorkTypeCrime:
       res = this.finishCrime(true);
+      break;
+    case CONSTANTS.WorkTypeGraftAugmentation:
+      res = this.finishGraftAugmentationWork(true, true);
       break;
     default:
       console.error(`Unrecognized work type (${this.workType})`);


### PR DESCRIPTION
Allows Grafting to be cancelled via singularity

Also fixes issues where the player may be in an invalid work state, while not actually be working (players affected by this should be able to start and then stop any work action to rectify their player object)