### PR TITLE
MISC: Add faction membership check to singularity.purchaseAugmentation

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -164,6 +164,11 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
 
         const augs = getFactionAugmentationsFiltered(player, fac);
 
+        if (!player.factions.includes(fac.name)) {
+          _ctx.log(() => `You can't purchase augmentations from '${facName}' because you aren't a member`);
+          return false;
+        }
+
         if (!augs.includes(augName)) {
           _ctx.log(() => `Faction '${facName}' does not have the '${augName}' augmentation.`);
           return false;


### PR DESCRIPTION
`ns.singularity.purchaseAugmentation` now checks that you're a member of the faction you're trying to buy the augmentation from. In particular, this stops you calling `ns.singularity.purchaseAugmentation("Church of the Machine God", "Stanek's Gift - Genesis")` to get Stanek's Gift outside of BN13 without SF-13.