### PR TITLE
UI: FIX #3514 Clear recently killed tab on BN end event

### DIFF
--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -15,6 +15,7 @@ import { updateHashManagerCapacity } from "./Hacknet/HacknetHelpers";
 import { prestigeWorkerScripts } from "./NetscriptWorker";
 import { Player } from "./Player";
 import { Router } from "./ui/GameRoot";
+import { recentScripts } from "./Netscript/RecentScripts";
 import { resetPidCounter } from "./Netscript/Pid";
 import { LiteratureNames } from "./Literature/data/LiteratureNames";
 
@@ -309,5 +310,7 @@ export function prestigeSourceFile(flume: boolean): void {
   // Gain int exp
   if (Player.sourceFileLvl(5) !== 0 && !flume) Player.gainIntelligenceExp(300);
 
+  // Clear recent scripts
+  recentScripts.splice(0, recentScripts.length);
   resetPidCounter();
 }


### PR DESCRIPTION
## Issue

The player could still see their old script logs after a hard reset (BitNode end/flume).
Fixes #3514.

## Solution
The ``prestigeSourceFile`` function in ``Prestige.ts`` has been altered to empty the ``RecentScripts`` collection on call.

```js
export function prestigeSourceFile(flume: boolean): void {
   // ...
   // Clear recent scripts
   recentScripts.splice(0, recentScripts.length);
   // ...
}
```


One could do the same in ``prestigeAugmentation``, however, since some players might forcefully soft-reset to fix some issue in the game and might want access to their script logs, one might want to lean on the conservative side. Will add on request, if needed.

## Testing

The changes have been tested by running dummy scripts and checking for their presence after a ``prestigeSourceFile`` call, with success.