### PR TITLE
OPTIONS: Fix sliders not sliding correctly

### DIFF
--- a/src/GameOptions/ui/CurrentOptionsPage.tsx
+++ b/src/GameOptions/ui/CurrentOptionsPage.tsx
@@ -70,7 +70,7 @@ export const CurrentOptionsPage = (props: IProps): React.ReactElement => {
         <>
           <OptionsSlider
             label=".script exec time (ms)"
-            value={execTime}
+            initialValue={execTime}
             callback={handleExecTimeChange}
             step={1}
             min={5}
@@ -84,7 +84,7 @@ export const CurrentOptionsPage = (props: IProps): React.ReactElement => {
           />
           <OptionsSlider
             label="Recently killed scripts size"
-            value={recentScriptsSize}
+            initialValue={recentScriptsSize}
             callback={handleRecentScriptsSizeChange}
             step={25}
             min={0}
@@ -98,7 +98,7 @@ export const CurrentOptionsPage = (props: IProps): React.ReactElement => {
           />
           <OptionsSlider
             label="Netscript log size"
-            value={logSize}
+            initialValue={logSize}
             callback={handleLogSizeChange}
             step={20}
             min={20}
@@ -112,7 +112,7 @@ export const CurrentOptionsPage = (props: IProps): React.ReactElement => {
           />
           <OptionsSlider
             label="Netscript port size"
-            value={portSize}
+            initialValue={portSize}
             callback={handlePortSizeChange}
             step={1}
             min={20}
@@ -126,7 +126,7 @@ export const CurrentOptionsPage = (props: IProps): React.ReactElement => {
           />
           <OptionsSlider
             label="Terminal capacity"
-            value={terminalSize}
+            initialValue={terminalSize}
             callback={handleTerminalSizeChange}
             step={50}
             min={50}
@@ -141,7 +141,7 @@ export const CurrentOptionsPage = (props: IProps): React.ReactElement => {
           />
           <OptionsSlider
             label="Autosave interval (s)"
-            value={autosaveInterval}
+            initialValue={autosaveInterval}
             callback={handleAutosaveIntervalChange}
             step={30}
             min={0}

--- a/src/GameOptions/ui/OptionsSlider.tsx
+++ b/src/GameOptions/ui/OptionsSlider.tsx
@@ -1,8 +1,8 @@
 import { Slider, Tooltip, Typography, Box } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 
 interface IProps {
-  value: any;
+  initialValue: any;
   callback: (event: any, newValue: number | number[]) => void;
   step: number;
   min: number;
@@ -13,14 +13,21 @@ interface IProps {
 }
 
 export const OptionsSlider = (props: IProps): React.ReactElement => {
+  const [value, setValue] = useState(props.initialValue);
+
+  const onChange = (_evt: Event, newValue: number | Array<number>): void => {
+    setValue(newValue);
+  };
+
   return (
     <Box>
       <Tooltip title={<Typography>{props.tooltip}</Typography>}>
         <Typography>{props.label}</Typography>
       </Tooltip>
       <Slider
-        value={props.value}
-        onChange={props.callback}
+        value={value}
+        onChange={onChange}
+        onChangeCommitted={(evt) => props.callback(evt, value)}
         step={props.step}
         min={props.min}
         max={props.max}

--- a/src/GameOptions/ui/OptionsSlider.tsx
+++ b/src/GameOptions/ui/OptionsSlider.tsx
@@ -27,7 +27,7 @@ export const OptionsSlider = (props: IProps): React.ReactElement => {
       <Slider
         value={value}
         onChange={onChange}
-        onChangeCommitted={(evt) => props.callback(evt, value)}
+        onChangeCommitted={props.callback}
         step={props.step}
         min={props.min}
         max={props.max}


### PR DESCRIPTION
fixes options sliders so that they don't freeze up every time their value is changed

![firefox_1ozrr8IkMe](https://user-images.githubusercontent.com/60761231/167519810-805ed9b5-b84e-4aff-a48b-05737ee9abb9.gif)

the slider value is now computed within the slider element, and is only released to the user `Settings` once the slider is no longer being used (this can be observed in the above GIF as the save icon on the character overview only changes state once the slider thumb is released)

### Testing
- [x] I have confirmed that the sliders can be slid
