### PR TITLE
API: FIX#3732  Cannot assign two sleeve on "Take on contracts" regardless of contract type.

### DIFF
--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -332,7 +332,11 @@ export function NetscriptSleeve(player: IPlayer): InternalAPI<ISleeve> {
               continue;
             }
             const other = player.sleeves[i];
-            if (other.currentTask === SleeveTaskType.Bladeburner && other.bbAction === action) {
+            if (
+              other.currentTask === SleeveTaskType.Bladeburner &&
+              other.bbAction === action &&
+              other.bbContract === contract
+            ) {
               throw ctx.helper.makeRuntimeErrorMsg(
                 `Sleeve ${sleeveNumber} cannot take of contracts because Sleeve ${i} is already performing that action.`,
               );

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -338,7 +338,7 @@ export function NetscriptSleeve(player: IPlayer): InternalAPI<ISleeve> {
               other.bbContract === contract
             ) {
               throw ctx.helper.makeRuntimeErrorMsg(
-                `Sleeve ${sleeveNumber} cannot take of contracts because Sleeve ${i} is already performing that action.`,
+                `Sleeve ${sleeveNumber} cannot take on contracts because Sleeve ${i} is already performing that action.`,
               );
             }
           }


### PR DESCRIPTION
fixes #3732
fixes #3773
ns.sleeve.setToBladeburnerAction() was not checking properly for other sleeve already taking undertaking the same contract.

Testing : 
```
/** @param {NS} ns */
export async function main(ns) {
	ns.sleeve.setToBladeburnerAction(0,"Take on contracts","Retirement");
	ns.sleeve.setToBladeburnerAction(1,"Take on contracts","Tracking");
	ns.sleeve.setToBladeburnerAction(2,"Take on contracts","Retirement");
}
```
Was failing on the second setAction call. 
Now fail on third call as intended.

![image](https://user-images.githubusercontent.com/104104269/169921760-d78679c6-3ae5-4def-bf73-26cd9aaceda2.png)

