### PR TITLE
BUGFIX: Handle edge case in LZ compression code and fix docs

### DIFF
--- a/doc/source/basicgameplay/codingcontracts.rst
+++ b/doc/source/basicgameplay/codingcontracts.rst
@@ -336,12 +336,12 @@ The list contains the name of (i.e. the value returned by
 |                                         | |                                                                                        |
 |                                         | | You are given an LZ-encoded string. Decode it and output the original string.          |
 |                                         | |                                                                                        |
-|                                         | | Example: decoding '5aaabc340533bca' chunk-by-chunk                                     |
-|                                         | |  5aaabc           ->  aaabc                                                            |
-|                                         | |  5aaabc34         ->  aaabcaab                                                         |
-|                                         | |  5aaabc340        ->  aaabcaab                                                         |
-|                                         | |  5aaabc34053      ->  aaabcaabaabaa                                                    |
-|                                         | |  5aaabc340533bca  ->  aaabcaabaabaabca                                                 |
+|                                         | | Example: decoding '5aaabb450723abb' chunk-by-chunk                                     |
+|                                         | |  5aaabb           ->  aaabb                                                            |
+|                                         | |  5aaabb45         ->  aaabbaaab                                                        |
+|                                         | |  5aaabb450        ->  aaabbaaab                                                        |
+|                                         | |  5aaabb45072      ->  aaabbaaababababa                                                 |
+|                                         | |  5aaabb450723abb  ->  aaabbaaababababaabb                                              |
 +-----------------------------------------+------------------------------------------------------------------------------------------+
 | Compression III: LZ Compression         | | Lempel-Ziv (LZ) compression is a data compression technique which encodes data using   |
 |                                         | | references to earlier parts of the data. In this variant of LZ, data is encoded in two |
@@ -361,12 +361,12 @@ The list contains the name of (i.e. the value returned by
 |                                         | | possible output length.                                                                |
 |                                         | |                                                                                        |
 |                                         | | Examples (some have other possible encodings of minimal length):                       |
-|                                         | |  abracadabra    ->  7abracad47                                                         |
-|                                         | |  mississippi    ->  4miss433ppi                                                        |
-|                                         | |  aAAaAAaAaAA    ->  3aAA53035                                                          |
-|                                         | |  2718281828     ->  627182844                                                          |
-|                                         | |  abcdefghijk    ->  9abcdefghi02jk                                                     |
-|                                         | |  aaaaaaaaaaa    ->  1a911a                                                             |
-|                                         | |  aaaaaaaaaaaa   ->  1a912aa                                                            |
-|                                         | |  aaaaaaaaaaaaa  ->  1a91031                                                            |
+|                                         | |  abracadabra     ->  7abracad47                                                        |
+|                                         | |  mississippi     ->  4miss433ppi                                                       |
+|                                         | |  aAAaAAaAaAA     ->  3aAA53035                                                         |
+|                                         | |  2718281828      ->  627182844                                                         |
+|                                         | |  abcdefghijk     ->  9abcdefghi02jk                                                    |
+|                                         | |  aaaaaaaaaaaa    ->  3aaa91                                                            |
+|                                         | |  aaaaaaaaaaaaa   ->  1a91031                                                           |
+|                                         | |  aaaaaaaaaaaaaa  ->  1a91041                                                           |
 +-----------------------------------------+------------------------------------------------------------------------------------------+

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -1532,7 +1532,8 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
           length += 2;
         }
       }
-      return ans.length === length;
+
+      return ans.length <= length;
     },
   },
   {
@@ -1555,12 +1556,12 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         "You are given the following LZ-encoded string:\n",
         `&nbsp; &nbsp; ${compressed}\n`,
         "Decode it and output the original string.\n\n",
-        "Example: decoding '5aaabc340533bca' chunk-by-chunk\n",
-        "&nbsp; &nbsp; 5aaabc &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; -> &nbsp;aaabc\n",
-        "&nbsp; &nbsp; 5aaabc34 &nbsp; &nbsp; &nbsp; &nbsp; -> &nbsp;aaabcaab\n",
-        "&nbsp; &nbsp; 5aaabc340 &nbsp; &nbsp; &nbsp; &nbsp;-> &nbsp;aaabcaab\n",
-        "&nbsp; &nbsp; 5aaabc34053 &nbsp; &nbsp; &nbsp;-> &nbsp;aaabcaabaabaa\n",
-        "&nbsp; &nbsp; 5aaabc340533bca &nbsp;-> &nbsp;aaabcaabaabaabca",
+        "Example: decoding '5aaabb450723abb' chunk-by-chunk\n",
+        "&nbsp; &nbsp; 5aaabb &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; -> &nbsp;aaabb\n",
+        "&nbsp; &nbsp; 5aaabb45 &nbsp; &nbsp; &nbsp; &nbsp; -> &nbsp;aaabbaaab\n",
+        "&nbsp; &nbsp; 5aaabb450 &nbsp; &nbsp; &nbsp; &nbsp;-> &nbsp;aaabbaaab\n",
+        "&nbsp; &nbsp; 5aaabb45072 &nbsp; &nbsp; &nbsp;-> &nbsp;aaabbaaababababa\n",
+        "&nbsp; &nbsp; 5aaabb450723abb &nbsp;-> &nbsp;aaabbaaababababaabb",
       ].join(" ");
     },
     gen: (): string => {
@@ -1591,21 +1592,21 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         `&nbsp; &nbsp; ${plaintext}\n`,
         "Encode it using Lempel-Ziv encoding with the minimum possible output length.\n\n",
         "Examples (some have other possible encodings of minimal length):\n",
-        "&nbsp; &nbsp; abracadabra &nbsp; &nbsp;-> &nbsp;7abracad47\n",
-        "&nbsp; &nbsp; mississippi &nbsp; &nbsp;-> &nbsp;4miss433ppi\n",
-        "&nbsp; &nbsp; aAAaAAaAaAA &nbsp; &nbsp;-> &nbsp;3aAA53035\n",
-        "&nbsp; &nbsp; 2718281828 &nbsp; &nbsp; -> &nbsp;627182844\n",
-        "&nbsp; &nbsp; abcdefghijk &nbsp; &nbsp;-> &nbsp;9abcdefghi02jk\n",
-        "&nbsp; &nbsp; aaaaaaaaaaa &nbsp; &nbsp;-> &nbsp;1a911a\n",
-        "&nbsp; &nbsp; aaaaaaaaaaaa &nbsp; -> &nbsp;1a912aa\n",
-        "&nbsp; &nbsp; aaaaaaaaaaaaa &nbsp;-> &nbsp;1a91031",
+        "&nbsp; &nbsp; abracadabra &nbsp; &nbsp; -> &nbsp;7abracad47\n",
+        "&nbsp; &nbsp; mississippi &nbsp; &nbsp; -> &nbsp;4miss433ppi\n",
+        "&nbsp; &nbsp; aAAaAAaAaAA &nbsp; &nbsp; -> &nbsp;3aAA53035\n",
+        "&nbsp; &nbsp; 2718281828 &nbsp; &nbsp; &nbsp;-> &nbsp;627182844\n",
+        "&nbsp; &nbsp; abcdefghijk &nbsp; &nbsp; -> &nbsp;9abcdefghi02jk\n",
+        "&nbsp; &nbsp; aaaaaaaaaaaa &nbsp; &nbsp;-> &nbsp;3aaa91\n",
+        "&nbsp; &nbsp; aaaaaaaaaaaaa &nbsp; -> &nbsp;1a91031\n",
+        "&nbsp; &nbsp; aaaaaaaaaaaaaa &nbsp;-> &nbsp;1a91041",
       ].join(" ");
     },
     gen: (): string => {
       return comprLZGenerate();
     },
     solver: (plain: string, ans: string): boolean => {
-      return comprLZDecode(ans) === plain && ans.length === comprLZEncode(plain).length;
+      return comprLZDecode(ans) === plain && ans.length <= comprLZEncode(plain).length;
     },
   },
 ];

--- a/src/utils/CompressionContracts.ts
+++ b/src/utils/CompressionContracts.ts
@@ -105,6 +105,13 @@ export function comprLZEncode(plain: string): string {
 
         // start new literal
         set(new_state, 0, 1, string + length + offset);
+
+        // end current backreference and start new backreference
+        for (let new_offset = 1; new_offset <= Math.min(9, i); ++new_offset) {
+          if (plain[i - new_offset] === c) {
+            set(new_state, new_offset, 1, string + length + offset + "0");
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Add code to handle edge case in `comprLZEncode`.

Fix incorrect examples in documentation for Compression III contract

Fix example in Compression II not being an encoding of minimal length.