### PR TITLE
API: Terminal screen can now be cleared from within scripts with ns.ui.clearTerminal()

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -51,6 +51,7 @@ export const RamCostConstants: IMap<number> = {
   ScriptCodingContractBaseRamCost: 10,
   ScriptSleeveBaseRamCost: 4,
   ScriptGetOwnedSourceFiles: 5,
+  ScriptClearTerminalCost: 0.2,
 
   ScriptSingularityFn1RamCost: 2,
   ScriptSingularityFn2RamCost: 3,
@@ -358,6 +359,7 @@ export const RamCosts: IMap<any> = {
   enableLog: 0,
   isLogEnabled: 0,
   getScriptLogs: 0,
+  clearTerminal: RamCostConstants.ScriptClearTerminalCost,
   nuke: RamCostConstants.ScriptPortProgramRamCost,
   brutessh: RamCostConstants.ScriptPortProgramRamCost,
   ftpcrack: RamCostConstants.ScriptPortProgramRamCost,

--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -14,6 +14,7 @@ import { defaultTheme } from "../Themes/Themes";
 import { defaultStyles } from "../Themes/Styles";
 import { CONSTANTS } from "../Constants";
 import { hash } from "../hash/hash";
+import { Terminal } from "../../src/Terminal";
 
 export function NetscriptUserInterface(
   player: IPlayer,
@@ -107,6 +108,11 @@ export function NetscriptUserInterface(
       };
 
       return gameInfo;
+    },
+
+    clearTerminal: function (): void {
+      updateRam("clearTerminal");
+      Terminal.clear();
     },
   };
 }

--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -112,6 +112,7 @@ export function NetscriptUserInterface(
 
     clearTerminal: function (): void {
       updateRam("clearTerminal");
+      workerScript.log("ui.clearTerminal", () => `Clearing terminal`);
       Terminal.clear();
     },
   };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4395,7 +4395,7 @@ interface UserInterface {
   /**
    * Clear the Terminal window, as if the player ran `clear` in the terminal
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.2 GB
    */
   clearTerminal(): void;
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4391,6 +4391,13 @@ interface UserInterface {
    * RAM cost: 0 GB
    */
   getGameInfo(): GameInfo;
+
+  /**
+   * Clear the Terminal window, as if the player ran `clear` in the terminal
+   * @remarks
+   * RAM cost: 0 GB
+   */
+  clearTerminal(): void;
 }
 
 /**


### PR DESCRIPTION
# API addition

## Based on
User request from Discord:
![Screenshot of user request](https://user-images.githubusercontent.com/19653491/167116942-ea7e3640-8b81-41ff-b33c-5a6f8d9682bb.png)

## Tests

- Verified to work when in other screens than Terminal
- Log result tested
- RAM usage of script verified
- `npm run format` and `npm run lint` were ran
