### PR TITLE
UI: FIX #2741 Allow using modifier keys inside the typing infiltration

### DIFF
--- a/src/Infiltration/ui/BackwardGame.tsx
+++ b/src/Infiltration/ui/BackwardGame.tsx
@@ -38,10 +38,7 @@ export function BackwardGame(props: IMinigameProps): React.ReactElement {
   const hasAugment = Player.hasAugmentation(AugmentationNames.ChaosOfDionysus, true);
 
   function ignorableKeyboardEvent(event: KeyboardEvent): boolean {
-    return event.key === KEY.BACKSPACE
-    || (event.shiftKey && event.key === "Shift")
-    || event.ctrlKey
-    || event.altKey;
+    return event.key === KEY.BACKSPACE || (event.shiftKey && event.key === "Shift") || event.ctrlKey || event.altKey;
   }
 
   function press(this: Document, event: KeyboardEvent): void {

--- a/src/Infiltration/ui/BackwardGame.tsx
+++ b/src/Infiltration/ui/BackwardGame.tsx
@@ -38,7 +38,10 @@ export function BackwardGame(props: IMinigameProps): React.ReactElement {
   const hasAugment = Player.hasAugmentation(AugmentationNames.ChaosOfDionysus, true);
 
   function ignorableKeyboardEvent(event: KeyboardEvent): boolean {
-    return event.key === KEY.BACKSPACE || (event.shiftKey && event.key === "Shift");
+    return event.key === KEY.BACKSPACE
+    || (event.shiftKey && event.key === "Shift")
+    || event.ctrlKey
+    || event.altKey;
   }
 
   function press(this: Document, event: KeyboardEvent): void {

--- a/src/Infiltration/ui/BackwardGame.tsx
+++ b/src/Infiltration/ui/BackwardGame.tsx
@@ -37,9 +37,13 @@ export function BackwardGame(props: IMinigameProps): React.ReactElement {
   const [guess, setGuess] = useState("");
   const hasAugment = Player.hasAugmentation(AugmentationNames.ChaosOfDionysus, true);
 
+  function ignorableKeyboardEvent(event: KeyboardEvent): boolean {
+    return event.key === KEY.BACKSPACE || (event.shiftKey && event.key === "Shift");
+  }
+
   function press(this: Document, event: KeyboardEvent): void {
     event.preventDefault();
-    if (event.key === KEY.BACKSPACE) return;
+    if (ignorableKeyboardEvent(event)) return;
     const nextGuess = guess + event.key.toUpperCase();
     if (!answer.startsWith(nextGuess)) props.onFailure();
     else if (answer === nextGuess) props.onSuccess();


### PR DESCRIPTION
fixes #2741 
Ignores shift keypresses if performed without another keypress. Extracts logic to define ignorable keyboard events out to a separate helper function if more complex logic should be added.