### PR TITLE
UI: Sort and color Graft Augmentation list

### DIFF
--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -95,9 +95,9 @@ export const GraftingRoot = (): React.ReactElement => {
         {getGraftingAvailableAugs(player).length > 0 ? (
           <Paper sx={{ my: 1, width: "fit-content", display: "grid", gridTemplateColumns: "1fr 3fr" }}>
             <List sx={{ height: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
-              {getGraftingAvailableAugs(player).map((k, i) => (
+              {getGraftingAvailableAugs(player).sort((a, b) => GraftableAugmentations[a].cost - GraftableAugmentations[b].cost).map((k, i) => (
                 <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
-                  <Typography>{k}</Typography>
+                  <Typography sx={{color: canGraft(player, GraftableAugmentations[k]) ? Settings.theme.primary : Settings.theme.disabled}}>{k}</Typography>
                 </ListItemButton>
               ))}
             </List>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -95,11 +95,21 @@ export const GraftingRoot = (): React.ReactElement => {
         {getGraftingAvailableAugs(player).length > 0 ? (
           <Paper sx={{ my: 1, width: "fit-content", display: "grid", gridTemplateColumns: "1fr 3fr" }}>
             <List sx={{ height: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
-              {getGraftingAvailableAugs(player).sort((a, b) => GraftableAugmentations[a].cost - GraftableAugmentations[b].cost).map((k, i) => (
-                <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
-                  <Typography sx={{color: canGraft(player, GraftableAugmentations[k]) ? Settings.theme.primary : Settings.theme.disabled}}>{k}</Typography>
-                </ListItemButton>
-              ))}
+              {getGraftingAvailableAugs(player)
+                .sort((a, b) => GraftableAugmentations[a].cost - GraftableAugmentations[b].cost)
+                .map((k, i) => (
+                  <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
+                    <Typography
+                      sx={{
+                        color: canGraft(player, GraftableAugmentations[k])
+                          ? Settings.theme.primary
+                          : Settings.theme.disabled,
+                      }}
+                    >
+                      {k}
+                    </Typography>
+                  </ListItemButton>
+                ))}
             </List>
             <Box sx={{ m: 1 }}>
               <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>


### PR DESCRIPTION
Changed the Graft Augmentation list to be sorted by costs and show availability by color.

![image](https://user-images.githubusercontent.com/23121671/167041286-cca191e3-1f80-4919-90eb-ed52df51db93.png)
