### PR TITLE
MISC: Fix #3125 BREAKING Renamed BN mult CorporationSoftCap to CorporationSoftcap

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -488,7 +488,7 @@ export const defaultMultipliers: IBitNodeMultipliers = {
   FourSigmaMarketDataApiCost: 1,
 
   CorporationValuation: 1,
-  CorporationSoftCap: 1,
+  CorporationSoftcap: 1,
 
   BladeburnerRank: 1,
   BladeburnerSkillCost: 1,
@@ -523,7 +523,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: 2,
         StaneksGiftExtraSize: -6,
         PurchasedServerSoftcap: 1.3,
-        CorporationSoftCap: 0.9,
+        CorporationSoftcap: 0.9,
         WorldDaemonDifficulty: 5,
       });
     }
@@ -609,7 +609,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: 0.5,
         StaneksGiftExtraSize: 2,
         GangSoftcap: 0.7,
-        CorporationSoftCap: 0.9,
+        CorporationSoftcap: 0.9,
         WorldDaemonDifficulty: 2,
         GangUniqueAugs: 0.2,
       });
@@ -637,7 +637,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: 0.9,
         StaneksGiftExtraSize: -1,
         GangSoftcap: 0.7,
-        CorporationSoftCap: 0.9,
+        CorporationSoftcap: 0.9,
         WorldDaemonDifficulty: 2,
         GangUniqueAugs: 0.2,
       });
@@ -657,7 +657,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftExtraSize: -99,
         PurchasedServerSoftcap: 4,
         GangSoftcap: 0,
-        CorporationSoftCap: 0,
+        CorporationSoftcap: 0,
         GangUniqueAugs: 0,
       });
     }
@@ -685,7 +685,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: 0.5,
         StaneksGiftExtraSize: 2,
         GangSoftcap: 0.8,
-        CorporationSoftCap: 0.7,
+        CorporationSoftcap: 0.7,
         WorldDaemonDifficulty: 2,
         GangUniqueAugs: 0.25,
       });
@@ -717,7 +717,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftExtraSize: -3,
         PurchasedServerSoftcap: 1.1,
         GangSoftcap: 0.9,
-        CorporationSoftCap: 0.9,
+        CorporationSoftcap: 0.9,
         WorldDaemonDifficulty: 2,
         GangUniqueAugs: 0.25,
       });
@@ -741,7 +741,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         FourSigmaMarketDataCost: 4,
         FourSigmaMarketDataApiCost: 4,
         PurchasedServerSoftcap: 2,
-        CorporationSoftCap: 0.9,
+        CorporationSoftcap: 0.9,
         WorldDaemonDifficulty: 1.5,
         GangUniqueAugs: 0.75,
       });
@@ -809,7 +809,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: inc,
         StaneksGiftExtraSize: inc,
         GangSoftcap: 0.8,
-        CorporationSoftCap: 0.8,
+        CorporationSoftcap: 0.8,
         WorldDaemonDifficulty: inc,
 
         GangUniqueAugs: dec,
@@ -854,7 +854,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: 2,
         StaneksGiftExtraSize: 1,
         GangSoftcap: 0.3,
-        CorporationSoftCap: 0.3,
+        CorporationSoftcap: 0.3,
         WorldDaemonDifficulty: 3,
         GangUniqueAugs: 0.1,
       });

--- a/src/BitNode/BitNodeMultipliers.ts
+++ b/src/BitNode/BitNodeMultipliers.ts
@@ -242,7 +242,7 @@ export interface IBitNodeMultipliers {
   /**
    * Influences corporation dividends.
    */
-  CorporationSoftCap: number;
+  CorporationSoftcap: number;
 
   // Index signature
   [key: string]: number;

--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -528,7 +528,7 @@ function CorporationMults({ n, mults }: IMultsProps): React.ReactElement {
   if (n !== 3 && player.sourceFileLvl(3) === 0) return <></>;
   // is it empty check
   if (
-    mults.CorporationSoftCap === defaultMultipliers.CorporationSoftCap &&
+    mults.CorporationSoftcap === defaultMultipliers.CorporationSoftcap &&
     mults.CorporationValuation === defaultMultipliers.CorporationValuation
   )
     return <></>;
@@ -538,8 +538,8 @@ function CorporationMults({ n, mults }: IMultsProps): React.ReactElement {
       <br />
       <Typography variant={"h5"}>Corporation:</Typography>
       <Box mx={1}>
-        {mults.CorporationSoftCap !== defaultMultipliers.CorporationSoftCap ? (
-          <Typography>Softcap: {mults.CorporationSoftCap.toFixed(3)}</Typography>
+        {mults.CorporationSoftcap !== defaultMultipliers.CorporationSoftcap ? (
+          <Typography>Softcap: {mults.CorporationSoftcap.toFixed(3)}</Typography>
         ) : (
           <></>
         )}

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -159,7 +159,7 @@ export class Corporation {
     if (this.unlockUpgrades[6] === 1) {
       upgrades += 0.1;
     }
-    return Math.pow(dividends, BitNodeMultipliers.CorporationSoftCap + upgrades);
+    return Math.pow(dividends, BitNodeMultipliers.CorporationSoftcap + upgrades);
   }
 
   determineValuation(): number {

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -317,7 +317,7 @@ export function SpecialLocation(props: IProps): React.ReactElement {
       return renderGrafting();
     }
     case LocationName.Sector12CityHall: {
-      return (BitNodeMultipliers.CorporationSoftCap < 0.15 && <></>) || <CreateCorporation />;
+      return (BitNodeMultipliers.CorporationSoftcap < 0.15 && <></>) || <CreateCorporation />;
     }
     case LocationName.Sector12NSA: {
       return renderBladeburner();

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -78,7 +78,7 @@ export function NetscriptCorporation(
     if (!player.canAccessCorporation() || player.hasCorporation()) return false;
     if (!corporationName) return false;
     if (player.bitNodeN !== 3 && !selfFund) throw new Error("cannot use seed funds outside of BitNode 3");
-    if (BitNodeMultipliers.CorporationSoftCap < 0.15)
+    if (BitNodeMultipliers.CorporationSoftcap < 0.15)
       throw new Error(`You cannot create a corporation in Bitnode ${player.bitNodeN}`);
 
     if (selfFund) {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -560,7 +560,7 @@ export interface BitNodeMultipliers {
   /** Influences how much money the player earns when completing working their job. */
   CompanyWorkMoney: number;
   /** Influences the money gain from dividends of corporations created by the player. */
-  CorporationSoftCap: number;
+  CorporationSoftcap: number;
   /** Influences the valuation of corporations created by the player. */
   CorporationValuation: number;
   /** Influences the base experience gained for each ability when the player commits a crime. */


### PR DESCRIPTION
Replaced all instances of "CorporationSoftCap" in src/ with "CorporationSoftcap" for parity with other instances of "Softcap". By my testing, this does not seem to require a save file migration except for any user scripts that have hardcoded the name of this property, which is obviously not reasonable to migrate automatically.

Tested by loading a BN8 save from the current Steam build and ensuring that the CorporationSoftCap multiplier was properly replaced by CorporationSoftcap.

Resolves #3125