### PR TITLE
DOC: Remove outdated information from getGrowTime, getHackTime, getWeakenTime docs

### DIFF
--- a/markdown/bitburner.ns.getgrowtime.md
+++ b/markdown/bitburner.ns.getgrowtime.md
@@ -28,5 +28,5 @@ Returns the amount of time in milliseconds it takes to execute the grow Netscrip
 
 RAM cost: 0.05 GB
 
-Returns the amount of time in milliseconds it takes to execute the grow Netscript function on the target server. The function takes in an optional hackLvl parameter that can be specified to see what the grow time would be at different hacking levels. The required time is increased by the security level of the target server and decreased by the player's hacking level.
+Returns the amount of time in milliseconds it takes to execute the grow Netscript function on the target server. The required time is increased by the security level of the target server and decreased by the player's hacking level.
 

--- a/markdown/bitburner.ns.gethacktime.md
+++ b/markdown/bitburner.ns.gethacktime.md
@@ -26,5 +26,5 @@ Returns the amount of time in milliseconds it takes to execute the hack Netscrip
 
 ## Remarks
 
-RAM cost: 0.05 GB When `hack` completes an amount of money is stolen depending on the player's skills. Returns the amount of time in milliseconds it takes to execute the hack Netscript function on the target server. The function takes in an optional hackLvl parameter that can be specified to see what the hack time would be at different hacking levels. The required time is increased by the security level of the target server and decreased by the player's hacking level.
+RAM cost: 0.05 GB When `hack` completes an amount of money is stolen depending on the player's skills. Returns the amount of time in milliseconds it takes to execute the hack Netscript function on the target server. The required time is increased by the security level of the target server and decreased by the player's hacking level.
 

--- a/markdown/bitburner.ns.getweakentime.md
+++ b/markdown/bitburner.ns.getweakentime.md
@@ -28,5 +28,5 @@ Returns the amount of time in milliseconds it takes to execute the weaken Netscr
 
 RAM cost: 0.05 GB
 
-Returns the amount of time in milliseconds it takes to execute the weaken Netscript function on the target server. The function takes in an optional hackLvl parameter that can be specified to see what the weaken time would be at different hacking levels. The required time is increased by the security level of the target server and decreased by the player's hacking level.
+Returns the amount of time in milliseconds it takes to execute the weaken Netscript function on the target server. 
 

--- a/markdown/bitburner.ns.getweakentime.md
+++ b/markdown/bitburner.ns.getweakentime.md
@@ -28,5 +28,5 @@ Returns the amount of time in milliseconds it takes to execute the weaken Netscr
 
 RAM cost: 0.05 GB
 
-Returns the amount of time in milliseconds it takes to execute the weaken Netscript function on the target server. 
+Returns the amount of time in milliseconds it takes to execute the weaken Netscript function on the target server. The required time is increased by the security level of the target server and decreased by the player's hacking level.
 


### PR DESCRIPTION
# Issue

The documentation for ``ns.getXYZTime()`` was outdated, making a reference in the "Remarks" section to an optional argument that no longer exists (it is now part of ``Formulas.exe``)

## Example: 

From ``ns.getgrowtime.md``:
> RAM cost: 0.05 GB
>
> Returns the amount of time in milliseconds it takes to execute the grow Netscript function on the target server. **The function takes in an optional hackLvl parameter that can be specified to see what the grow time would be at different hacking levels.** The required time is increased by the security level of the target server and decreased by the player's hacking level.


## Fix

Remove said reference from ``getgrowtime.md``, ``gethacktime.md``, ``getweakentime.md``