### PR TITLE
CORPORATIONS: Expose makeProducts on NSDivision interface

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -295,6 +295,7 @@ export function NetscriptCorporation(
       if (office === 0) continue;
       cities.push(office.loc);
     }
+
     return {
       name: division.name,
       type: division.type,
@@ -309,6 +310,7 @@ export function NetscriptCorporation(
       upgrades: division.upgrades.slice(),
       cities: cities,
       products: division.products === undefined ? [] : Object.keys(division.products),
+      makesProducts: getDivision(division.name).makesProducts,
     };
   }
 

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -310,7 +310,7 @@ export function NetscriptCorporation(
       upgrades: division.upgrades.slice(),
       cities: cities,
       products: division.products === undefined ? [] : Object.keys(division.products),
-      makesProducts: getDivision(division.name).makesProducts,
+      makesProducts: division.makesProducts,
     };
   }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7202,6 +7202,8 @@ interface Division {
   cities: string[];
   /** Products developed by this division */
   products: string[];
+  /** Whether the industry this division is in is capable of making products */
+  makesProducts: boolean;
 }
 
 /**


### PR DESCRIPTION
`corp.makeProduct()` barfs if you try to make a product on an industry that does not make products (such as Agriculture). The game does not provide systematic access to what industries do and don't make products, so users are left to manually make maps, which sucks. 

Exposing this value fixes that.