### PR TITLE
AUGMENTATIONS: Fix Augmentation rep req not being properly influenced by BitNode multipliers

### DIFF
--- a/src/Augmentation/Augmentation.tsx
+++ b/src/Augmentation/Augmentation.tsx
@@ -631,6 +631,7 @@ export class Augmentation {
         augmentationReference.baseCost *
         getGenericAugmentationPriceMultiplier() *
         BitNodeMultipliers.AugmentationMoneyCost;
+      repCost = augmentationReference.baseRepRequirement * BitNodeMultipliers.AugmentationRepCost;
     }
     return { moneyCost, repCost };
   }


### PR DESCRIPTION
the `AugmentationRepCost` BitNode multiplier was previously only being applied to NeuroFlux Governor, rather than to all augmentations

(this assumes that it *is* supposed to apply to all Augmentations, as is implied by the source code comments)