### PR TITLE
MISC: Remove comments that describe nonexistent augs

### DIFF
--- a/src/Augmentation/data/AugmentationNames.ts
+++ b/src/Augmentation/data/AugmentationNames.ts
@@ -114,17 +114,6 @@ export enum AugmentationNames {
   StaneksGift2 = "Stanek's Gift - Awakening",
   StaneksGift3 = "Stanek's Gift - Serenity",
 
-  /*
-  MightOfAres = "Might of Ares", // slash
-  WisdomOfAthena = "Wisdom of Athena", // bracket
-  TrickeryOfHermes = "Trickery of Hermes", // cheatcode
-  BeautyOfAphrodite = "Beauty of Aphrodite", // bribe
-  ChaosOfDionysus = "Chaos of Dionysus", // reverse
-  FloodOfPoseidon = "Flood of Poseidon", // hex
-  HuntOfArtemis = "Hunt of Artemis", // mine
-  KnowledgeOfApollo = "Knowledge of Apollo", // wire
- */
-
   // Infiltrators MiniGames
   MightOfAres = "SoA - Might of Ares", // slash
   WisdomOfAthena = "SoA - Wisdom of Athena", // bracket
@@ -135,10 +124,4 @@ export enum AugmentationNames {
   HuntOfArtemis = "SoA - Hunt of Artemis", // mine
   KnowledgeOfApollo = "SoA - Knowledge of Apollo", // wire
   WKSharmonizer = "SoA - phyzical WKS harmonizer",
-
-  //Wasteland Augs
-  //PepBoy:                             "P.E.P-Boy", Plasma Energy Projection System
-  //PepBoyForceField Generates plasma force fields
-  //PepBoyBlasts Generate high density plasma concussive blasts
-  //PepBoyDataStorage STore more data on pep boy,
 }


### PR DESCRIPTION
Removes comments that describe nonexistent augs, as
the title states. Tested by making sure the game runs
and nothing more, because in theory this PR should do
absolutely nothing to the compiled version of the game.