### PR TITLE
MISC: Remove progMult fomr product create as it is redundant

### DIFF
--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -131,8 +131,6 @@ export class Product {
     this.fin = true;
 
     //Calculate properties
-    const progrMult = this.prog / 100;
-
     const engrRatio = employeeProd[EmployeePositions.Engineer] / employeeProd["total"];
     const mgmtRatio = employeeProd[EmployeePositions.Management] / employeeProd["total"];
     const rndRatio = employeeProd[EmployeePositions.RandD] / employeeProd["total"];
@@ -141,7 +139,7 @@ export class Product {
     const designMult = 1 + Math.pow(this.designCost, 0.1) / 100;
     const balanceMult = 1.2 * engrRatio + 0.9 * mgmtRatio + 1.3 * rndRatio + 1.5 * opsRatio + busRatio;
     const sciMult = 1 + Math.pow(industry.sciResearch.qty, industry.sciFac) / 800;
-    const totalMult = progrMult * balanceMult * designMult * sciMult;
+    const totalMult = balanceMult * designMult * sciMult;
 
     this.qlt =
       totalMult *


### PR DESCRIPTION
There was a case where the progMult could go over 100%, as it looks to be redundant simply removing instead of capping at a max of 100%

File List:
src/Corporation/Product.ts

closes #3737 