### PR TITLE
MISC: FIX #3711 Generate contracts only on network

### DIFF
--- a/src/CodingContractGenerator.ts
+++ b/src/CodingContractGenerator.ts
@@ -155,7 +155,7 @@ function getRandomReward(): ICodingContractReward {
 }
 
 function getRandomServer(): BaseServer {
-  const servers = GetAllServers();
+  const servers = GetAllServers().filter((server: BaseServer) => server.serversOnNetwork.length !== 0);
   let randIndex = getRandomInt(0, servers.length - 1);
   let randServer = servers[randIndex];
 


### PR DESCRIPTION
# Issue

Contracts could appear on servers that are not part of the network, such as ``darkweb``.

# Fix

Contracts will now only generate on servers that are part of the network.

In CodingContractGenerator.ts >> getRandomServer(): 
```ts
function getRandomServer(): BaseServer {
  const servers = GetAllServers().filter((server: BaseServer) => server.serversOnNetwork.length !== 0);
  // ...
```
  

# Linked issues
Closes #3711 

# Tests

Tested by spawning 2000+ contracts, none generated on ``darkweb`` or world daemon.
