### PR TITLE
API: Lightweight FIX - in-game API doc Gang & Bladeburner getBonusTime() referenced wrong time unit

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3257,7 +3257,7 @@ export interface Bladeburner {
    * @remarks
    * RAM cost: 0 GB
    *
-   * Returns the amount of accumulated “bonus time” (seconds) for the Bladeburner mechanic.
+   * Returns the amount of accumulated “bonus time” (milliseconds) for the Bladeburner mechanic.
    *
    * “Bonus time” is accumulated when the game is offline or if the game is inactive in the browser.
    *
@@ -3594,7 +3594,7 @@ export interface Gang {
    * @remarks
    * RAM cost: 0 GB
    *
-   * Returns the amount of accumulated “bonus time” (seconds) for the Gang mechanic.
+   * Returns the amount of accumulated “bonus time” (milliseconds) for the Gang mechanic.
    *
    * “Bonus time” is accumulated when the game is offline or if the game is inactive in the browser.
    *


### PR DESCRIPTION
Fix two instances of in-game API doc referencing the wrong time unit.

ns.Gang.GetBonusTime()
ns.Bladeburner.GetBonusTime()

Description stated that function returned time in second. When its actually millisecond.