### PR TITLE
UI: Fix #3854 ctrl+c does not clear terminal input 

### DIFF
--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -324,6 +324,7 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
     if (Settings.EnableBashHotkeys) {
       if (event.code === KEYCODE.C && event.ctrlKey && ref && ref.selectionStart === ref.selectionEnd) {
         event.preventDefault();
+        terminal.print(`[${player.getCurrentServer().hostname} ~${terminal.cwd()}]> ${value}`);
         modifyInput("clearall");
       }
 

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -128,6 +128,9 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
       case "clearbefore": // Deletes everything before cursor
         saveValue(inputText.substr(start), () => moveTextCursor("home"));
         break;
+      case "clearall": // Deletes everything in the input
+        saveValue("");
+        break;
     }
   }
 
@@ -318,6 +321,11 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
 
     // Extra Bash Emulation Hotkeys, must be enabled through options
     if (Settings.EnableBashHotkeys) {
+      if (event.code === KEYCODE.C && event.ctrlKey) {
+        event.preventDefault();
+        modifyInput("clearall");
+      }
+
       if (event.code === KEYCODE.A && event.ctrlKey) {
         event.preventDefault();
         moveTextCursor("home");

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -199,6 +199,8 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
   });
 
   async function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): Promise<void> {
+    const ref = terminalInput.current;
+
     // Run command.
     if (event.key === KEY.ENTER && value !== "") {
       event.preventDefault();
@@ -285,7 +287,6 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
       }
       const prevCommand = terminal.commandHistory[terminal.commandHistoryIndex];
       saveValue(prevCommand);
-      const ref = terminalInput.current;
       if (ref) {
         setTimeout(function () {
           ref.selectionStart = ref.selectionEnd = 10000;
@@ -321,7 +322,7 @@ export function TerminalInput({ terminal, router, player }: IProps): React.React
 
     // Extra Bash Emulation Hotkeys, must be enabled through options
     if (Settings.EnableBashHotkeys) {
-      if (event.code === KEYCODE.C && event.ctrlKey) {
+      if (event.code === KEYCODE.C && event.ctrlKey && ref && ref.selectionStart === ref.selectionEnd) {
         event.preventDefault();
         modifyInput("clearall");
       }


### PR DESCRIPTION
Fixes #3854

Implement ctrl+c bash hotkey. Clears current terminal input. If there is selected text, the hotkey is not triggered to allow copying.

1. Check if ctrl+c clears terminal input when no text is selected in terminal input
2. Check if ctrl+c copies text when text is selected in terminal input

![bb-3854-s](https://user-images.githubusercontent.com/10543339/177025427-38443c6e-575e-4958-aaac-9a4260bb20b0.gif)

