### PR TITLE
API: Add safeguard to ns.killall(), preventing killing itself by default

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5311,9 +5311,10 @@ export interface NS {
    * If no host is defined, it will kill all scripts, where the script is running.
    *
    * @param host - IP or hostname of the server on which to kill all scripts.
+   * @param safetyguard - Skips the script that calls this function
    * @returns True if any scripts were killed, and false otherwise.
    */
-  killall(host?: string): boolean;
+  killall(host?: string, safetyguard?: boolean): boolean;
 
   /**
    * Terminates the current script immediately.


### PR DESCRIPTION
# QoL improvement
`ns.killall()` receives a safeguard (on by default) that prevents killing the calling script.
This way it behaves more like beginners expect it to when called on the server the script is ran on.
Besides that it removes the need for a workaround kill script that deletes everything but it's own PID.

## Linked issues
No linked issue, based on user feedback from Discord.

## Tests
Ran with the toggle on and off, toggled off it behaves like before,
With toggle on (default) the called script keeps running, but everything else on the targeted server dies.