### PR TITLE
MISC: FIX #3593 Float errors can no longer prevent full usage of a server's available ram.

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -84,7 +84,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
       if (script.filename === cbScript) {
         const ramUsage = script.ramUsage;
         const ramAvailable = home.maxRam - home.ramUsed;
-        if (ramUsage > ramAvailable) {
+        if (ramUsage > ramAvailable + 0.001) {
           return; // Not enough RAM
         }
         const runningScriptObj = new RunningScript(script, []); // No args

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -532,7 +532,7 @@ function createAndAddWorkerScript(
   const oneRamUsage = getRamUsageFromRunningScript(runningScriptObj);
   const ramUsage = roundToTwo(oneRamUsage * threads);
   const ramAvailable = server.maxRam - server.ramUsed;
-  if (ramUsage > ramAvailable) {
+  if (ramUsage > ramAvailable + 0.001) {
     dialogBoxCreate(
       `Not enough RAM to run script ${runningScriptObj.filename} with args ` +
         `${arrayToString(runningScriptObj.args)}. This likely occurred because you re-loaded ` +
@@ -750,7 +750,7 @@ export function runScriptFromScript(
     if (server.hasAdminRights == false) {
       workerScript.log(caller, () => `You do not have root access on '${server.hostname}'`);
       return 0;
-    } else if (ramUsage > ramAvailable) {
+    } else if (ramUsage > ramAvailable + 0.001) {
       workerScript.log(
         caller,
         () =>

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -65,11 +65,9 @@ export function runScript(
 
     if (ramUsage > ramAvailable + 0.001) {
       terminal.error(
-        "This machine does not have enough RAM to run this script with " +
-          numThreads +
-          " threads. Script requires " +
-          numeralWrapper.formatRAM(ramUsage) +
-          " of RAM",
+        "This machine does not have enough RAM to run this script" +
+          (numThreads === 1 ? "" : ` with ${numThreads} threads`) +
+          `. Script requires ${numeralWrapper.formatRAM(ramUsage)} of RAM`,
       );
       return;
     }

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -63,7 +63,7 @@ export function runScript(
       return;
     }
 
-    if (ramUsage > ramAvailable) {
+    if (ramUsage > ramAvailable + 0.001) {
       terminal.error(
         "This machine does not have enough RAM to run this script with " +
           numThreads +


### PR DESCRIPTION
Fixes #3593 

1MB added to available ram when checking if available is sufficient for running a script. All actual ram values in game are a multiple of 50MB so an extra 1MB can't ever allow additional script load to be ran, but it does counteract floating point errors like that described in issue #3593 .

Also unrelated but in nearby code, address issue mentioned on discord (https://discord.com/channels/415207508303544321/921120989000114257/971233305020231722) - only mention # of threads if it was not 1. 

![image](https://user-images.githubusercontent.com/84951833/167138831-c56082cb-3d60-4aa3-822a-8c11f5237e11.png)