### PR TITLE
MISC: FIX 3690 Add missing function to RamCostGenerator

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -105,6 +105,7 @@ const hacknet: IMap<any> = {
   numHashes: 0,
   hashCost: 0,
   spendHashes: 0,
+  maxNumNodes: 0,
 };
 
 // Stock API


### PR DESCRIPTION
In 1.7.0, the function ns.hacknet.maxNumNodes() is missing from RamCostGenerator.ts 

This fix adds the missing function to the appropriate section in src.

*Running the test script:*

Before: 
![2022-05-21 18_05_53- dev  Bitburner v1 7 0 (35978689) (Ubuntu)](https://user-images.githubusercontent.com/4533301/169659995-fc71745e-891a-4617-818f-ba39f3008240.png)

After:
![2022-05-21 18_01_40- dev  Bitburner v1 7 0 (35978689) (Ubuntu)](https://user-images.githubusercontent.com/4533301/169660017-fd264281-44a4-49a9-a681-2a53f3d90e23.png)
