### PR TITLE
MISC: Add inline source mapping support for stack traces

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   testPathIgnorePatterns: [".cypress", "node_modules", "dist"],
   testEnvironment: "jsdom",
   moduleNameMapper: {
-    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|wasm)$":
       "<rootDir>/test/__mocks__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/test/__mocks__/styleMock.js",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@types/react-resizable": "^1.7.3",
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",
+        "arraybuffer-loader": "^1.0.8",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.0.5",
         "cypress": "^8.3.1",
@@ -5038,6 +5039,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arraybuffer-loader": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/arraybuffer-loader/-/arraybuffer-loader-1.0.8.tgz",
+      "integrity": "sha512-CwUVCcxCgcgZUu2w741OV6Xj1tvRVQebq22RCyGXiLgJOJ4e4M/59EPYdtK2MLfIN28t1TDvuh2ojstNq3Kh5g==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/asar": {
@@ -18449,9 +18462,9 @@
       "dev": true
     },
     "node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -26043,6 +26056,15 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "arraybuffer-loader": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/arraybuffer-loader/-/arraybuffer-loader-1.0.8.tgz",
+      "integrity": "sha512-CwUVCcxCgcgZUu2w741OV6Xj1tvRVQebq22RCyGXiLgJOJ4e4M/59EPYdtK2MLfIN28t1TDvuh2ojstNq3Kh5g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0"
+      }
     },
     "asar": {
       "version": "3.1.0",
@@ -36658,9 +36680,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true
     },
     "source-map-resolve": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/react-resizable": "^1.7.3",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
+    "arraybuffer-loader": "^1.0.8",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.0.5",
     "cypress": "^8.3.1",

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -25,7 +25,7 @@ import { Settings } from "./Settings/Settings";
 
 import { generate } from "escodegen";
 
-import { dialogBoxCreate } from "./ui/React/DialogBox";
+import { dialogBoxCreate, dialogBoxCreateEscape } from "./ui/React/DialogBox";
 import { arrayToString } from "./utils/helpers/arrayToString";
 import { roundToTwo } from "./utils/helpers/roundToTwo";
 import { isString } from "./utils/helpers/isString";
@@ -612,9 +612,8 @@ function createAndAddWorkerScript(
             msg += `Args: ${arrayToString(workerScript.args)}<br>`;
           }
           msg += "<br>";
-          msg += errorMsg;
 
-          dialogBoxCreate(msg);
+          dialogBoxCreateEscape(msg, errorMsg);
           workerScript.log("", () => "Script crashed with runtime error");
         } else {
           workerScript.log("", () => "Script killed");

--- a/src/ui/React/DialogBox.tsx
+++ b/src/ui/React/DialogBox.tsx
@@ -11,3 +11,14 @@ export function dialogBoxCreate(txt: string | JSX.Element, styles?: SxProps): vo
     AlertEvents.emit(<Typography component="span" sx={styles} dangerouslySetInnerHTML={{ __html: txt }} />);
   }
 }
+
+export function dialogBoxCreateEscape(txt: string, escape: string, styles?: SxProps): void {
+  AlertEvents.emit(
+    <>
+      <Typography component="span" sx={styles} dangerouslySetInnerHTML={{ __html: txt }} />
+      <Typography component="span" sx={styles}>
+        {escape}
+      </Typography>
+    </>,
+  );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -127,9 +127,9 @@ module.exports = (env, argv) => {
       isFastRefresh && new ReactRefreshWebpackPlugin(),
     ].filter(Boolean),
     target: "web",
-    // node: {
-    //   fs: "mock",
-    // },
+    node: {
+      fs: "empty",
+    },
     entry: entry,
     output: {
       path: path.resolve(__dirname, outputDirectory),
@@ -160,6 +160,11 @@ module.exports = (env, argv) => {
             outputPath: "images",
             publicPath: `${outputDirectory}/images`,
           },
+        },
+        {
+          test: /\.wasm$/,
+          type: "javascript/auto",
+          loader: "arraybuffer-loader",
         },
       ],
     },


### PR DESCRIPTION
I made a typescript project that compiled into javascript and was getting some pain points when debugging exceptions because the files didn't match.

# Changes
- Fixed certain stack traces being treated as broken html and causing react to truncate it
  - I created a new function here since I wasn't sure where else this was used and didn't want to break existing code
- Added `source-map` dependency
  - Looks like it was already here but never really used directly (only by dependencies)
  - Used by the new process to map stack traces to inline source maps
- Added `arraybuffer-loader` dependency
  - Used by `source-map` dependency to load the wasm binary

Fully tested on chrome and firefox (should work on all/most browsers)

# Files
`test.ts`
```ts
import { foo } from './foo'

export async function main(ns: NS) {
  const errHere = ns.args[0]
  if (errHere) throw new Error('test')
  else foo()
}
```
`test.js` (transpiled by tsc)
```js
var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
    return new (P || (P = Promise))(function (resolve, reject) {
        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
        step((generator = generator.apply(thisArg, _arguments || [])).next());
    });
};
import { foo } from './foo';
export function main(ns) {
    return __awaiter(this, void 0, void 0, function* () {
        const errHere = ns.args[0];
        if (errHere)
            throw new Error('test');
        else
            foo();
    });
}
//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy90ZXN0LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7OztBQUFBLE9BQU8sRUFBRSxHQUFHLEVBQUUsTUFBTSxPQUFPLENBQUE7QUFFM0IsTUFBTSxVQUFnQixJQUFJLENBQUMsRUFBTTs7UUFDL0IsTUFBTSxPQUFPLEdBQUcsRUFBRSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQTtRQUMxQixJQUFJLE9BQU87WUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFBOztZQUMvQixHQUFHLEVBQUUsQ0FBQTtJQUNaLENBQUM7Q0FBQSJ9
```
`foo.ts`
```ts
export function foo() {
  throw new Error('test foo')
}
```
`foo.js` (transpiled by tsc)
```js
export function foo() {
    throw new Error('test foo');
}
//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZm9vLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiLi4vc3JjL2Zvby50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLFVBQVUsR0FBRztJQUNqQixNQUFNLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFBO0FBQzdCLENBQUMifQ==
```

# Tests

## Chrome
`run test.js true` (crash on test.js)
```
RUNTIME ERROR
test.js@home (PID - 1)
Args: [true]

test
stack:
Error: test
at Module.<anonymous> (../src/test.ts:5:21)
at Generator.next (<anonymous>)
at home/test.js:7:71
at new Promise (<anonymous>)
at __awaiter (home/test.js:3:12)
at Module.main (home/test.js:12:12)
at executeJSScript (webpack-internal:///663:80:23)
```
`run test.js false` (crash on foo.js)
```
RUNTIME ERROR
test.js@home (PID - 2)
Args: [false]

test foo
stack:
Error: test foo
at foo (../src/foo.ts:2:8)
at Module.<anonymous> (../src/test.ts:6:7)
at Generator.next (<anonymous>)
at home/test.js:7:71
at new Promise (<anonymous>)
at __awaiter (home/test.js:3:12)
at Module.main (home/test.js:12:12)
at executeJSScript (webpack-internal:///663:80:23)
```

## Firefox
`run test.js true` (crash on test.js)
```
RUNTIME ERROR
test.js@home (PID - 2)
Args: [true]

test
stack:
main/<@../src/test.ts:5:21
__awaiter</<@home/test.js:7:71
__awaiter<@home/test.js:3:12
main@home/test.js:12:12
executeJSScript@webpack-internal:///663:80:23
```
`run test.js false` (crash on foo.js)
```
RUNTIME ERROR
test.js@home (PID - 3)
Args: [false]

test foo
stack:
foo@../src/foo.ts:2:8
main/<@../src/test.ts:6:7
__awaiter</<@home/test.js:7:71
__awaiter<@home/test.js:3:12
main@home/test.js:12:12
executeJSScript@webpack-internal:///663:80:23
async*startNetscript2Script/<@webpack-internal:///203:176:91
startNetscript2Script@webpack-internal:///203:175:10
createAndAddWorkerScript@webpack-internal:///203:659:23
startWorkerScript@webpack-internal:///203:602:31
runScript@webpack-internal:///1479:71:103
run@webpack-internal:///1478:16:75
executeCommand@webpack-internal:///976:920:6
executeCommands@webpack-internal:///976:656:12
onKeyDown@webpack-internal:///1375:228:16
callCallback@webpack-internal:///1601:3945:14
invokeGuardedCallbackDev@webpack-internal:///1601:3994:16
invokeGuardedCallback@webpack-internal:///1601:4056:31
invokeGuardedCallbackAndCatchFirstError@webpack-internal:///1601:4070:25
executeDispatch@webpack-internal:///1601:8243:42
processDispatchQueueItemsInOrder@webpack-internal:///1601:8275:22
processDispatchQueue@webpack-internal:///1601:8288:37
dispatchEventsForPlugins@webpack-internal:///1601:8299:23
dispatchEventForPluginEventSystem/<@webpack-internal:///1601:8508:12
batchedEventUpdates$1@webpack-internal:///1601:22391:12
batchedEventUpdates@webpack-internal:///1601:3745:12
dispatchEventForPluginEventSystem@webpack-internal:///1601:8507:22
attemptToDispatchEvent@webpack-internal:///1601:6005:36
dispatchEvent@webpack-internal:///1601:5924:41
unstable_runWithPriority@webpack-internal:///1603:468:12
runWithPriority$1@webpack-internal:///1601:11276:10
discreteUpdates$1@webpack-internal:///1601:22408:14
discreteUpdates@webpack-internal:///1601:3756:12
dispatchDiscreteEvent@webpack-internal:///1601:5889:18
```

## Considerations

- The source `../src/foo.ts` comes directly from the source mapping.
- Some sources don't have a mapping. This looks intentional by tsc but is up to the source to provide one or not.
- In the second firefox test the stacktrace is a lot larger than normal because `__awaiter</<@home/test.js:7:71` has the character `</` which react was taking as a broken html tag and truncating everything. Technically a happy bug since a lot of it is noise but worry it might be hiding other stuff. It's also possible it's only this big because it's webpack shenanigans but nonetheless I think it's in a better spot.

# Final thoughts

I'm not entirely happy the complexity added by `source-map` but I couldn't find a better way. It looks like every browser is very opinionated and stacktraces are horribly unstandard. The approach taken is "best effort" so if anything fails it will just fallback to what the browser thinks it should be.

I'm also not sure where exactly the best place to put the `initialize` function from `source-map` is but it probably doesn't belong where it's at now. It works but it's probably doing more than it should. I'd be happy to move it somewhere it only gets called once on load.