### PR TITLE
TERMINAL: FIX #3651 Make directory name regex more flexible

### DIFF
--- a/src/Terminal/DirectoryHelpers.ts
+++ b/src/Terminal/DirectoryHelpers.ts
@@ -51,7 +51,7 @@ export function isValidFilename(filename: string): boolean {
 export function isValidDirectoryName(name: string): boolean {
   // Allows alphanumerics, hyphens, underscores, and percentage signs.
   // Name can begin with a single period, but otherwise cannot have any
-  const regex = /^.?[a-zA-Z0-9_-]+$/;
+  const regex = /^\.?(?:\w[_\-.%]*)+$/;
 
   // match() returns null if no match is found
   return name.match(regex) != null;

--- a/src/Terminal/DirectoryHelpers.ts
+++ b/src/Terminal/DirectoryHelpers.ts
@@ -49,9 +49,11 @@ export function isValidFilename(filename: string): boolean {
  * not an entire path
  */
 export function isValidDirectoryName(name: string): boolean {
-  // Allows alphanumerics, hyphens, underscores, and percentage signs.
-  // Name can begin with a single period, but otherwise cannot have any
-  const regex = /^\.?(?:\w[_\-.%]*)+$/;
+  // A valid directory name:
+  // Must be at least 1 character long
+  // Can only include characters in the character set [-.%a-zA-Z0-9_]
+  // Cannot end with a '.'
+  const regex = /^(?:[-.%]|\w)*[-%a-zA-Z0-9_]$/;
 
   // match() returns null if no match is found
   return name.match(regex) != null;

--- a/test/jest/Terminal/Directory.test.js
+++ b/test/jest/Terminal/Directory.test.js
@@ -102,17 +102,18 @@ describe("Terminal Directory Tests", function () {
       expect(isValidDirectoryName(".a1")).toEqual(true);
       expect(isValidDirectoryName("._foo")).toEqual(true);
       expect(isValidDirectoryName("_foo")).toEqual(true);
+      expect(isValidDirectoryName("foo.dir")).toEqual(true);
+      expect(isValidDirectoryName("1.")).toEqual(true);
+      expect(isValidDirectoryName("foo.")).toEqual(true);
     });
 
     it("should return false for invalid directory names", function () {
       expect(isValidDirectoryName("")).toEqual(false);
-      expect(isValidDirectoryName("foo.dir")).toEqual(false);
-      expect(isValidDirectoryName("1.")).toEqual(false);
-      expect(isValidDirectoryName("foo.")).toEqual(false);
       expect(isValidDirectoryName("dir#")).toEqual(false);
       expect(isValidDirectoryName("dir!")).toEqual(false);
       expect(isValidDirectoryName("dir*")).toEqual(false);
       expect(isValidDirectoryName(".")).toEqual(false);
+      expect(isValidDirectoryName("..")).toEqual(false);
     });
   });
 

--- a/test/jest/Terminal/Directory.test.js
+++ b/test/jest/Terminal/Directory.test.js
@@ -103,17 +103,18 @@ describe("Terminal Directory Tests", function () {
       expect(isValidDirectoryName("._foo")).toEqual(true);
       expect(isValidDirectoryName("_foo")).toEqual(true);
       expect(isValidDirectoryName("foo.dir")).toEqual(true);
-      expect(isValidDirectoryName("1.")).toEqual(true);
-      expect(isValidDirectoryName("foo.")).toEqual(true);
     });
 
     it("should return false for invalid directory names", function () {
       expect(isValidDirectoryName("")).toEqual(false);
+      expect(isValidDirectoryName("👨‍💻")).toEqual(false);
       expect(isValidDirectoryName("dir#")).toEqual(false);
       expect(isValidDirectoryName("dir!")).toEqual(false);
       expect(isValidDirectoryName("dir*")).toEqual(false);
       expect(isValidDirectoryName(".")).toEqual(false);
       expect(isValidDirectoryName("..")).toEqual(false);
+      expect(isValidDirectoryName("1.")).toEqual(false);
+      expect(isValidDirectoryName("foo.")).toEqual(false);
     });
   });
 

--- a/test/jest/Terminal/Directory.test.js
+++ b/test/jest/Terminal/Directory.test.js
@@ -103,6 +103,14 @@ describe("Terminal Directory Tests", function () {
       expect(isValidDirectoryName("._foo")).toEqual(true);
       expect(isValidDirectoryName("_foo")).toEqual(true);
       expect(isValidDirectoryName("foo.dir")).toEqual(true);
+      expect(isValidDirectoryName("foov1.0.0.1")).toEqual(true);
+      expect(isValidDirectoryName("foov1..0..0..1")).toEqual(true);
+      expect(isValidDirectoryName("foov1-0-0-1")).toEqual(true);
+      expect(isValidDirectoryName("foov1-0-0-1-")).toEqual(true);
+      expect(isValidDirectoryName("foov1--0--0--1--")).toEqual(true);
+      expect(isValidDirectoryName("foov1_0_0_1")).toEqual(true);
+      expect(isValidDirectoryName("foov1_0_0_1_")).toEqual(true);
+      expect(isValidDirectoryName("foov1__0__0__1")).toEqual(true);
     });
 
     it("should return false for invalid directory names", function () {
@@ -115,6 +123,7 @@ describe("Terminal Directory Tests", function () {
       expect(isValidDirectoryName("..")).toEqual(false);
       expect(isValidDirectoryName("1.")).toEqual(false);
       expect(isValidDirectoryName("foo.")).toEqual(false);
+      expect(isValidDirectoryName("foov1.0.0.1.")).toEqual(false);
     });
   });
 


### PR DESCRIPTION
Fixes #3651  

Initial change to expand the set of allowed directory names. Draft PR while investigating the potential consequences of this.