### PR TITLE
MISC: Fixed typo in exceptionAlert.ts

### DIFF
--- a/src/utils/helpers/exceptionAlert.ts
+++ b/src/utils/helpers/exceptionAlert.ts
@@ -20,6 +20,6 @@ export function exceptionAlert(e: IError | string): void {
       "This is a bug, please report to game developer with this " +
       "message as well as details about how to reproduce the bug.<br><br>" +
       "If you want to be safe, I suggest refreshing the game WITHOUT saving so that your " +
-      "safe doesn't get corrupted",
+      "save doesn't get corrupted",
   );
 }


### PR DESCRIPTION
Corrects "your safe" to "your save" in exceptionAlert.ts
