### PR TITLE
BUGFIX: Fix #3803 Servers can no longer have duplicate IPs

### DIFF
--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -79,10 +79,10 @@ export function DeleteServer(serverkey: string): void {
 export function ipExists(ip: string): boolean {
   for (const hostName in AllServers) {
     if (AllServers[hostName].ip === ip) {
-      return true
+      return true;
     }
   }
-  return false
+  return false;
 }
 
 export function createUniqueRandomIp(): string {

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -77,7 +77,12 @@ export function DeleteServer(serverkey: string): void {
 }
 
 export function ipExists(ip: string): boolean {
-  return AllServers[ip] != null;
+  for (const hostName in AllServers) {
+    if (AllServers[hostName].ip === ip) {
+      return true
+    }
+  }
+  return false
 }
 
 export function createUniqueRandomIp(): string {


### PR DESCRIPTION
# Issue 

There was a possibility that two servers could share an IP address. 

# Fix

The AllServers object was indexed by IP instead of hostname, and so it always returned `null`. This loops through the servers to see if any of the IPs match. 

# Linked issues

Closes #3803 

# Testing

I made `createRandomIp` return the same IP address every time, and I tested the game before and after. 

Before applying the fix, the game ran fine. Every server had the same IP, and you could buy servers fine. 

After applying the fix, the game would be in an infinite loop on launch, which is expected since `createUniqueRandomIp` will loop infinitely when the same IP is returned every time. 
