### PR TITLE
CORPORATION: (BREAKING) Dividend fixes and exposing dividends info via scripts

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -84,12 +84,12 @@ export function LevelUpgrade(corporation: ICorporation, upgrade: CorporationUpgr
   }
 }
 
-export function IssueDividends(corporation: ICorporation, percent: number): void {
-  if (isNaN(percent) || percent < 0 || percent > CorporationConstants.DividendMaxPercentage) {
-    throw new Error(`Invalid value. Must be an integer between 0 and ${CorporationConstants.DividendMaxPercentage}`);
+export function IssueDividends(corporation: ICorporation, rate: number): void {
+  if (isNaN(rate) || rate < 0 || rate > CorporationConstants.DividendMaxRate) {
+    throw new Error(`Invalid value. Must be an number between 0 and ${CorporationConstants.DividendMaxRate}`);
   }
 
-  corporation.dividendPercentage = percent * 100;
+  corporation.dividendRate = rate;
 }
 
 export function SellMaterial(mat: Material, amt: string, price: string): void {

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -35,8 +35,8 @@ export class Corporation {
   shareSalesUntilPriceUpdate = CorporationConstants.SHARESPERPRICEUPDATE;
   shareSaleCooldown = 0; // Game cycles until player can sell shares again
   issueNewSharesCooldown = 0; // Game cycles until player can issue shares again
-  dividendPercentage = 0;
-  dividendTaxPercentage = 50;
+  dividendRate = 0;
+  dividendTaxPercentage = 100 - 100 * BitNodeMultipliers.CorporationSoftcap;
   issuedShares = 0;
   sharePrice = 0;
   storedCycles = 0;
@@ -121,16 +121,16 @@ export class Corporation {
         }
 
         // Process dividends
-        if (this.dividendPercentage > 0 && cycleProfit > 0) {
+        if (this.dividendRate > 0 && cycleProfit > 0) {
           // Validate input again, just to be safe
           if (
-            isNaN(this.dividendPercentage) ||
-            this.dividendPercentage < 0 ||
-            this.dividendPercentage > CorporationConstants.DividendMaxPercentage * 100
+            isNaN(this.dividendRate) ||
+            this.dividendRate < 0 ||
+            this.dividendRate > CorporationConstants.DividendMaxRate
           ) {
-            console.error(`Invalid Corporation dividend percentage: ${this.dividendPercentage}`);
+            console.error(`Invalid Corporation dividend rate: ${this.dividendRate}`);
           } else {
-            const totalDividends = (this.dividendPercentage / 100) * cycleProfit;
+            const totalDividends = this.dividendRate * cycleProfit;
             const retainedEarnings = cycleProfit - totalDividends;
             player.gainMoney(this.getDividends(), "corporation");
             this.addFunds(retainedEarnings);
@@ -149,7 +149,7 @@ export class Corporation {
   getDividends(): number {
     const profit = this.revenue - this.expenses;
     const cycleProfit = profit * CorporationConstants.SecsPerMarketCycle;
-    const totalDividends = (this.dividendPercentage / 100) * cycleProfit;
+    const totalDividends = this.dividendRate * cycleProfit;
     const dividendsPerShare = totalDividends / this.totalShares;
     const dividends = this.numShares * dividendsPerShare;
     let upgrades = -0.15;
@@ -167,8 +167,8 @@ export class Corporation {
       profit = this.avgProfit;
     if (this.public) {
       // Account for dividends
-      if (this.dividendPercentage > 0) {
-        profit *= (100 - this.dividendPercentage) / 100;
+      if (this.dividendRate > 0) {
+        profit *= 1 - this.dividendRate;
       }
 
       val = this.funds + profit * 85e3;

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -133,7 +133,7 @@ export class Corporation {
           } else {
             const totalDividends = this.dividendRate * cycleProfit;
             const retainedEarnings = cycleProfit - totalDividends;
-            player.gainMoney(this.getDividends(), "corporation");
+            player.gainMoney(this.getCycleDividends(), "corporation");
             this.addFunds(retainedEarnings);
           }
         } else {
@@ -157,7 +157,7 @@ export class Corporation {
     }
   }
 
-  getDividends(): number {
+  getCycleDividends(): number {
     const profit = this.revenue - this.expenses;
     const cycleProfit = profit * CorporationConstants.SecsPerMarketCycle;
     const totalDividends = this.dividendRate * cycleProfit;

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -281,9 +281,7 @@ export class Corporation {
     this.funds = this.funds - price;
 
     // Apply effects for one-time upgrades
-    if (upgN === 5 || upgN === 6) {
-      this.updateDividendTax();
-    }
+    this.updateDividendTax();
   }
 
   //Levelable upgrades

--- a/src/Corporation/ICorporation.ts
+++ b/src/Corporation/ICorporation.ts
@@ -19,7 +19,7 @@ export interface ICorporation {
   shareSalesUntilPriceUpdate: number;
   shareSaleCooldown: number;
   issueNewSharesCooldown: number;
-  dividendPercentage: number;
+  dividendRate: number;
   dividendTaxPercentage: number;
   issuedShares: number;
   sharePrice: number;

--- a/src/Corporation/ICorporation.ts
+++ b/src/Corporation/ICorporation.ts
@@ -55,6 +55,6 @@ export interface ICorporation {
   getScientificResearchMultiplier(): number;
   getStarterGuide(player: IPlayer): void;
   updateDividendTax(): void;
-  getDividends(): number;
+  getCycleDividends(): number;
   toJSON(): any;
 }

--- a/src/Corporation/ICorporation.ts
+++ b/src/Corporation/ICorporation.ts
@@ -20,7 +20,7 @@ export interface ICorporation {
   shareSaleCooldown: number;
   issueNewSharesCooldown: number;
   dividendRate: number;
-  dividendTaxPercentage: number;
+  dividendTax: number;
   issuedShares: number;
   sharePrice: number;
   storedCycles: number;
@@ -54,6 +54,7 @@ export interface ICorporation {
   getSalesMultiplier(): number;
   getScientificResearchMultiplier(): number;
   getStarterGuide(player: IPlayer): void;
-  toJSON(): any;
+  updateDividendTax(): void;
   getDividends(): number;
+  toJSON(): any;
 }

--- a/src/Corporation/data/Constants.ts
+++ b/src/Corporation/data/Constants.ts
@@ -19,7 +19,7 @@ export const CorporationConstants: {
   BribeThreshold: number;
   BribeToRepRatio: number;
   ProductProductionCostRatio: number;
-  DividendMaxPercentage: number;
+  DividendMaxRate: number;
   EmployeeSalaryMultiplier: number;
   CyclesPerEmployeeRaise: number;
   EmployeeRaiseAmount: number;
@@ -61,7 +61,7 @@ export const CorporationConstants: {
 
   ProductProductionCostRatio: 5, //Ratio of material cost of a product to its production cost
 
-  DividendMaxPercentage: 1,
+  DividendMaxRate: 1,
 
   EmployeeSalaryMultiplier: 3, // Employee stats multiplied by this to determine initial salary
   CyclesPerEmployeeRaise: 400, // All employees get a raise every X market cycles

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -275,15 +275,15 @@ interface IDividendsStatsProps {
 }
 function DividendsStats({ profit }: IDividendsStatsProps): React.ReactElement {
   const corp = useCorporation();
-  if (corp.dividendPercentage <= 0 || profit <= 0) return <></>;
-  const totalDividends = (corp.dividendPercentage / 100) * profit;
+  if (corp.dividendRate <= 0 || profit <= 0) return <></>;
+  const totalDividends = corp.dividendRate * profit;
   const retainedEarnings = profit - totalDividends;
   const dividendsPerShare = totalDividends / corp.totalShares;
   return (
     <StatsTable
       rows={[
         ["Retained Profits (after dividends):", <MoneyRate money={retainedEarnings} />],
-        ["Dividend Percentage:", numeralWrapper.format(corp.dividendPercentage / 100, "0%")],
+        ["Dividend Percentage:", numeralWrapper.format(corp.dividendRate, "0%")],
         ["Dividends per share:", <MoneyRate money={dividendsPerShare} />],
         ["Your earnings as a shareholder:", <MoneyRate money={corp.getDividends()} />],
       ]}

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -279,7 +279,7 @@ function DividendsStats({ profit }: IDividendsStatsProps): React.ReactElement {
   const totalDividends = corp.dividendRate * profit;
   const retainedEarnings = profit - totalDividends;
   const dividendsPerShare = totalDividends / corp.totalShares;
-  const playerEarnings = corp.getDividends() / CorporationConstants.SecsPerMarketCycle;
+  const playerEarnings = corp.getCycleDividends() / CorporationConstants.SecsPerMarketCycle;
   return (
     <StatsTable
       rows={[

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -279,13 +279,14 @@ function DividendsStats({ profit }: IDividendsStatsProps): React.ReactElement {
   const totalDividends = corp.dividendRate * profit;
   const retainedEarnings = profit - totalDividends;
   const dividendsPerShare = totalDividends / corp.totalShares;
+  const playerEarnings = corp.getDividends() / CorporationConstants.SecsPerMarketCycle;
   return (
     <StatsTable
       rows={[
         ["Retained Profits (after dividends):", <MoneyRate money={retainedEarnings} />],
         ["Dividend Percentage:", numeralWrapper.format(corp.dividendRate, "0%")],
         ["Dividends per share:", <MoneyRate money={dividendsPerShare} />],
-        ["Your earnings as a shareholder:", <MoneyRate money={corp.getDividends()} />],
+        ["Your earnings as a shareholder:", <MoneyRate money={playerEarnings} />],
       ]}
     />
   );

--- a/src/Corporation/ui/modals/IssueDividendsModal.tsx
+++ b/src/Corporation/ui/modals/IssueDividendsModal.tsx
@@ -19,7 +19,7 @@ export function IssueDividendsModal(props: IProps): React.ReactElement {
   const corp = useCorporation();
   const [percent, setPercent] = useState(0);
 
-  const canIssue = !isNaN(percent) && percent >= 0 && percent <= CorporationConstants.DividendMaxPercentage * 100;
+  const canIssue = !isNaN(percent) && percent >= 0 && percent <= CorporationConstants.DividendMaxRate * 100;
   function issueDividends(): void {
     if (!canIssue) return;
     if (percent === null) return;

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -955,7 +955,7 @@ export function NetscriptCorporation(player: IPlayer, workerScript: WorkerScript
         sharePrice: corporation.sharePrice,
         dividendRate: corporation.dividendRate,
         dividendTax: corporation.dividendTax,
-        dividendEarnings: corporation.getDividends() / CorporationConstants.SecsPerMarketCycle,
+        dividendEarnings: corporation.getCycleDividends() / CorporationConstants.SecsPerMarketCycle,
         state: corporation.state.getState(),
         divisions: corporation.divisions.map((division): NSDivision => getSafeDivision(division)),
       };

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -952,6 +952,9 @@ export function NetscriptCorporation(player: IPlayer, workerScript: WorkerScript
         shareSaleCooldown: corporation.shareSaleCooldown,
         issuedShares: corporation.issuedShares,
         sharePrice: corporation.sharePrice,
+        dividendRate: corporation.dividendRate,
+        dividendTax: corporation.dividendTax,
+        dividendEarnings: corporation.getDividends() / CorporationConstants.SecsPerMarketCycle,
         state: corporation.state.getState(),
         divisions: corporation.divisions.map((division): NSDivision => getSafeDivision(division)),
       };

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -918,14 +918,15 @@ export function NetscriptCorporation(player: IPlayer, workerScript: WorkerScript
       },
     issueDividends:
       (ctx: NetscriptContext) =>
-      (_percent: unknown): void => {
+      (_rate: unknown): void => {
         checkAccess(ctx);
-        const percent = ctx.helper.number("percent", _percent);
-        if (percent < 0 || percent > 100)
-          throw new Error("Invalid value for percent field! Must be numeric, greater than 0, and less than 100");
+        const rate = ctx.helper.number("rate", _rate);
+        const max = CorporationConstants.DividendMaxRate;
+        if (rate < 0 || rate > max)
+          throw new Error(`Invalid value for rate field! Must be numeric, greater than 0, and less than ${max}`);
         const corporation = getCorporation();
         if (!corporation.public) throw ctx.makeRuntimeErrorMsg(`Your company has not gone public!`);
-        IssueDividends(corporation, percent);
+        IssueDividends(corporation, rate);
       },
 
     // If you modify these objects you will affect them for real, it's not

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7100,6 +7100,12 @@ interface CorporationInfo {
   issuedShares: number;
   /** Price of the shares */
   sharePrice: number;
+  /** Fraction of profits issued as dividends */
+  dividendRate: number;
+  /** Tax applied on your earnings as a shareholder */
+  dividendTax: number;
+  /** Your earnings as a shareholder per second this cycle */
+  dividendEarnings: number;
   /** State of the corporation. Possible states are START, PURCHASE, PRODUCTION, SALE, EXPORT. */
   state: string;
   /** Array of all divisions */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7048,9 +7048,9 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
   levelUpgrade(upgradeName: string): void;
   /**
    * Issue dividends
-   * @param percent - Percent of profit to issue as dividends.
+   * @param rate - Fraction of profit to issue as dividends.
    */
-  issueDividends(percent: number): void;
+  issueDividends(rate: number): void;
   /**
    * Buyback Shares
    * @param amount - Amount of shares to buy back.


### PR DESCRIPTION
Makes the corporation internals consistent in using a dividend rate (between 0 and 1) instead of mostly percentages (between 0 and 100), except sometimes it was between 0 and 1 but called a percentage. Renames `corporation.dividendPercentage` to `corporation.dividendRate` accordingly.

Replaces the unused `corporation.dividendTaxPercentage` with an actually-used `coropration.dividendTax`.

Exposes `dividendRate`, `dividendTax`, and `dividendEarnings` (which is shareholder earnings per second) to scripts via `ns.corporation.getCorporation`.

Fixes documentation for `ns.corporation.issueDividends` to clarify it expects a value between 0 and 1. Also fixes the error checking for that function which checks if it's between 0 and 100, and then passes it to a function which checks if it's between 0 and 1.

Fixes the value of the player's shareholder earnings on the corporation overview page which was a factor of 10 out; the value was per-cycle but was displayed as if it were per-second.


