### PR TITLE
CODINGCONTRACT: Fix #3391 Double contract reward exploit

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -284,7 +284,7 @@ export class Terminal implements ITerminal {
       `Security decreased on '${server.hostname}' from ${numeralWrapper.formatSecurity(
         oldSec,
       )} to ${numeralWrapper.formatSecurity(newSec)} (min: ${numeralWrapper.formatSecurity(server.minDifficulty)})` +
-      ` and Gained ${numeralWrapper.formatExp(expGain)} hacking exp.`,
+        ` and Gained ${numeralWrapper.formatExp(expGain)} hacking exp.`,
     );
   }
 
@@ -330,7 +330,8 @@ export class Terminal implements ITerminal {
         this.print("Time to hack: " + (!isHacknet ? convertTimeMsToTimeElapsedString(hackingTime, true) : "N/A"));
       }
       this.print(
-        `Total money available on server: ${currServ instanceof Server ? numeralWrapper.formatMoney(currServ.moneyAvailable) : "N/A"
+        `Total money available on server: ${
+          currServ instanceof Server ? numeralWrapper.formatMoney(currServ.moneyAvailable) : "N/A"
         }`,
       );
       if (currServ instanceof Server) {

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -284,7 +284,7 @@ export class Terminal implements ITerminal {
       `Security decreased on '${server.hostname}' from ${numeralWrapper.formatSecurity(
         oldSec,
       )} to ${numeralWrapper.formatSecurity(newSec)} (min: ${numeralWrapper.formatSecurity(server.minDifficulty)})` +
-        ` and Gained ${numeralWrapper.formatExp(expGain)} hacking exp.`,
+      ` and Gained ${numeralWrapper.formatExp(expGain)} hacking exp.`,
     );
   }
 
@@ -330,8 +330,7 @@ export class Terminal implements ITerminal {
         this.print("Time to hack: " + (!isHacknet ? convertTimeMsToTimeElapsedString(hackingTime, true) : "N/A"));
       }
       this.print(
-        `Total money available on server: ${
-          currServ instanceof Server ? numeralWrapper.formatMoney(currServ.moneyAvailable) : "N/A"
+        `Total money available on server: ${currServ instanceof Server ? numeralWrapper.formatMoney(currServ.moneyAvailable) : "N/A"
         }`,
       );
       if (currServ instanceof Server) {
@@ -462,6 +461,12 @@ export class Terminal implements ITerminal {
 
     this.contractOpen = true;
     const res = await contract.prompt();
+
+    //Check if the contract still exists by the time the promise is fullfilled
+    if (serv.getContract(contractName) == null) {
+      this.contractOpen = false;
+      return this.error("Contract no longer exists (Was it solved by a script?)");
+    }
 
     switch (res) {
       case CodingContractResult.Success:


### PR DESCRIPTION
Added a check to the contract solution handler to prevent rewarding the player for contracts that no longer exist by the time the contract is solved. Tested by ensuring contracts work as expected when ns functions are not used to solve them, by ensuring contracts give an error when they do not exist, and by then checking that contracts work as expected after this error is thrown.

The following image demonstrates the error kicking in when I attempt to manually solve a contract that existed at the time of starting but not at the time of finishing:
![image](https://user-images.githubusercontent.com/55594961/167946378-9594bc4a-e9e8-453e-966b-c2fcdd3e3d65.png)
Fixes #3391
