### PR TITLE
MISC: #3596 Enhanced terminal command parsing

### DIFF
--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -64,7 +64,7 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
         lastQuote = c;
         // Otherwise if we're in a string argument, add the current character to it
       } else {
-      	arg += c;
+        arg += c;
       }
       // If the current character is a space and we are not inside a string, parse the current argument
       // and start a new one

--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -1,17 +1,17 @@
 import { KEY } from "../utils/helpers/keyCodes";
 import { substituteAliases } from "../Alias";
 // Helper function to parse individual arguments into number/boolean/string as appropriate
-function parseArg(arg) {
+function parseArg(arg: string): string | number | boolean {
   // Handles all numbers including hexadecimal, octal, and binary representations, returning NaN on an unparseable string
   const asNumber = Number(arg);
   if (!isNaN(asNumber)) {
     return asNumber;
   }
-  
+
   if (arg === 'true' || arg === 'false') {
     return arg === 'true';
   }
-  
+
   // Strip quotation marks from strings that begin/end with the same mark
   return arg.replace(/^"(.*?)"$/g, '$1').replace(/^'(.*?)'$/g, '$1');
 }
@@ -44,14 +44,14 @@ export function ParseCommands(commands: string): string[] {
 export function ParseCommand(command: string): (string | number | boolean)[] {
   let idx = 0;
   const args = [];
-  
+
   // Track depth of quoted strings, e.g.: "the're 'going away' rather 'quickly \"and awkwardly\"'" should be parsed as a single string
-  const quotes = [];
-  
+  const quotes: string[] = [];
+
   let arg = '';
   while (idx < command.length) {
     const c = command.charAt(idx);
-    
+
     // If the current character is a backslash, add the next character verbatim to the argument
     if (c === '\\') {
       arg += command.charAt(++idx);
@@ -89,20 +89,20 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
     // and start a new one
     } else if (c === KEY.SPACE && quotes.length === 0) {
       args.push(parseArg(arg));
-      
+
       arg = '';
     } else {
       // Add the current character to the current argument
       arg += c;
     }
-    
+
     idx++;
   }
-  
+
   // Add the last arg (if any)
   if (arg !== '') {
-  	args.push(parseArg(arg));
+    args.push(parseArg(arg));
   }
-  
+
   return args;
 }

--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -8,12 +8,12 @@ function parseArg(arg: string): string | number | boolean {
     return asNumber;
   }
 
-  if (arg === 'true' || arg === 'false') {
-    return arg === 'true';
+  if (arg === "true" || arg === "false") {
+    return arg === "true";
   }
 
   // Strip quotation marks from strings that begin/end with the same mark
-  return arg.replace(/^"(.*?)"$/g, '$1').replace(/^'(.*?)'$/g, '$1');
+  return arg.replace(/^"(.*?)"$/g, "$1").replace(/^'(.*?)'$/g, "$1");
 }
 
 export function ParseCommands(commands: string): string[] {
@@ -48,14 +48,14 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
   // Track depth of quoted strings, e.g.: "the're 'going away' rather 'quickly \"and awkwardly\"'" should be parsed as a single string
   const quotes: string[] = [];
 
-  let arg = '';
+  let arg = "";
   while (idx < command.length) {
     const c = command.charAt(idx);
 
     // If the current character is a backslash, add the next character verbatim to the argument
-    if (c === '\\') {
+    if (c === "\\") {
       arg += command.charAt(++idx);
-    // If the current character is a single- or double-quote mark, add it to the current argument.
+      // If the current character is a single- or double-quote mark, add it to the current argument.
     } else if (c === KEY.DOUBLE_QUOTE || c === KEY.QUOTE) {
       arg += c;
       const quote = quotes[quotes.length - 1];
@@ -65,32 +65,28 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
       // If we're already in a quoted string, push onto the stack of string starts to track depth.
       if (
         c !== quote &&
-        (
-          prev === KEY.SPACE ||
+        (prev === KEY.SPACE ||
           prev === KEY.EQUAL ||
           (c === KEY.DOUBLE_QUOTE && prev === KEY.QUOTE) ||
-          (c === KEY.QUOTE && prev === KEY.DOUBLE_QUOTE)
-        )
+          (c === KEY.QUOTE && prev === KEY.DOUBLE_QUOTE))
       ) {
         quotes.push(c);
-      // If the next character is a space and the current character is the same as the previously used
-      // quotation mark, this is a valid end to a string. Pop off the depth tracker.
+        // If the next character is a space and the current character is the same as the previously used
+        // quotation mark, this is a valid end to a string. Pop off the depth tracker.
       } else if (
         c === quote &&
-        (
-          next === KEY.SPACE ||
+        (next === KEY.SPACE ||
           (c === KEY.DOUBLE_QUOTE && next === KEY.QUOTE) ||
-          (c === KEY.QUOTE && next === KEY.DOUBLE_QUOTE)
-        )
+          (c === KEY.QUOTE && next === KEY.DOUBLE_QUOTE))
       ) {
         quotes.pop();
       }
-    // If the current character is a space and we are not inside a string, parse the current argument
-    // and start a new one
+      // If the current character is a space and we are not inside a string, parse the current argument
+      // and start a new one
     } else if (c === KEY.SPACE && quotes.length === 0) {
       args.push(parseArg(arg));
 
-      arg = '';
+      arg = "";
     } else {
       // Add the current character to the current argument
       arg += c;
@@ -100,7 +96,7 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
   }
 
   // Add the last arg (if any)
-  if (arg !== '') {
+  if (arg !== "") {
     args.push(parseArg(arg));
   }
 

--- a/src/utils/helpers/keyCodes.ts
+++ b/src/utils/helpers/keyCodes.ts
@@ -25,6 +25,7 @@ export enum KEY {
   CLOSE_PARENTHESIS = ")",
   OPEN_BRACE = "{",
   CLOSE_BRACE = "}",
+  EQUAL = "=",
 
   PIPE = "|",
   DOT = ".",


### PR DESCRIPTION
This is a partial fix for #3596 in that it does not address the autocomplete issues identified, but it does address terminal command parsing in order to allow joining what would be split arguments before into single arguments if they were separated by an escaped space.

```sh
# before
$ run script.js single\ argument
Running script with 1 thread(s), pid 1 and args: ["single\\", "argument"].

# after
$ run script.js single\ argument
Running script with 1 thread(s), pid 1 and args: ["single argument"]
```

Other command parsing improvements included in this PR:

- Additional JS numeric literal formats are now supported by using the Number constructor instead of parseFloat, so hexadecimal, octal, and binary number representations can be used as arguments
- Nested quoting in quoted arguments is handled properly, e.g.: `"quoted arg 'with nested \"quoting\" gets parsed as a single arg'"`
  - also does not break on apostrophes inside of arguments

I attempted to create a unit test suite in order to verify functionality beyond my testing in the browser while I was refactoring the `ParseCommand` function, but compilation of the test failed while trying to resolve an import in a file I didn't touch. I've included the error I got below, if anyone has any suggestions on how to get around that I'd be more than happy to add a unit test suite.

```
$ npm run test Terminal/Parser

> bitburner@1.6.4 test
> jest "Terminal/Parser"

 FAIL  test/jest/Terminal/Parser.test.ts
  ● Test suite failed to run

    Cannot find module '!!raw-loader!../NetscriptDefinitions.d.ts' from 'src/ScriptEditor/ui/ScriptEditorRoot.tsx'

    Require stack:
      src/ScriptEditor/ui/ScriptEditorRoot.tsx
      src/ui/GameRoot.tsx
      src/NetscriptFunctions/Grafting.ts
      src/NetscriptFunctions.ts
      src/NetscriptWorker.ts
      src/Prestige.ts
      src/Augmentation/AugmentationHelpers.tsx
      src/Faction/FactionHelpers.tsx
      src/Bladeburner/Bladeburner.tsx
      src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
      src/PersonObjects/Player/PlayerObject.ts
      src/Player.ts
      src/DarkWeb/DarkWeb.tsx
      src/Terminal/Terminal.ts
      src/Terminal.ts
      src/Alias.ts
      src/Terminal/Parser.ts
      test/jest/Terminal/Parser.test.ts

      43 | import { Modal } from "../../ui/React/Modal";
      44 |
    > 45 | import libSource from "!!raw-loader!../NetscriptDefinitions.d.ts";
         | ^
      46 | import { TextField, Tooltip } from "@mui/material";
      47 |
      48 | interface IProps {

      at Resolver.resolveModule (node_modules/jest-resolve/build/resolver.js:322:11)
      at Object.<anonymous> (src/ScriptEditor/ui/ScriptEditorRoot.tsx:45:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        17.149 s
Ran all test suites matching /Terminal\\Parser/i.
```