### PR TITLE
API: Fix #2700 alter/add API function to get unmodified augmentation cost.

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -287,6 +287,8 @@ const sleeve: IMap<any> = {
   getSleevePurchasableAugs: RamCostConstants.ScriptSleeveBaseRamCost,
   purchaseSleeveAug: RamCostConstants.ScriptSleeveBaseRamCost,
   setToBladeburnerAction: RamCostConstants.ScriptSleeveBaseRamCost,
+  getSleeveAugmentationPrice: RamCostConstants.ScriptSleeveBaseRamCost,
+  getSleeveAugmentationRepReq: RamCostConstants.ScriptSleeveBaseRamCost,
 };
 
 // Stanek API

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -134,18 +134,20 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
         return aug.prereqs.slice();
       },
     getAugmentationPrice: (_ctx: NetscriptContext) =>
-      function (_augName: unknown): number {
+      function (_augName: unknown, _returnBasePrice: unknown = false): number {
         _ctx.helper.checkSingularityAccess();
         const augName = _ctx.helper.string("augName", _augName);
+        const returnBasePrice = _ctx.helper.boolean(_returnBasePrice);
         const aug = getAugmentation(_ctx, augName);
-        return aug.getCost(player).moneyCost;
+        return !returnBasePrice ? aug.getCost(player).moneyCost : aug.baseCost;
       },
     getAugmentationRepReq: (_ctx: NetscriptContext) =>
-      function (_augName: unknown): number {
+      function (_augName: unknown, _returnBasePrice: unknown = false): number {
         _ctx.helper.checkSingularityAccess();
         const augName = _ctx.helper.string("augName", _augName);
+        const returnBasePrice = _ctx.helper.boolean(_returnBasePrice);
         const aug = getAugmentation(_ctx, augName);
-        return aug.getCost(player).repCost;
+        return !returnBasePrice ? aug.getCost(player).repCost : aug.baseRepRequirement;
       },
     getAugmentationStats: (_ctx: NetscriptContext) =>
       function (_augName: unknown): AugmentationStats {

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -15,6 +15,7 @@ import {
 } from "../ScriptEditor/NetscriptDefinitions";
 import { checkEnum } from "../utils/helpers/checkEnum";
 import { InternalAPI, NetscriptContext } from "../Netscript/APIWrapper";
+import { Augmentation } from "../Augmentation/Augmentation";
 
 export function NetscriptSleeve(player: IPlayer): InternalAPI<ISleeve> {
   const checkSleeveAPIAccess = function (ctx: NetscriptContext): void {
@@ -271,6 +272,22 @@ export function NetscriptSleeve(player: IPlayer): InternalAPI<ISleeve> {
           augs.push(player.sleeves[sleeveNumber].augmentations[i].name);
         }
         return augs;
+      },
+    getSleeveAugmentationPrice:
+      (ctx: NetscriptContext) =>
+      (_augName: unknown): number => {
+        checkSleeveAPIAccess(ctx);
+        const augName = ctx.helper.string("augName", _augName);
+        const aug: Augmentation = StaticAugmentations[augName];
+        return aug.baseCost;
+      },
+    getSleeveAugmentationRepReq:
+      (ctx: NetscriptContext) =>
+      (_augName: unknown, _basePrice = false): number => {
+        checkSleeveAPIAccess(ctx);
+        const augName = ctx.helper.string("augName", _augName);
+        const aug: Augmentation = StaticAugmentations[augName];
+        return aug.getCost(player).repCost;
       },
     getSleevePurchasableAugs:
       (ctx: NetscriptContext) =>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2160,9 +2160,10 @@ export interface Singularity {
    *
    *
    * @param augName - Name of Augmentation.
+   * @param basePrice - If true, function return base cost value. False by default.
    * @returns Price of the augmentation.
    */
-  getAugmentationPrice(augName: string): number;
+  getAugmentationPrice(augName: string, returnBasePrice?: boolean): number;
 
   /**
    * Get reputation requirement of an augmentation.
@@ -2171,9 +2172,10 @@ export interface Singularity {
    *
    *
    * @param augName - Name of Augmentation.
+   * @param basePrice - If true, function return base cost value. False by default.
    * @returns Reputation requirement of the augmentation.
    */
-  getAugmentationRepReq(augName: string): number;
+  getAugmentationRepReq(augName: string, returnBasePrice?: boolean): number;
 
   /**
    * Purchase an augmentation
@@ -3775,6 +3777,28 @@ export interface Sleeve {
    * @returns List of augmentation names that this sleeve has installed.
    */
   getSleeveAugmentations(sleeveNumber: number): string[];
+
+  /**
+   * Get price of an augmentation.
+   * @remarks
+   * RAM cost: 4 GB
+   *
+   *
+   * @param augName - Name of Augmentation.
+   * @returns Price of the augmentation.
+   */
+  getSleeveAugmentationPrice(augName: string): number;
+
+  /**
+   * Get reputation requirement of an augmentation.
+   * @remarks
+   * RAM cost: 4 GB
+   *
+   *
+   * @param augName - Name of Augmentation.
+   * @returns Reputation requirement of the augmentation.
+   */
+  getSleeveAugmentationRepReq(augName: string): number;
 
   /**
    * List purchasable augs for a sleeve.


### PR DESCRIPTION
fixes #2700

Tweaked existing function : ( by adding a returnBaseCost boolean parameter. )
-    singularity.GetAugmentationPrice( )
-    singularity.GetAugmentationRepReq( )
 
Added new functions :
-    sleeve.GetSleeveAugmentationPrice( )
-    sleeve.GetSleeveAugmentationRepReq( )

![image](https://user-images.githubusercontent.com/104104269/169890648-7a1828f3-ba32-47f7-947d-2712f5ddd3fa.png)
