### PR TITLE
MISC: Added NS function closeTail to close tail windows

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -193,7 +193,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       throw makeRuntimeRejectMsg(
         workerScript,
         `Invalid scriptArgs argument passed into getRunningScript() from ${callingFnName}(). ` +
-        `This is probably a bug. Please report to game developer`,
+          `This is probably a bug. Please report to game developer`,
       );
     }
 
@@ -826,7 +826,8 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
         workerScript.log(
           "weaken",
           () =>
-            `'${server.hostname}' security level weakened to ${server.hackDifficulty
+            `'${server.hostname}' security level weakened to ${
+              server.hackDifficulty
             }. Gained ${numeralWrapper.formatExp(expGain)} hacking exp (t=${numeralWrapper.formatThreads(threads)})`,
         );
         workerScript.scriptRef.onlineExpGained += expGain;

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -987,37 +987,14 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       LogBoxEvents.emit(runningScriptObj);
     },
-    closeTail: function (fn: any, hostname: any = workerScript.hostname, ...scriptArgs: any[]): void {
+    closeTail: function (pid?: number): void {
       updateDynamicRam("closeTail", getRamCost(Player, "closeTail"));
-      //Get the script details
-      let server;
-      let filename;
-      let args;
-      if (arguments.length === 0) {
-        //Get the details from the script calling the function
-        const runningScriptObj = workerScript.scriptRef;
-        server = runningScriptObj.server;
-        filename = runningScriptObj.filename;
-        args = runningScriptObj.args;
-      } else if (typeof fn === "number") {
-        //Get the details via the pid of a running script
-        const runningScriptObj = getRunningScriptByPid(fn, "tail");
-        if (runningScriptObj == null) {
-          workerScript.log("closeTail", () => getCannotFindRunningScriptErrorMessage(`${fn}`, hostname, scriptArgs));
-          return;
-        }
-        server = runningScriptObj.server;
-        filename = runningScriptObj.filename;
-        args = runningScriptObj.args;
-      } else {
-        //Get the details from the input directly
-        server = hostname;
-        filename = fn;
-        args = scriptArgs;
+      //Get the pid of the calling script if no pid is given
+      if (pid === undefined) {
+        pid = workerScript.scriptRef.pid;
       }
-
       //Emit an event to tell the game to close the tail window if it exists
-      LogBoxCloserEvents.emit(server, filename, args.map((x: any): string => `${x}`));
+      LogBoxCloserEvents.emit(pid);
     },
     nuke: function (_hostname: unknown): boolean {
       updateDynamicRam("nuke", getRamCost(Player, "nuke"));

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -988,6 +988,10 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       LogBoxEvents.emit(runningScriptObj);
     },
+    closeTail: function (fn: any, hostname: any = workerScript.hostname, ...scriptArgs: any[]): void {
+      updateDynamicRam("closeTail", getRamCost(Player, "closeTail"));
+      // TODO
+    },
     nuke: function (_hostname: unknown): boolean {
       updateDynamicRam("nuke", getRamCost(Player, "nuke"));
       const hostname = helper.string("tail", "hostname", _hostname);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -988,12 +988,9 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
 
       LogBoxEvents.emit(runningScriptObj);
     },
-    closeTail: function (pid?: number): void {
+    closeTail: function (_pid: unknown = workerScript.scriptRef.pid): void {
       updateDynamicRam("closeTail", getRamCost(Player, "closeTail"));
-      //Get the pid of the calling script if no pid is given
-      if (pid === undefined) {
-        pid = workerScript.scriptRef.pid;
-      }
+      const pid = helper.number("closeTail", "pid", _pid);
       //Emit an event to tell the game to close the tail window if it exists
       LogBoxCloserEvents.emit(pid);
     },

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4990,14 +4990,11 @@ export interface NS {
    *
    * If the function is called with no arguments, it will close the current script’s logs.
    *
-   * Otherwise, the fn, hostname/ip, and args… arguments can be used to close the logs from another script.
-   * Remember that scripts are uniquely identified by both their names and arguments.
+   * Otherwise, the pid argument can be used to close the logs from another script.
    *
-   * @param fn - Optional. Filename or PID of the script having its tail closed. If omitted, the current script is used.
-   * @param host - Optional. Hostname of the script having its tail closed. Defaults to the server this script is running on. If args are specified, this is not optional.
-   * @param args - Arguments for the script having its tail closed.
+   * @param pid - Optional. PID of the script having its tail closed. If omitted, the current script is used.
    */
-   closeTail(fn?: FilenameOrPID, host?: string, ...args: any[]): void;
+   closeTail(pid?: number): void;
 
   /**
    * Get the list of servers connected to a server.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4982,6 +4982,24 @@ export interface NS {
   tail(fn?: FilenameOrPID, host?: string, ...args: any[]): void;
 
   /**
+   * Close the tail window of a script.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * Closes a script’s logs. This is functionally the same pressing the "Close" button on the tail window.
+   *
+   * If the function is called with no arguments, it will close the current script’s logs.
+   *
+   * Otherwise, the fn, hostname/ip, and args… arguments can be used to close the logs from another script.
+   * Remember that scripts are uniquely identified by both their names and arguments.
+   *
+   * @param fn - Optional. Filename or PID of the script having its tail closed. If omitted, the current script is used.
+   * @param host - Optional. Hostname of the script having its tail closed. Defaults to the server this script is running on. If args are specified, this is not optional.
+   * @param args - Arguments for the script having its tail closed.
+   */
+   closeTail(fn?: FilenameOrPID, host?: string, ...args: any[]): void;
+
+  /**
    * Get the list of servers connected to a server.
    * @remarks
    * RAM cost: 0.2 GB

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4994,7 +4994,7 @@ export interface NS {
    *
    * @param pid - Optional. PID of the script having its tail closed. If omitted, the current script is used.
    */
-   closeTail(pid?: number): void;
+  closeTail(pid?: number): void;
 
   /**
    * Get the list of servers connected to a server.

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -131,6 +131,8 @@ function LogWindow(props: IProps): React.ReactElement {
     return () => clearInterval(id);
   }, []);
 
+  //TODO Not actually a todo I just want this file to show up as changed
+  //so I can find it easier later
   function kill(): void {
     killWorkerScript(script, script.server, true);
   }

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -255,14 +255,14 @@ function LogWindow(props: IProps): React.ReactElement {
           minHeight: `${minConstraints[1]}px`,
           ...(minimized
             ? {
-              border: "none",
-              margin: 0,
-              maxHeight: 0,
-              padding: 0,
-            }
+                border: "none",
+                margin: 0,
+                maxHeight: 0,
+                padding: 0,
+              }
             : {
-              border: `1px solid ${Settings.theme.welllight}`,
-            }),
+                border: `1px solid ${Settings.theme.welllight}`,
+              }),
         }}
         ref={container}
       >

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -23,7 +23,7 @@ import { Settings } from "../../Settings/Settings";
 let layerCounter = 0;
 
 export const LogBoxEvents = new EventEmitter<[RunningScript]>();
-export const LogBoxCloserEvents = new EventEmitter<[any, any, any[]]>();
+export const LogBoxCloserEvents = new EventEmitter<[number]>();
 export const LogBoxClearEvents = new EventEmitter<[]>();
 
 interface Log {
@@ -55,9 +55,8 @@ export function LogBoxManager(): React.ReactElement {
   //Event used by ns.closeTail to close tail windows
   useEffect(
     () =>
-      LogBoxCloserEvents.subscribe((hostname: any, filename: any, stringArgs: any[]) => {
-        const id = hostname + "-" + filename + stringArgs.map((x: any): string => `${x}`).join("-");
-        close(id);
+      LogBoxCloserEvents.subscribe((pid: number) => {
+        closePid(pid);
       }),
     [],
   );
@@ -69,8 +68,15 @@ export function LogBoxManager(): React.ReactElement {
     }),
   );
 
+  //Close tail windows by their id
   function close(id: string): void {
     logs = logs.filter((l) => l.id !== id);
+    rerender();
+  }
+
+  //Close tail windows by their pid
+  function closePid(pid: number): void {
+    logs = logs.filter((log) => log.script.pid != pid);
     rerender();
   }
 
@@ -249,14 +255,14 @@ function LogWindow(props: IProps): React.ReactElement {
           minHeight: `${minConstraints[1]}px`,
           ...(minimized
             ? {
-                border: "none",
-                margin: 0,
-                maxHeight: 0,
-                padding: 0,
-              }
+              border: "none",
+              margin: 0,
+              maxHeight: 0,
+              padding: 0,
+            }
             : {
-                border: `1px solid ${Settings.theme.welllight}`,
-              }),
+              border: `1px solid ${Settings.theme.welllight}`,
+            }),
         }}
         ref={container}
       >

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -23,7 +23,7 @@ import { Settings } from "../../Settings/Settings";
 let layerCounter = 0;
 
 export const LogBoxEvents = new EventEmitter<[RunningScript]>();
-export const LogBoxCloserEvents = new EventEmitter<[RunningScript]>();
+export const LogBoxCloserEvents = new EventEmitter<[any, any, any[]]>();
 export const LogBoxClearEvents = new EventEmitter<[]>();
 
 interface Log {
@@ -55,8 +55,8 @@ export function LogBoxManager(): React.ReactElement {
   //Event used by ns.closeTail to close tail windows
   useEffect(
     () =>
-      LogBoxCloserEvents.subscribe((script: RunningScript) => {
-        const id = script.server + "-" + script.filename + script.args.map((x: any): string => `${x}`).join("-");
+      LogBoxCloserEvents.subscribe((hostname: any, filename: any, stringArgs: any[]) => {
+        const id = hostname + "-" + filename + stringArgs.map((x: any): string => `${x}`).join("-");
         close(id);
       }),
     [],

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -23,6 +23,7 @@ import { Settings } from "../../Settings/Settings";
 let layerCounter = 0;
 
 export const LogBoxEvents = new EventEmitter<[RunningScript]>();
+export const LogBoxCloserEvents = new EventEmitter<[RunningScript]>();
 export const LogBoxClearEvents = new EventEmitter<[]>();
 
 interface Log {
@@ -47,6 +48,16 @@ export function LogBoxManager(): React.ReactElement {
           script: script,
         });
         rerender();
+      }),
+    [],
+  );
+
+  //Event used by ns.closeTail to close tail windows
+  useEffect(
+    () =>
+      LogBoxCloserEvents.subscribe((script: RunningScript) => {
+        const id = script.server + "-" + script.filename + script.args.map((x: any): string => `${x}`).join("-");
+        close(id);
       }),
     [],
   );

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -148,8 +148,6 @@ function LogWindow(props: IProps): React.ReactElement {
     return () => clearInterval(id);
   }, []);
 
-  //TODO Not actually a todo I just want this file to show up as changed
-  //so I can find it easier later
   function kill(): void {
     killWorkerScript(script, script.server, true);
   }


### PR DESCRIPTION
Old, and now inaccurate description of this PR, kept for posterity (See later comment for new description):

Attempted to implement `ns.closeTail()`, `ns.closeTail(pid)`, and `ns.closeTail(fn, hostname, ...args)`. Currently, `ns.closeTail()` works, `ns.closeTail(pid)` works if the given pid points to a script that's still running, and `ns.closeTail(fn, hostname, ...args)` works. It has not been tested extensively, and has not been formatted/linted because it's a WIP.

Related to #3585