### PR TITLE
UI: FIX #2829 Remove defeated NPC gangs from territory page

### DIFF
--- a/src/Gang/ui/TerritorySubpage.tsx
+++ b/src/Gang/ui/TerritorySubpage.tsx
@@ -86,7 +86,11 @@ export function TerritorySubpage(): React.ReactElement {
       </Box>
       <Box sx={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)" }}>
         {gangNames
-          .filter((name) => AllGangs[name].territory > 0)
+          .sort((a, b) => {
+            if (AllGangs[a].territory <= 0 && AllGangs[b].territory > 0) return 1;
+            if (AllGangs[a].territory > 0 && AllGangs[b].territory <= 0) return -1;
+            return 0;
+          })
           .map((name) => (
             <OtherGangTerritory key={name} name={name} />
           ))}
@@ -116,14 +120,16 @@ function OtherGangTerritory(props: ITerritoryProps): React.ReactElement {
   const playerPower = AllGangs[gang.facName].power;
   const power = AllGangs[props.name].power;
   const clashVictoryChance = playerPower / (power + playerPower);
+  const territory = AllGangs[props.name].territory;
+  const opacity = territory ? 1 : 0.75;
   return (
-    <Box component={Paper} sx={{ p: 1 }}>
+    <Box component={Paper} sx={{ p: 1, opacity }}>
       <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
         {props.name}
       </Typography>
       <Typography>
         <b>Power:</b> {formatNumber(power, 3)} <br />
-        <b>Territory:</b> {formatTerritory(AllGangs[props.name].territory)}% <br />
+        <b>Territory:</b> {formatTerritory(territory)}% <br />
         <b>Clash Win Chance:</b> {numeralWrapper.formatPercentage(clashVictoryChance, 3)}
       </Typography>
     </Box>

--- a/src/Gang/ui/TerritorySubpage.tsx
+++ b/src/Gang/ui/TerritorySubpage.tsx
@@ -85,9 +85,11 @@ export function TerritorySubpage(): React.ReactElement {
         </Typography>
       </Box>
       <Box sx={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)" }}>
-        {gangNames.map((name) => (
-          <OtherGangTerritory key={name} name={name} />
-        ))}
+        {gangNames
+          .filter((name) => AllGangs[name].territory > 0)
+          .map((name) => (
+            <OtherGangTerritory key={name} name={name} />
+          ))}
       </Box>
       <TerritoryInfoModal open={infoOpen} onClose={() => setInfoOpen(false)} />
     </Container>


### PR DESCRIPTION
fixes #2829 
Filters non player gangs with 0 territory out of the territory list, screenshots below:
![0-gangs](https://user-images.githubusercontent.com/20649301/167315748-e80542bc-5b6c-4613-bcac-159e1ba04342.PNG)
![1-gang](https://user-images.githubusercontent.com/20649301/167315750-45d49052-6b60-4b58-8230-62e915b84868.PNG)
![2-gangs](https://user-images.githubusercontent.com/20649301/167315751-df4d63d1-d069-4da8-901d-5fdfe2ae3451.PNG)
![3-gangs](https://user-images.githubusercontent.com/20649301/167315752-69aef46f-eb15-4102-a59e-db55bfbda515.PNG)
![4-gangs](https://user-images.githubusercontent.com/20649301/167315753-38239dea-1d11-45cf-b07e-9efc6dd8e19c.PNG)
![5-gangs](https://user-images.githubusercontent.com/20649301/167315754-62f69929-4395-47d1-a8b6-26c6d84e39b2.PNG)
![6-gangs](https://user-images.githubusercontent.com/20649301/167315755-351337a8-0eb4-4f0b-b067-c4528bff099a.PNG)
