### PR TITLE
AUGMENTATIONS: Tweak a couple small UI elements

### DIFF
--- a/src/Augmentation/ui/PurchasableAugmentations.tsx
+++ b/src/Augmentation/ui/PurchasableAugmentations.tsx
@@ -219,6 +219,7 @@ export function PurchasableAugmentation(props: IPurchasableAugProps): React.Reac
                   textOverflow: "ellipsis",
                   whiteSpace: "nowrap",
                   overflow: "hidden",
+                  color: props.owned ? Settings.theme.disabled : Settings.theme.primary,
                 }}
               >
                 {aug.name}

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -145,7 +145,7 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
     <>
       <Container disableGutters maxWidth="lg" sx={{ mx: 0 }}>
         <Button onClick={props.routeToMainPage}>Back</Button>
-        <Typography variant="h4">Faction Augmentations</Typography>
+        <Typography variant="h4">Faction Augmentations - {props.faction.name}</Typography>
         <Paper sx={{ p: 1, mb: 1 }}>
           <Typography>
             These are all of the Augmentations that are available to purchase from <b>{props.faction.name}</b>.


### PR DESCRIPTION
adjusts the text color of purchased augmentations for readability

adds the current faction name to the top of the augmentations page for ease of access

![image](https://user-images.githubusercontent.com/60761231/166944846-dab5fa3e-780c-465c-9e49-9484b7122f4e.png)
