### PR TITLE
DOCUMENTATION: FIX #2602 Remove incorrect info from getHackTime and friends

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6204,9 +6204,9 @@ export interface NS {
    * Get the execution time of a hack() call.
    * @remarks
    * RAM cost: 0.05 GB
-   *When `hack` completes an amount of money is stolen depending on the player's skills.
+   *
+   * When `hack` completes an amount of money is stolen depending on the player's skills.
    * Returns the amount of time in milliseconds it takes to execute the hack Netscript function on the target server.
-   * The function takes in an optional hackLvl parameter that can be specified to see what the hack time would be at different hacking levels.
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
    * @param host - Host of target server.
@@ -6220,7 +6220,6 @@ export interface NS {
    * RAM cost: 0.05 GB
    *
    * Returns the amount of time in milliseconds it takes to execute the grow Netscript function on the target server.
-   * The function takes in an optional hackLvl parameter that can be specified to see what the grow time would be at different hacking levels.
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
    * @param host - Host of target server.
@@ -6234,7 +6233,6 @@ export interface NS {
    * RAM cost: 0.05 GB
    *
    * Returns the amount of time in milliseconds it takes to execute the weaken Netscript function on the target server.
-   * The function takes in an optional hackLvl parameter that can be specified to see what the weaken time would be at different hacking levels.
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
    * @param host - Host of target server.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6210,7 +6210,7 @@ export interface NS {
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
    * @param host - Host of target server.
-   * @returns Returns the amount of time in milliseconds it takes to execute the hack Netscript function. Returns Infinity if called on a Hacknet Server.
+   * @returns Returns the amount of time in milliseconds it takes to execute the hack Netscript function.
    */
   getHackTime(host: string): number;
 
@@ -6223,7 +6223,7 @@ export interface NS {
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
    * @param host - Host of target server.
-   * @returns Returns the amount of time in milliseconds it takes to execute the grow Netscript function. Returns Infinity if called on a Hacknet Server.
+   * @returns Returns the amount of time in milliseconds it takes to execute the grow Netscript function.
    */
   getGrowTime(host: string): number;
 
@@ -6236,7 +6236,7 @@ export interface NS {
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
    * @param host - Host of target server.
-   * @returns Returns the amount of time in milliseconds it takes to execute the weaken Netscript function. Returns Infinity if called on a Hacknet Server.
+   * @returns Returns the amount of time in milliseconds it takes to execute the weaken Netscript function.
    */
   getWeakenTime(host: string): number;
 


### PR DESCRIPTION
For whatever reason, getHackTime, getGrowTime, and getWeakenTime have comments about a second `hackLvl` argument that doesn't exist.

I've also removed comments about Hacknet Servers, since IMO for a basic function like this we should avoid spoilers in the docs, even at the cost of completeness. If people disagree, the last commit can be reverted to put them back in.