### PR TITLE
LOGS: Fix text wrap in log boxes

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -103,6 +103,7 @@ const useStyles = makeStyles((_theme: Theme) =>
       scrollbarWidth: "auto",
       flexDirection: "column-reverse",
       whiteSpace: "pre-wrap",
+      wordWrap: "break-word",
     },
     titleButton: {
       padding: "1px 0",


### PR DESCRIPTION
wrapping behavior was different between browsers

fixes #3699