### PR TITLE
UI: Fix Agility BitNode multiplier not appearing in UI

### DIFF
--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -202,6 +202,10 @@ function SkillMults({ mults }: IMultsProps): React.ReactElement {
       name: "Dexterity Level",
       color: Settings.theme.combat,
     },
+    AgilityLevelMultiplier: {
+      name: "Agility Level",
+      color: Settings.theme.combat,
+    },
     CharismaLevelMultiplier: {
       name: "Charisma Level",
       color: Settings.theme.cha,


### PR DESCRIPTION
does what it says in the title. agi mult was missing, now it is not