### PR TITLE
MISC: Fix #3742 manualHack() should use correct BitNode Multiplier

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -427,8 +427,12 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
         if (server.moneyAvailable < 0) {
           server.moneyAvailable = 0;
         }
-
-        const moneyGained = moneyDrained * BitNodeMultipliers.ScriptHackMoneyGain;
+        
+        if (manual) {
+          const moneyGained = moneyDrained * BitNodeMultipliers.ManualHackMoney;
+        } else {
+          const moneyGained = moneyDrained * BitNodeMultipliers.ScriptHackMoneyGain;
+        }
 
         Player.gainMoney(moneyGained, "hacking");
         workerScript.scriptRef.onlineMoneyMade += moneyGained;


### PR DESCRIPTION
Fix #3742