### PR TITLE
GANG: Diversify gang creation requisite

### DIFF
--- a/src/Augmentation/ui/PurchasableAugmentations.tsx
+++ b/src/Augmentation/ui/PurchasableAugmentations.tsx
@@ -83,7 +83,7 @@ const Exclusive = (props: IExclusiveProps): React.ReactElement => {
               <li>
                 <b>{props.aug.factions[0]}</b> faction
               </li>
-              {props.player.canAccessGang() && !props.aug.isSpecial && (
+              {props.player.isAwareOfGang() && !props.aug.isSpecial && (
                 <li>
                   Certain <b>gangs</b>
                 </li>

--- a/src/Faction/ui/GangButton.tsx
+++ b/src/Faction/ui/GangButton.tsx
@@ -1,5 +1,6 @@
 import { Button, Typography, Box, Paper, Tooltip } from "@mui/material";
 import React, { useState } from "react";
+import { Money } from "../../ui/React/Money";
 import { GangConstants } from "../../Gang/data/Constants";
 import { use } from "../../ui/Context";
 import { Faction } from "../Faction";
@@ -37,11 +38,19 @@ export function GangButton({ faction }: IProps): React.ReactElement {
       description: "Manage a gang for this Faction. Gangs will earn you money and faction reputation",
     };
   } else {
+    const requirement = player.getGangRequirement(faction.name);
     data = {
-      enabled: player.canAccessGang(),
+      enabled: player.canAccessGang(faction.name),
       title: "Create Gang",
-      tooltip: !player.canAccessGang() ? (
-        <Typography>Unlocked when reaching {GangConstants.GangKarmaRequirement} karma</Typography>
+      tooltip: !player.canAccessGang(faction.name) ? (
+        <Typography>
+          Unlocked when reaching : <br />
+          {player.karma}/{requirement.karma} karma,
+          <br />
+          <Money money={player.moneySourceB.crime} />/<Money money={requirement.crime} /> from crime source,
+          <br />
+          <Money money={player.moneySourceB.hacking} />/<Money money={requirement.hacking} /> from hacking source.
+        </Typography>
       ) : (
         ""
       ),

--- a/src/Faction/ui/GangButton.tsx
+++ b/src/Faction/ui/GangButton.tsx
@@ -44,12 +44,13 @@ export function GangButton({ faction }: IProps): React.ReactElement {
       title: "Create Gang",
       tooltip: !player.canAccessGang(faction.name) ? (
         <Typography>
-          Unlocked when reaching : <br />
-          {player.karma}/{requirement.karma} karma,
+          Unlocked when reaching :
           <br />
-          <Money money={player.moneySourceB.crime} />/<Money money={requirement.crime} /> from crime source,
+          {player.karma}/{requirement.karma} karma
           <br />
-          <Money money={player.moneySourceB.hacking} />/<Money money={requirement.hacking} /> from hacking source.
+          <Money money={player.moneySourceB.crime} />/<Money money={requirement.crime} /> from crime source
+          <br />
+          <Money money={player.moneySourceB.hacking} />/<Money money={requirement.hacking} /> from hacking source
         </Typography>
       ) : (
         ""

--- a/src/Gang/data/Constants.ts
+++ b/src/Gang/data/Constants.ts
@@ -7,6 +7,8 @@ export const GangConstants: {
   AscensionMultiplierRatio: number;
   Names: string[];
   GangKarmaRequirement: number;
+  GangCrimeMoneyRequirement: number;
+  GangHackingMoneyRequirement: number;
 } = {
   // Respect is divided by this to get rep gain
   GangRespectToReputationRatio: 75,
@@ -25,4 +27,6 @@ export const GangConstants: {
     FactionNames.TheBlackHand,
   ],
   GangKarmaRequirement: -54000,
+  GangCrimeMoneyRequirement: 100000000,
+  GangHackingMoneyRequirement: 150000000,
 };

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -190,6 +190,7 @@ const singularity: IMap<any> = {
 
 // Gang API
 const gang: IMap<any> = {
+  getGangRequirement: RamCostConstants.ScriptGangApiBaseRamCost / 4,
   createGang: RamCostConstants.ScriptGangApiBaseRamCost / 4,
   inGang: RamCostConstants.ScriptGangApiBaseRamCost / 4,
   getMemberNames: RamCostConstants.ScriptGangApiBaseRamCost / 4,

--- a/src/NetscriptFunctions/Gang.ts
+++ b/src/NetscriptFunctions/Gang.ts
@@ -20,6 +20,7 @@ import {
   EquipmentStats,
   GangTaskStats,
 } from "../ScriptEditor/NetscriptDefinitions";
+import { GangRequirement } from "../PersonObjects/Player/PlayerObjectGangMethods";
 
 export function NetscriptGang(player: IPlayer, workerScript: WorkerScript, helper: INetscriptHelper): IGang {
   const checkGangApiAccess = function (func: string): void {
@@ -50,12 +51,16 @@ export function NetscriptGang(player: IPlayer, workerScript: WorkerScript, helpe
   const updateRam = (funcName: string): void => helper.updateDynamicRam(funcName, getRamCost(player, "gang", funcName));
 
   return {
+    getGangRequirement: function (_faction: unknown): GangRequirement {
+      updateRam("getGangRequirement");
+      const faction = helper.string("getGangRequirement", "faction", _faction);
+      return player.getGangRequirement(faction);
+    },
     createGang: function (_faction: unknown): boolean {
       updateRam("createGang");
       const faction = helper.string("createGang", "faction", _faction);
-      // this list is copied from Faction/ui/Root.tsx
 
-      if (!player.canAccessGang() || !GangConstants.Names.includes(faction)) return false;
+      if (!player.canAccessGang(faction) || !GangConstants.Names.includes(faction)) return false;
       if (player.inGang()) return false;
       if (!player.factions.includes(faction)) return false;
 

--- a/src/PersonObjects/IPlayer.ts
+++ b/src/PersonObjects/IPlayer.ts
@@ -31,6 +31,7 @@ import { HacknetServer } from "../Hacknet/HacknetServer";
 import { ISkillProgress } from "./formulas/skill";
 import { PlayerAchievement } from "../Achievements/Achievements";
 import { WorkType, ClassType, CrimeType } from "../utils/WorkType";
+import { GangRequirement } from "./Player/PlayerObjectGangMethods";
 
 export interface IPlayer {
   // Class members
@@ -183,7 +184,7 @@ export interface IPlayer {
   applyForWaiterJob(sing?: boolean): boolean;
   canAccessBladeburner(): boolean;
   canAccessCorporation(): boolean;
-  canAccessGang(): boolean;
+  canAccessGang(factionName: string): boolean;
   canAccessGrafting(): boolean;
   canAfford(cost: number): boolean;
   gainHackingExp(exp: number): void;
@@ -197,6 +198,7 @@ export interface IPlayer {
   getCurrentServer(): BaseServer;
   getGangFaction(): Faction;
   getGangName(): string;
+  getGangRequirement(factionName: string): GangRequirement;
   getHomeComputer(): Server;
   getNextCompanyPosition(company: Company, entryPosType: CompanyPosition): CompanyPosition | null;
   getUpgradeHomeRamCost(): number;

--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -39,6 +39,7 @@ import { cyrb53 } from "../../utils/StringHelperFunctions";
 import { getRandomInt } from "../../utils/helpers/getRandomInt";
 import { CONSTANTS } from "../../Constants";
 import { WorkType, ClassType, CrimeType, PlayerFactionWorkType } from "../../utils/WorkType";
+import { GangRequirement } from "./PlayerObjectGangMethods";
 
 export class PlayerObject implements IPlayer {
   // Class members
@@ -193,7 +194,7 @@ export class PlayerObject implements IPlayer {
   applyForWaiterJob: (sing?: boolean) => boolean;
   canAccessBladeburner: () => boolean;
   canAccessCorporation: () => boolean;
-  canAccessGang: () => boolean;
+  canAccessGang: (factioName: string) => boolean;
   canAccessGrafting: () => boolean;
   canAfford: (cost: number) => boolean;
   gainHackingExp: (exp: number) => void;
@@ -207,6 +208,7 @@ export class PlayerObject implements IPlayer {
   getCurrentServer: () => BaseServer;
   getGangFaction: () => Faction;
   getGangName: () => string;
+  getGangRequirement: (factionName: string) => GangRequirement;
   getHomeComputer: () => Server;
   getNextCompanyPosition: (company: Company, entryPosType: CompanyPosition) => CompanyPosition | null;
   getUpgradeHomeRamCost: () => number;
@@ -609,6 +611,7 @@ export class PlayerObject implements IPlayer {
     this.isAwareOfGang = gangMethods.isAwareOfGang;
     this.getGangFaction = gangMethods.getGangFaction;
     this.getGangName = gangMethods.getGangName;
+    this.getGangRequirement = gangMethods.GetGangRequirement;
     this.hasGangWith = gangMethods.hasGangWith;
     this.inGang = gangMethods.inGang;
     this.startGang = gangMethods.startGang;

--- a/src/PersonObjects/Player/PlayerObjectGangMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGangMethods.ts
@@ -22,13 +22,13 @@ export function canAccessGang(this: IPlayer, factionName: string): boolean {
   const requirement = GetGangRequirement(factionName);
   return (
     this.karma <= requirement.karma &&
-    this.moneySourceB.crime <= requirement.crime &&
-    this.moneySourceB.hacking <= requirement.crime
+    this.moneySourceB.crime >= requirement.crime &&
+    this.moneySourceB.hacking >= requirement.crime
   );
 }
 
 export function GetGangRequirement(factionName: string): GangRequirement {
-  let requirement = {
+  const requirement = {
     karma: GangConstants.GangKarmaRequirement,
     crime: GangConstants.GangCrimeMoneyRequirement,
     hacking: GangConstants.GangHackingMoneyRequirement,

--- a/src/PersonObjects/Player/PlayerObjectGangMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGangMethods.ts
@@ -3,8 +3,15 @@ import { Faction } from "../../Faction/Faction";
 import { Gang } from "../../Gang/Gang";
 import { IPlayer } from "../IPlayer";
 import { GangConstants } from "../../Gang/data/Constants";
+import { FactionNames } from "../../Faction/data/FactionNames";
 
-export function canAccessGang(this: IPlayer): boolean {
+export type GangRequirement = {
+  karma: number;
+  crime: number;
+  hacking: number;
+};
+
+export function canAccessGang(this: IPlayer, factionName: string): boolean {
   if (this.bitNodeN === 2) {
     return true;
   }
@@ -12,7 +19,61 @@ export function canAccessGang(this: IPlayer): boolean {
     return false;
   }
 
-  return this.karma <= GangConstants.GangKarmaRequirement;
+  const requirement = GetGangRequirement(factionName);
+  return (
+    this.karma <= requirement.karma &&
+    this.moneySourceB.crime <= requirement.crime &&
+    this.moneySourceB.hacking <= requirement.crime
+  );
+}
+
+export function GetGangRequirement(factionName: string): GangRequirement {
+  let requirement = {
+    karma: GangConstants.GangKarmaRequirement,
+    crime: GangConstants.GangCrimeMoneyRequirement,
+    hacking: GangConstants.GangHackingMoneyRequirement,
+  };
+
+  switch (factionName) {
+    case FactionNames.SlumSnakes:
+      requirement.karma *= 1;
+      requirement.crime *= 0;
+      requirement.hacking *= 0;
+      break;
+    case FactionNames.Tetrads:
+      requirement.karma *= 0;
+      requirement.crime *= 1;
+      requirement.hacking *= 0;
+      break;
+    case FactionNames.TheSyndicate:
+      requirement.karma *= 0;
+      requirement.crime *= 0.1;
+      requirement.hacking *= 0.1;
+      break;
+    case FactionNames.TheDarkArmy:
+      requirement.karma *= 0.01;
+      requirement.crime *= 0.01;
+      requirement.hacking *= 0.01;
+      break;
+    case FactionNames.SpeakersForTheDead:
+      requirement.karma *= 0.1;
+      requirement.crime *= 0.1;
+      requirement.hacking *= 0;
+      break;
+    case FactionNames.NiteSec:
+      requirement.karma *= 0;
+      requirement.crime *= 0;
+      requirement.hacking *= 1;
+      break;
+    case FactionNames.TheBlackHand:
+      requirement.karma *= 0.1;
+      requirement.crime *= 0;
+      requirement.hacking *= 0.1;
+      break;
+    default:
+      throw new Error("This is not a Gang Faction.");
+  }
+  return requirement;
 }
 
 export function isAwareOfGang(this: IPlayer): boolean {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1,9 +1,16 @@
-import { GangRequirement } from "src/PersonObjects/Player/PlayerObjectGangMethods";
-
 /**
  * @public
  */
 type FilenameOrPID = number | string;
+
+/**
+ * @public
+ */
+type GangRequirement = {
+  karma: number;
+  crime: number;
+  hacking: number;
+};
 
 /**
  * @public
@@ -3346,9 +3353,7 @@ export interface Gang {
    * List all gang requirement.
    * @remarks
    * RAM cost: 1GB
-   *
    * Get the amount of karma, crime-sourced money, and hacking-sourced money needed to create a gang with the specified faction.
-   *
    * @returns Gang's requirement.
    */
   getGangRequirement(faction: string): GangRequirement;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1,3 +1,5 @@
+import { GangRequirement } from "src/PersonObjects/Player/PlayerObjectGangMethods";
+
 /**
  * @public
  */
@@ -3340,6 +3342,17 @@ export interface CodingContract {
  * @public
  */
 export interface Gang {
+  /**
+   * List all gang requirement.
+   * @remarks
+   * RAM cost: 1GB
+   *
+   * Get the amount of karma, crime-sourced money, and hacking-sourced money needed to create a gang with the specified faction.
+   *
+   * @returns Gang's requirement.
+   */
+  getGangRequirement(faction: string): GangRequirement;
+
   /**
    * Create a gang.
    * @remarks


### PR DESCRIPTION
Modify the Gang creation requisite : 
- SlumSnakes : -54000 karma (no change)
- Tetrads : 100$b crime money
- NiteSec :150$b hacking money
- TheSyndicate :10$b crime money / 15$b hacking money
- TheBlackHand : -5400 karma / 15$b hacking money
- SpeakersForTheDead : -5400 karma / 10$b crime money
- TheDarkArmy : -540 karma / 1$b crime money / 1.5$b hacking money

Note : You don't need to currently have the required money. Only to have earned that total amount since last Bitnode reset.

It should not upset the game balance. Most of the time, Slum Snake will still be the most accessible gang available. 
Hopefully, it will make hacking gang more viable. At least for the brief period before one unlock Singularity or Sleeve.

Tweak Faction UI's Gang button : 
![image](https://user-images.githubusercontent.com/104104269/168498928-ed53afe5-45e7-4d89-a4dd-5e58454dcc34.png)

Add a getGangRequirement(factionName) function to the Gang API.

Add 2 GangConstants - alongside the existing karma's one - for the amount of crime's and hacking's sourced money needed.
