### PR TITLE
STANEK: Stanek NS functions correctly throw errors when stanek not installed

### DIFF
--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -26,7 +26,7 @@ export function NetscriptStanek(
 ): InternalAPI<IStanek> {
   function checkStanekAPIAccess(func: string): void {
     if (!player.hasAugmentation(AugmentationNames.StaneksGift1, true)) {
-      helper.makeRuntimeErrorMsg(func, "Requires Stanek's Gift installed.");
+      throw helper.makeRuntimeErrorMsg(func, "Stanek's Gift is not installed");
     }
   }
 


### PR DESCRIPTION
Fixed a bug found by @Insight on Discord where Stanek NS functions would not terminate when it was detected Stanek's gift is not installed. Tested by ensuring that the program correctly terminates. Also reworded the error in order to make the issue more clear to the user if this error is ever seen.

Tested by ensuring the error properly terminates the script.