### PR TITLE
UI: FIX #3714 Add tprintf to RamCostGenerator

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -356,6 +356,7 @@ export const RamCosts: IMap<any> = {
   print: 0,
   printf: 0,
   tprint: 0,
+  tprintf: 0,
   clearLog: 0,
   disableLog: 0,
   enableLog: 0,


### PR DESCRIPTION
Fixes #3714

`tprintf` is not defined in RamCosts thus spams developer console every time it's called in a script

This pr defines `tprintf` as cost 0, coherent with the other print functions