### PR TITLE
STANEK: Fix #3196 Charging booster fragments throws an error

### DIFF
--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -5,6 +5,7 @@ import { netscriptDelay } from "../NetscriptEvaluator";
 
 import { staneksGift } from "../CotMG/Helper";
 import { Fragments, FragmentById } from "../CotMG/Fragment";
+import { FragmentType } from "../CotMG/FragmentType";
 
 import {
   Fragment as IFragment,
@@ -42,11 +43,19 @@ export function NetscriptStanek(
       },
     chargeFragment: (_ctx: NetscriptContext) =>
       function (_rootX: unknown, _rootY: unknown): Promise<void> {
+        //Get the fragment object using the given coordinates
         const rootX = _ctx.helper.number("rootX", _rootX);
         const rootY = _ctx.helper.number("rootY", _rootY);
         checkStanekAPIAccess("chargeFragment");
         const fragment = staneksGift.findFragment(rootX, rootY);
+        //Check whether the selected fragment can ge charged
         if (!fragment) throw _ctx.makeRuntimeErrorMsg(`No fragment with root (${rootX}, ${rootY}).`);
+        if (fragment.fragment().type == FragmentType.Booster) {
+          throw _ctx.makeRuntimeErrorMsg(
+            `The fragment with root (${rootX}, ${rootY}) is a Booster Fragment and thus cannot be charged.`,
+          );
+        }
+        //Charge the fragment
         const time = staneksGift.inBonus() ? 200 : 1000;
         return netscriptDelay(time, workerScript).then(function () {
           const charge = staneksGift.charge(player, fragment, workerScript.scriptRef.threads);


### PR DESCRIPTION
Added a check to ns.stanek.chargeFragment(x, y) to throw an error if the selected fragment is a booster. Technically a breaking change in some sense, because it now throws an error in a case where previously it would simply accomplish nothing. If a user script relies on this fringe behavior, it will no longer work. 
![image](https://user-images.githubusercontent.com/55594961/167483958-5420b474-8caa-4be3-a6de-1b8cbf519ba8.png)
Tested by attempting an invalid charge on an empty space, a valid charge on a chargeable fragment, and an invalid charge on a booster fragment. All three functioned as expected.
Closes #3196
