### PR TITLE
API: Fix #3661 Add missing memory property to Sleeve API

### DIFF
--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -38,6 +38,7 @@ export function NetscriptSleeve(player: IPlayer): InternalAPI<ISleeve> {
     return {
       shock: 100 - sl.shock,
       sync: sl.sync,
+      memory: sl.memory,
       hacking: sl.hacking,
       strength: sl.strength,
       defense: sl.defense,

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1050,6 +1050,8 @@ export interface SleeveSkills {
   shock: number;
   /** Current sync of the sleeve [0-100] */
   sync: number;
+  /** Current memory of the sleeve [1-100] */
+  memory: number;
   /** Current hacking skill of the sleeve */
   hacking: number;
   /** Current strength of the sleeve */


### PR DESCRIPTION
fixes #3661

Add the missing memory stat to NS.SleeveSkills Interface.
Update ns.Sleeve.GetSleeveStats accordingly.
![image](https://user-images.githubusercontent.com/104104269/169878215-a9ad0d7d-75d0-4134-89bc-e8918d7bf588.png)
