### PR TITLE
MISC: FIX Update type in NetscriptDefinitions.d.ts for ns.args[0] being undefined

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4532,7 +4532,7 @@ export interface NS {
    * It is also possible to get the number of arguments that was passed into a script using: 'args.length'
    * WARNING: Do not try to modify the args array. This will break the game.
    */
-  readonly args: (string | number | boolean)[];
+  readonly args: (string | number | boolean | undefined)[];
 
   /**
    * Steal a servers money.


### PR DESCRIPTION
Simple one liner PR.
Add undefined type to `ns.args[]` for better type checking

## Details
I've copied over this type file to vscode, and linter didn't warn that args was never undefined.
Hence I was caught out, and had the below error pop up in bitburner.

```js
const target = ns.args[0].toString()
```
![image](https://user-images.githubusercontent.com/12622625/169638237-a5b64ff4-0a1f-4861-89d6-2dd963b1fbcf.png)

It may be good to merge this PR so others won't be caught out by this.

For reference, nodejs `process.env` types uses `Dict<string>` which has `undefined` explicitly stated
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/75f98a0b191aa1458658b90b5b1329748cc3c082/types/node/v14/globals.d.ts#L739
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/75f98a0b191aa1458658b90b5b1329748cc3c082/types/node/v14/process.d.ts#L84

