### PR TITLE
UI: Fixed an issue causing BN12 stats to show incorrectly

### DIFF
--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -228,8 +228,7 @@ export function CharacterStats(): React.ReactElement {
   let showBitNodeMults = false;
   if (player.sourceFileLvl(5) > 0) {
     const n = player.bitNodeN;
-    const maxSfLevel = n === 12 ? Infinity : 3;
-    const mults = getBitNodeMultipliers(n, Math.min(player.sourceFileLvl(n) + 1, maxSfLevel));
+    const mults = getBitNodeMultipliers(n, player.sourceFileLvl(n));
     showBitNodeMults = !isEqual(mults, defaultMultipliers);
   }
 


### PR DESCRIPTION
Fixed an off-by-one error causing the stats screen to display BN mults for BN12.(n+1) when the player was actually in BN12.n