### PR TITLE
DOC: Added a link from "Source-Files" page to "How to destroy a Bitnode"

### DIFF
--- a/doc/source/advancedgameplay/bitnodes.rst
+++ b/doc/source/advancedgameplay/bitnodes.rst
@@ -35,6 +35,8 @@ Furthermore, some BitNodes introduce new content and mechanics. For example ther
 BitNode that grants access to the `Singularity API <https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.singularity.md>`_.
 There is another BitNode in which you can manage a gang to earn money and reputation.
 
+.. _gameplay_bitnodes_howtodestroy:
+
 How to destroy a BitNode
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Initially, the only way to destroy a BitNode is to join the Daedalus :ref:`Daedalus <gameplay_factions>`.

--- a/doc/source/advancedgameplay/sourcefiles.rst
+++ b/doc/source/advancedgameplay/sourcefiles.rst
@@ -5,7 +5,7 @@
 Source-Files
 ============
 Source-Files are a type of persistent upgrade that is more powerful than Augmentations.
-Source-Files are received by destroying a BitNode. There are many different BitNodes
+Source-Files are received by :ref:`destroying a BitNode <gameplay_bitnodes_howtodestroy>`. There are many different BitNodes
 in the game and each BitNode will grant a different Source-File when it is destroyed.
 
 A Source-File can be upgraded by destroying its corresponding BitNode a second or


### PR DESCRIPTION
Had slight trouble finding how to destroy a bitnode so added a link in Source-Files for convenience.

You can see the change here:
https://bitburner-fork-oddiz.readthedocs.io/en/latest/advancedgameplay/sourcefiles.html