### PR TITLE
BLADEBURNER: Fix #3594 Blade's Simulacrum worked without being installed

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1919,7 +1919,7 @@ export class Bladeburner implements IBladeburner {
     }
 
     // If the Player starts doing some other actions, set action to idle and alert
-    if (player.hasAugmentation(AugmentationNames.BladesSimulacrum) === false && player.isWorking) {
+    if (!player.hasAugmentation(AugmentationNames.BladesSimulacrum, true) && player.isWorking) {
       if (this.action.type !== ActionTypes["Idle"]) {
         let msg = "Your Bladeburner action was cancelled because you started doing something else.";
         if (this.automateEnabled) {


### PR DESCRIPTION
The check for when an action is started was not set to ignore a
purchased but not yet installed Blade's Simulacrum. That is fixed
here.

Tested by attempting to perform a crime while doing a BB action.

Fixes #3594
