### PR TITLE
AUGMENTATIONS: Use disabled text color for non-buyable augs

### DIFF
--- a/src/Augmentation/ui/PurchasableAugmentations.tsx
+++ b/src/Augmentation/ui/PurchasableAugmentations.tsx
@@ -219,7 +219,10 @@ export function PurchasableAugmentation(props: IPurchasableAugProps): React.Reac
                   textOverflow: "ellipsis",
                   whiteSpace: "nowrap",
                   overflow: "hidden",
-                  color: props.owned ? Settings.theme.disabled : Settings.theme.primary,
+                  color:
+                    props.owned || !props.parent.canPurchase(props.parent.player, aug)
+                      ? Settings.theme.disabled
+                      : Settings.theme.primary,
                 }}
               >
                 {aug.name}


### PR DESCRIPTION
changes the title color for augs that can't currently be bought (i.e. lack of money or rep) to use the `disabled` color to more clearly separate them

![image](https://user-images.githubusercontent.com/60761231/169627437-f00af935-320b-4361-9a7d-ddd7e9873d23.png)
