### PR TITLE
STANEK: Fix  #3623 Ugly fix to ns.stanek functions engine leak

### DIFF
--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -18,6 +18,25 @@ import { FactionNames } from "../Faction/data/FactionNames";
 import { joinFaction } from "../Faction/FactionHelpers";
 import { Factions } from "../Faction/Factions";
 
+class APIActiveFragment implements IActiveFragment {
+  id: number;
+  highestCharge: number;
+  numCharge: number;
+  rotation: number;
+  x: number;
+  y: number;
+  
+  constructor (src:IActiveFragment) {
+    this.id = src.id;
+    this.highestCharge = src.highestCharge;
+    this.numCharge = src.numCharge;
+    this.rotation = src.rotation;
+    this.x = src.x;
+    this.y = src.y;
+  }
+}
+
+
 export function NetscriptStanek(
   player: IPlayer,
   workerScript: WorkerScript,
@@ -103,7 +122,7 @@ export function NetscriptStanek(
         const rootY = _ctx.helper.number("rootY", _rootY);
         checkStanekAPIAccess("getFragment");
         const fragment = staneksGift.findFragment(rootX, rootY);
-        if (fragment !== undefined) return fragment.copy();
+        if (fragment !== undefined) return new APIActiveFragment(fragment);
         return undefined;
       },
     removeFragment: (_ctx: NetscriptContext) =>

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -25,8 +25,8 @@ class APIActiveFragment implements IActiveFragment {
   rotation: number;
   x: number;
   y: number;
-  
-  constructor (src:IActiveFragment) {
+
+  constructor(src: IActiveFragment) {
     this.id = src.id;
     this.highestCharge = src.highestCharge;
     this.numCharge = src.numCharge;
@@ -36,6 +36,21 @@ class APIActiveFragment implements IActiveFragment {
   }
 }
 
+class APIFragment implements IFragment {
+  id: number;
+  shape: boolean[][];
+  type: number;
+  power: number;
+  limit: number;
+
+  constructor(src: IFragment) {
+    this.id = src.id;
+    this.shape = src.shape;
+    this.power = src.power;
+    this.type = src.type;
+    this.limit = src.limit;
+  }
+}
 
 export function NetscriptStanek(
   player: IPlayer,
@@ -77,7 +92,7 @@ export function NetscriptStanek(
       function (): IFragment[] {
         checkStanekAPIAccess("fragmentDefinitions");
         _ctx.log(() => `Returned ${Fragments.length} fragments`);
-        return Fragments.map((f) => f.copy());
+        return Fragments.map((f) => {return new APIFragment(f)});
       },
     activeFragments: (_ctx: NetscriptContext) =>
       function (): IActiveFragment[] {

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -92,7 +92,9 @@ export function NetscriptStanek(
       function (): IFragment[] {
         checkStanekAPIAccess("fragmentDefinitions");
         _ctx.log(() => `Returned ${Fragments.length} fragments`);
-        return Fragments.map((f) => {return new APIFragment(f)});
+        return Fragments.map((f) => {
+          return new APIFragment(f);
+        });
       },
     activeFragments: (_ctx: NetscriptContext) =>
       function (): IActiveFragment[] {


### PR DESCRIPTION
Reimplement the Fragment and ActiveFragment class, without any method attached. Uses them as a return value rather than the original class.

Feels likes too much code for too few added-value. 
There's probably a cleaner way to do it.