### PR TITLE
UI: Fix exclusive augs not always showing as purchasable through gangs when they should

### DIFF
--- a/src/Augmentation/ui/PurchasableAugmentations.tsx
+++ b/src/Augmentation/ui/PurchasableAugmentations.tsx
@@ -83,7 +83,7 @@ const Exclusive = (props: IExclusiveProps): React.ReactElement => {
               <li>
                 <b>{props.aug.factions[0]}</b> faction
               </li>
-              {props.player.canAccessGang() && !props.aug.isSpecial && (
+              {props.player.isAwareOfGang() && !props.aug.isSpecial && (
                 <li>
                   Certain <b>gangs</b>
                 </li>


### PR DESCRIPTION
changes the check for the `Certain gangs` bullet point in the purchasable augmentations UI to check via `Player.isAwareOfGang()` rather than `Player.canAccessGang()`