### PR TITLE
STANEK: Properly reapply entropy in Stanek's Gift

### DIFF
--- a/src/CotMG/StaneksGift.ts
+++ b/src/CotMG/StaneksGift.ts
@@ -136,8 +136,9 @@ export class StaneksGift implements IStaneksGift {
   }
 
   updateMults(p: IPlayer): void {
-    p.reapplyAllAugmentations(true);
-    p.reapplyAllSourceFiles();
+    // applyEntropy also reapplies all augmentations and source files
+    // This wraps up the reset nicely
+    p.applyEntropy(p.entropy);
 
     for (const aFrag of this.fragments) {
       const fragment = aFrag.fragment();


### PR DESCRIPTION
stanek's `updateMults` method now calls `Player.applyEntropy`, which reapplies augmentations and sourcefiles (same as before), but also now properly applies entropy as well