### PR TITLE
COMPANY: FIX #3837, #3830 corrected backwards logic in quitJob function

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1854,7 +1854,11 @@ export function getNextCompanyPosition(
 }
 
 export function quitJob(this: IPlayer, company: string, _sing = false): void {
-  if (this.isWorking === true && this.workType === WorkType.Company && this.companyName === company) {
+  if (
+    this.isWorking === true &&
+    [WorkType.Company, WorkType.CompanyPartTime].includes(this.workType) &&
+    this.companyName === company
+  ) {
     this.finishWork(true);
   }
   delete this.jobs[company];

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.tsx
@@ -1854,7 +1854,7 @@ export function getNextCompanyPosition(
 }
 
 export function quitJob(this: IPlayer, company: string, _sing = false): void {
-  if (this.isWorking == true && this.workType !== WorkType.Company && this.companyName == company) {
+  if (this.isWorking === true && this.workType === WorkType.Company && this.companyName === company) {
     this.finishWork(true);
   }
   delete this.jobs[company];


### PR DESCRIPTION
Fixes #3830
Fixes #3837 (or at least seems to)

If you're currently doing company work, and quitting from the same company that is active, then it will finish your work shift before deleting the job. Previously, it would only attempt to finish the work shift if you _weren't_ doing company work, but were quitting from your active company.

Edit: Fixes #3851, Fixes #3855, Fixes #3826, Fixes #3809, Fixes #3769, Fixes #3857, Fixes #3856, Fixes #3877, Fixes #3878