### PR TITLE
MISC: Close some GitHub issues that do not need action

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -1382,7 +1382,8 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
       return [n + m, edges];
     },
     solver: (data: [number, [number, number][]], ans: string): boolean => {
-      //Case where the player believes there is no solution
+      //Case where the player believes there is no solution.
+      //Attempt to construct one to check if this is correct.
       if (ans == "[]") {
         //Helper function to get neighbourhood of a vertex
         function neighbourhood(vertex: number): number[] {


### PR DESCRIPTION
Glanced through all the PRs from 2022/03/01 - 2022/05/09 (YYYY/MM/DD) To close any outstanding PRs that do not require action of any kind. Feel free to pull to automatically handle all these, or to merely use it as a reference list of PRs that should probably be closed manually.

Close #3636 - Not a bug
Close #3629 - Previously resolved
Close #3506 - Not descriptive, and int being nebulous is an intentional design choice.
Close #3448 - Not descriptive, could not reproduce, and inactive for nearly a month. Also, most likely caused by a previously fixed issue wherein it was possible to create a new division in an existing city, overwriting the division that was already present.
Close #3472 - Poorly described, inactive for nearly a month, and as far as I can tell is merely the player failing to realize the player gets the money from sold corp shares, not the corp.
Close #3316 - Not a bug
Close #3317 - Most likely previously resolved; if not, there are no steps to reproduce and this is therefore not a useful issue.
Close #3262 - Previously resolved
Close #3243 - Not descriptive
Close #3252 - Previously resolved
Close #3142 - Not descriptive
