### PR TITLE
Small docs and help updates

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4859,6 +4859,7 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
+   * see: https://github.com/alexei/sprintf.js
    * @param format - format of the message
    * @param msg - Value to be printed.
    */

--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -35,7 +35,7 @@ export const TerminalHelpText: string[] = [
   "    rm [file]                            Delete a file from the server",
   "    run [name] [-t n] [--tail] [args...] Execute a program or script",
   "    scan                                 Prints all immediately-available network connections",
-  "    scan-analyze [d] [-a]                Prints info for all servers up to <i>d</i> nodes away",
+  "    scan-analyze [d] [-a]                Prints info for all servers up to d nodes away",
   "    scp [file ...] [server]              Copies a file to a destination server",
   "    sudov                                Shows whether you have root access on this computer",
   "    tail [script] [args...]              Displays dynamic logs for the specified script",


### PR DESCRIPTION
# Small docs update for tprintf and help update for scan-analyze

All `*printf` functions link to the used library `https://github.com/alexei/sprintf.js` except for `tprintf`. So I added it there as well.
#3843 was open and easy to fix so I added that in as well.

# Linked issues

#3843 

# Documentation

- [x] DO NOT CHANGE any markdown/\*.md, these files are autogenerated from NetscriptDefinitions.d.ts and will be overwritten
- [x] DO NOT re-generate the documentation, makes it harder to review.

