### PR TITLE
BLADEBURNER: FIX #3685 Error being thrown when finishing a BlackOps

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1677,11 +1677,11 @@ export class Bladeburner implements IBladeburner {
     this.actionTimeOverflow = 0;
     if (this.actionTimeCurrent >= this.actionTimeToComplete) {
       this.actionTimeOverflow = this.actionTimeCurrent - this.actionTimeToComplete;
+      const action = this.getActionObject(this.action);
       const retValue = this.completeAction(player, player, this.action);
       player.gainMoney(retValue.money, "bladeburner");
       player.gainStats(retValue);
       // Operation Daedalus
-      const action = this.getActionObject(this.action);
       if (action == null) {
         throw new Error("Failed to get BlackOperation Object for: " + this.action.name);
       } else if (action.name === BlackOperationNames.OperationDaedalus && this.blackops[action.name]) {


### PR DESCRIPTION
fixes #3685 - Bladeburner.action property was reset before being used for the last time in Bladeburner.processAction().
fixes #3701 - duplicate of the issue

Moving
`const action = this.getActionObject(this.action);`
before the call to
`const retValue = this.completeAction(player, player, this.action);`

Thus, ensuring the action state stay available for whatever check needs to be performed below.

