### PR TITLE
INFILTRATION: FIX#3720 SoA reputation exploit on Infiltration/Victory screen

### DIFF
--- a/src/Infiltration/ui/Victory.tsx
+++ b/src/Infiltration/ui/Victory.tsx
@@ -44,8 +44,8 @@ export function Victory(props: IProps): React.ReactElement {
   }
 
   function trade(): void {
-    handleInfiltrators();
     if (faction === "none") return;
+    handleInfiltrators();
     Factions[faction].playerReputation += repGain;
     quitInfiltration();
   }


### PR DESCRIPTION
fixes #3720 

On Infiltration's reward screen, when trading for rep :
SoA reward are not longer processed when selecting "none" in the faction's dropdownmenu. Effectively preventing to receiving SoA reward several time per infiltration run.