### PR TITLE
UI: Add a quick re-buy option on ascension modal

### DIFF
--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -252,7 +252,6 @@ export class Gang implements IGang {
         const total = Object.values(AllGangs)
           .map((g) => g.territory)
           .reduce((p, c) => p + c, 0);
-        console.log(total);
         Object.values(AllGangs).forEach((g) => (g.territory /= total));
       }
     }

--- a/src/Gang/ui/AscensionModal.tsx
+++ b/src/Gang/ui/AscensionModal.tsx
@@ -118,7 +118,7 @@ export function AscensionModal(props: IProps): React.ReactElement {
             confirm(true);
           }}
         >
-          Ascend + Re-Equip
+          Ascend and re-purchase upgrade.
         </Button>
       </Tooltip>
     </Modal>

--- a/src/Gang/ui/AscensionModal.tsx
+++ b/src/Gang/ui/AscensionModal.tsx
@@ -33,14 +33,17 @@ export function AscensionModal(props: IProps): React.ReactElement {
 
   function confirm(reEquip = false): void {
     props.onAscend();
-    const arrEquipement = Object.assign([], reEquip ? props.member.upgrades : null);
+    const arrEquipment = Object.assign([], reEquip ? props.member.upgrades : null);
     const res = gang.ascendMember(props.member);
-    arrEquipement?.forEach((equipement) => {
-      const upg = GangMemberUpgrades[equipement];
-      if (player.money >= gang.getUpgradeCost(upg)) {
-        props.member.buyUpgrade(upg, player, gang);
-      }
-    });
+
+    if (arrEquipment) {
+      arrEquipment.forEach((equipment) => {
+        const upg = GangMemberUpgrades[equipment];
+        if (player.money >= gang.getUpgradeCost(upg)) {
+          props.member.buyUpgrade(upg, player, gang);
+        }
+      });
+    }
 
     dialogBoxCreate(
       <>
@@ -112,13 +115,13 @@ export function AscensionModal(props: IProps): React.ReactElement {
       >
         Ascend
       </Button>
-      <Tooltip title={<Typography>Will attempt to buy back all current upgrade after ascending.</Typography>}>
+      <Tooltip title={<Typography>Will attempt to buy back all current upgrades after ascending.</Typography>}>
         <Button
           onClick={() => {
             confirm(true);
           }}
         >
-          Ascend and re-purchase upgrade.
+          Ascend and re-purchase upgrades.
         </Button>
       </Tooltip>
     </Modal>

--- a/src/Gang/ui/AscensionModal.tsx
+++ b/src/Gang/ui/AscensionModal.tsx
@@ -10,6 +10,9 @@ import { Modal } from "../../ui/React/Modal";
 import { useGang } from "./Context";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
+import { GangMemberUpgrades } from "../GangMemberUpgrades";
+import { use } from "../../ui/Context";
+import Tooltip from "@mui/material/Tooltip";
 
 interface IProps {
   open: boolean;
@@ -20,6 +23,7 @@ interface IProps {
 
 export function AscensionModal(props: IProps): React.ReactElement {
   const gang = useGang();
+  const player = use.Player();
   const setRerender = useState(false)[1];
 
   useEffect(() => {
@@ -27,9 +31,17 @@ export function AscensionModal(props: IProps): React.ReactElement {
     return () => clearInterval(id);
   }, []);
 
-  function confirm(): void {
+  function confirm(reEquip = false): void {
     props.onAscend();
+    const arrEquipement = Object.assign([], reEquip ? props.member.upgrades : null);
     const res = gang.ascendMember(props.member);
+    arrEquipement?.forEach((equipement) => {
+      const upg = GangMemberUpgrades[equipement];
+      if (player.money >= gang.getUpgradeCost(upg)) {
+        props.member.buyUpgrade(upg, player, gang);
+      }
+    });
+
     dialogBoxCreate(
       <>
         You ascended {props.member.name}!<br />
@@ -92,7 +104,23 @@ export function AscensionModal(props: IProps): React.ReactElement {
         {numeralWrapper.format(postAscend.cha, "0.000")}
         <br />
       </Typography>
-      <Button onClick={confirm}>Ascend</Button>
+      <Button
+        onClick={() => {
+          confirm();
+        }}
+        sx={{ mr: 1 }}
+      >
+        Ascend
+      </Button>
+      <Tooltip title={<Typography>Will attempt to buy back all current upgrade after ascending.</Typography>}>
+        <Button
+          onClick={() => {
+            confirm(true);
+          }}
+        >
+          Ascend + Re-Equip
+        </Button>
+      </Tooltip>
     </Modal>
   );
 }


### PR DESCRIPTION
Add a button to the Gang Ascension modal allowing for quick re-purchasing of upgrade owned by the gang member.

Also, some old territory-related console.log() was running in the background. => deleted it.

![image](https://user-images.githubusercontent.com/104104269/167276205-07ee365a-4b3b-43a8-a530-90d004567544.png)

Known issue : 
the button Tooltip is overshadowed by Modal => already handled by nickofolas in PR#3620

Testing : 
Vanilla Ascend button still work as intended.
Re-purchasing works as intended. No uprade is given for free, no negative money shenanigan, etc...