### PR TITLE
MISC: FIX #2709: Generate contracts while offline

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -282,7 +282,6 @@ const Engine: {
         // just average it.
         numContracts = (numCyclesOffline / 3000) * 0.25;
       }
-      console.log(`${numCyclesOffline} ${numContracts}`);
       for (let i = 0; i < numContracts; i++) {
         generateRandomContract();
       }

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -272,20 +272,20 @@ const Engine: {
       const numCyclesOffline = Math.floor(timeOffline / CONSTANTS._idleSpeed);
 
       // Generate coding contracts
-      // let numContracts = 0;
-      // if (numCyclesOffline < 3000 * 100) {
-      //   // if we have less than 100 rolls, just roll them exactly.
-      //   for (let i = 0; i < numCyclesOffline / 3000; i++) {
-      //     if (Math.random() < 0.25) numContracts++;
-      //   }
-      // } else {
-      //   // just average it.
-      //   numContracts = (numCyclesOffline / 3000) * 0.25;
-      // }
-      // console.log(`${numCyclesOffline} ${numContracts}`);
-      // for (let i = 0; i < numContracts; i++) {
-      //   generateRandomContract();
-      // }
+      let numContracts = 0;
+      if (numCyclesOffline < 3000 * 100) {
+        // if we have less than 100 rolls, just roll them exactly.
+        for (let i = 0; i < numCyclesOffline / 3000; i++) {
+          if (Math.random() < 0.25) numContracts++;
+        }
+      } else {
+        // just average it.
+        numContracts = (numCyclesOffline / 3000) * 0.25;
+      }
+      console.log(`${numCyclesOffline} ${numContracts}`);
+      for (let i = 0; i < numContracts; i++) {
+        generateRandomContract();
+      }
 
       let offlineReputation = 0;
       const offlineHackingIncome = (Player.moneySourceA.hacking / Player.playtimeSinceLastAug) * timeOffline * 0.75;


### PR DESCRIPTION
# DO NOT MERGE THIS PR UNTIL 3711 IS FIXED
# Feature

Add generation of contracts during bonus time.

## Linked issues

Closes #2709. 
#3711 - see below 

## Implementation
Refer to 2709.
Uncommented the code present in ``Engine.tsx`` - as rolling for the generation of a contract is done every 3000 cycles (1 cycle = 200 ms, 3000 cycles = 10 minutes) the code does exactly that with offline cycles. 

**The following code will generate less contracts than expected on average. This is due to 3711.**
```js
      // Generate coding contracts
      let numContracts = 0;
      if (numCyclesOffline < 3000 * 100) {
        // if we have less than 100 rolls, just roll them exactly.
        for (let i = 0; i < numCyclesOffline / 3000; i++) {
          if (Math.random() < 0.25) numContracts++;
        }
      } else {
        // just average it.
        numContracts = (numCyclesOffline / 3000) * 0.25;
      }
      console.log(`${numCyclesOffline} ${numContracts}`);
      for (let i = 0; i < numContracts; i++) {
        generateRandomContract();
      }
```

# Testing

See 3711.


