### PR TITLE
UI: FIX #2962 Add a setting to display middle time unit in Time Elapsed String

### DIFF
--- a/src/GameOptions/ui/CurrentOptionsPage.tsx
+++ b/src/GameOptions/ui/CurrentOptionsPage.tsx
@@ -220,6 +220,12 @@ export const CurrentOptionsPage = (props: IProps): React.ReactElement => {
             <>If this is set all references to memory will use GiB instead of GB, in accordance with IEC 60027-2.</>
           }
         />
+        <OptionSwitch
+          checked={Settings.ShowMiddleNullTimeUnit}
+          onChange={(newValue) => (Settings.ShowMiddleNullTimeUnit = newValue)}
+          text="Show all intermediary times unit, even when null."
+          tooltip={<>ex : 1 hours 13 seconds becomes 1 hours 0 minutes 13 seconds.</>}
+        />
         <Tooltip
           title={
             <Typography>

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -155,8 +155,8 @@ interface IDefaultSettings {
   UseIEC60027_2: boolean;
 
   /*
-  * Display intermediary time unit when their value is null
-  */
+   * Display intermediary time unit when their value is null
+   */
   ShowMiddleNullTimeUnit: boolean;
 
   /*

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -155,6 +155,11 @@ interface IDefaultSettings {
   UseIEC60027_2: boolean;
 
   /*
+  * Display intermediary time unit when their value is null
+  */
+  ShowMiddleNullTimeUnit: boolean;
+
+  /*
    * Character overview settings
    */
   overview: OverviewSettings;
@@ -222,6 +227,8 @@ export const defaultSettings: IDefaultSettings = {
   SuppressSavedGameToast: false,
   SuppressAutosaveDisabledWarnings: false,
   UseIEC60027_2: false,
+  ShowMiddleNullTimeUnit: false,
+
   ExcludeRunningScriptsFromSave: false,
   IsSidebarOpened: true,
 
@@ -265,6 +272,7 @@ export const Settings: ISettings & ISelfInitializer & ISelfLoading = {
   SuppressSavedGameToast: defaultSettings.SuppressSavedGameToast,
   SuppressAutosaveDisabledWarnings: defaultSettings.SuppressAutosaveDisabledWarnings,
   UseIEC60027_2: defaultSettings.UseIEC60027_2,
+  ShowMiddleNullTimeUnit: defaultSettings.ShowMiddleNullTimeUnit,
   ExcludeRunningScriptsFromSave: defaultSettings.ExcludeRunningScriptsFromSave,
   IsSidebarOpened: defaultSettings.IsSidebarOpened,
 

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -1,3 +1,4 @@
+import { Settings } from "../Settings/Settings";
 import { EqualityFunc } from "../types";
 import { isString } from "./helpers/isString";
 
@@ -39,10 +40,10 @@ function convertTimeMsToTimeElapsedString(time: number, showMilli = false): stri
   if (days > 0) {
     res += `${days} days `;
   }
-  if (hours > 0) {
+  if (hours > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
     res += `${hours} hours `;
   }
-  if (minutes > 0) {
+  if (minutes > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
     res += `${minutes} minutes `;
   }
   res += `${seconds} seconds`;


### PR DESCRIPTION
Fix #2962 Add a setting to display middle time unit in Time Elapsed String

ex : "1 days 14 seconds" becomes "1 days 0 hours 0 minutes 14 seconds".
"13 hours 55 seconds" becomes "13 hours 0 minutes 55 seconds".

![image](https://user-images.githubusercontent.com/104104269/169671221-4f4741d4-5686-468f-89da-aa33a213d088.png)


(Honestly, I'm not convinced of the added-value of this PR. But regardless of if it will be discarded or merged, at least, the issue will be adressed.)

Let me now if the toggleable settings is uneeded.

