### PR TITLE
CORPORATIONS: Expose sales cost on NSMaterial interface

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -359,6 +359,7 @@ export function NetscriptCorporation(
       const corporation = getCorporation();
       return {
         cost: material.bCost,
+        sCost: material.sCost,
         name: material.name,
         qty: material.qty,
         qlt: material.qlt,

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7111,6 +7111,8 @@ interface Material {
   sell: number;
   /** cost to buy material */
   cost: number;
+  /** Sell cost, can be "MP+5" */
+  sCost: string | number;
 }
 
 /**


### PR DESCRIPTION
There is no way to get sales cost of a material right now... thats pretty annoying. 