### PR TITLE
UI: FIX #3376 Add a Total Profit line on Corporation Overview

### DIFF
--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -60,6 +60,7 @@ export function Overview({ rerender }: IProps): React.ReactElement {
           ["Total Funds:", <Money money={corp.funds} />],
           ["Total Revenue:", <MoneyRate money={corp.revenue} />],
           ["Total Expenses:", <MoneyRate money={corp.expenses} />],
+          ["Total Profit:", <MoneyRate money={corp.revenue-corp.expenses} />],
           ["Publicly Traded:", corp.public ? "Yes" : "No"],
           ["Owned Stock Shares:", numeralWrapper.format(corp.numShares, "0.000a")],
           ["Stock Price:", corp.public ? <Money money={corp.sharePrice} /> : "N/A"],


### PR DESCRIPTION
Close # 3376 - Add a Total Profit line on Corporation Overview.

![image](https://user-images.githubusercontent.com/104104269/169689700-85509486-4567-45f4-b257-c422d5618a68.png)

Feels a bit like a low added-value bloat.
But division did use that pattern already, so I guess it can count as streamlining.

![image](https://user-images.githubusercontent.com/104104269/169689728-097f1bda-5b2f-4a85-85f5-b1cf870c0137.png)