### PR TITLE
WORK: FIX #2721 Singularity faction work logging.

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -993,6 +993,7 @@ export function finishFactionWork(this: IPlayer, cancelled: boolean, sing = fals
   faction.playerReputation += this.workRepGained;
 
   this.updateSkillLevels();
+  let res = "";
 
   if (!sing) {
     dialogBoxCreate(
@@ -1013,12 +1014,8 @@ export function finishFactionWork(this: IPlayer, cancelled: boolean, sing = fals
         <br />
       </>,
     );
-  }
-
-  this.isWorking = false;
-  this.resetWorkStatus();
-  if (sing) {
-    const res =
+  } else {
+    res =
       "You worked for your faction " +
       faction.name +
       " for a total of " +
@@ -1039,10 +1036,11 @@ export function finishFactionWork(this: IPlayer, cancelled: boolean, sing = fals
       " agi exp, and " +
       numeralWrapper.formatExp(this.workChaExpGained) +
       " cha exp.";
-
-    return res;
   }
-  return "";
+
+  this.isWorking = false;
+  this.resetWorkStatus();
+  return res;
 }
 
 //Money gained per game cycle


### PR DESCRIPTION
fixes #2721

Player's faction-work-related property were reset to 0 before the singularity's log message was formatted.
Reset is performed after preparing log message now.

I anticipate (really) minor conflict with Work System rework PR.