### PR TITLE
BLADEBURNER: FIX #3508 Add GetActionCurrentTime() to Bitburner API

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -287,6 +287,8 @@ export class Bladeburner implements IBladeburner {
 
   resetAction(): void {
     this.action = new ActionIdentifier({ type: ActionTypes.Idle });
+    this.actionTimeCurrent = 0;
+    this.actionTimeToComplete = 0;
   }
 
   clearConsole(): void {

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -226,6 +226,7 @@ const bladeburner: IMap<any> = {
   stopBladeburnerAction: RamCostConstants.ScriptBladeburnerApiBaseRamCost / 2,
   getCurrentAction: RamCostConstants.ScriptBladeburnerApiBaseRamCost / 4,
   getActionTime: RamCostConstants.ScriptBladeburnerApiBaseRamCost,
+  getActionCurrentTime: RamCostConstants.ScriptBladeburnerApiBaseRamCost,
   getActionEstimatedSuccessChance: RamCostConstants.ScriptBladeburnerApiBaseRamCost,
   getActionRepGain: RamCostConstants.ScriptBladeburnerApiBaseRamCost,
   getActionCountRemaining: RamCostConstants.ScriptBladeburnerApiBaseRamCost,

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -142,10 +142,9 @@ export function NetscriptBladeburner(player: IPlayer, workerScript: WorkerScript
       const bladeburner = player.bladeburner;
       if (bladeburner === null) throw new Error("Should not be called without Bladeburner");
       try {
-        const timecomputed = Math.min(
-          bladeburner.actionTimeCurrent + bladeburner.actionTimeOverflow,
-          bladeburner.actionTimeToComplete,
-        ) * 1000 ;
+        const timecomputed =
+          Math.min(bladeburner.actionTimeCurrent + bladeburner.actionTimeOverflow, bladeburner.actionTimeToComplete) *
+          1000;
         return timecomputed;
       } catch (e: any) {
         throw ctx.makeRuntimeErrorMsg(e);

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -137,6 +137,20 @@ export function NetscriptBladeburner(player: IPlayer, workerScript: WorkerScript
           throw ctx.makeRuntimeErrorMsg(e);
         }
       },
+    getActionCurrentTime: (ctx: NetscriptContext) => (): number => {
+      checkBladeburnerAccess(ctx);
+      const bladeburner = player.bladeburner;
+      if (bladeburner === null) throw new Error("Should not be called without Bladeburner");
+      try {
+        const timecomputed = Math.min(
+          bladeburner.actionTimeCurrent + bladeburner.actionTimeOverflow,
+          bladeburner.actionTimeToComplete,
+        ) * 1000 ;
+        return timecomputed;
+      } catch (e: any) {
+        throw ctx.makeRuntimeErrorMsg(e);
+      }
+    },
     getActionEstimatedSuccessChance:
       (ctx: NetscriptContext) =>
       (_type: unknown, _name: unknown): [number, number] => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2897,7 +2897,7 @@ export interface Bladeburner {
    * @remarks
    * RAM cost: 4 GB
    *
-   * Returns the number of milliseconds it takes to complete the specified action
+   * Returns the number of milliseconds already spent on the current action.
    *
    * @returns Number of milliseconds already spent on the current action.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2884,13 +2884,24 @@ export interface Bladeburner {
    * @remarks
    * RAM cost: 4 GB
    *
-   * Returns the number of seconds it takes to complete the specified action
+   * Returns the number of milliseconds it takes to complete the specified action
    *
    * @param type - Type of action.
    * @param name - Name of action. Must be an exact match.
    * @returns Number of milliseconds it takes to complete the specified action.
    */
   getActionTime(type: string, name: string): number;
+
+  /**
+   * Get the time elapsed on current action.
+   * @remarks
+   * RAM cost: 4 GB
+   *
+   * Returns the number of milliseconds it takes to complete the specified action
+   *
+   * @returns Number of milliseconds already spent on the current action.
+   */
+  getActionCurrentTime(): number;
 
   /**
    * Get estimate success chance of an action.


### PR DESCRIPTION
FIX #3508 - Add GetActionCurrentTime() to Bitburner API.
Slightly tweak BItburner.resetAction() to also reset time counters.
Fix GetActionTime documentation. 


I've some concerns : 

Not sure if it's the intended way to exploit Bladeburner API. Or if the player is expected to use ns.sleep in conjunction with getActionTime() instead.

Currently, the function return 0 when no Action is underway. Should it rather return NaN or throw an Error ?

