### PR TITLE
API: FIX #3860 destroyW0r1dD43m0n now properly gives achievements

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -25,6 +25,7 @@ import * as data from "./AchievementData.json";
 import { FactionNames } from "../Faction/data/FactionNames";
 import { BlackOperationNames } from "../Bladeburner/data/BlackOperationNames";
 import { isClassWork } from "../Work/ClassWork";
+import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
 
 // Unable to correctly cast the JSON data into AchievementDataJson type otherwise...
 const achievementData = (<AchievementDataJson>(<unknown>data)).achievements;
@@ -380,7 +381,10 @@ export const achievements: IMap<Achievement> = {
   DONATION: {
     ...achievementData["DONATION"],
     Icon: "donation",
-    Condition: () => Object.values(Factions).some((f) => f.favor >= 150),
+    Condition: () =>
+      Object.values(Factions).some(
+        (f) => f.favor >= Math.floor(CONSTANTS.BaseFavorToDonate * BitNodeMultipliers.RepToDonateToFaction),
+      ),
   },
   TRAVEL: {
     ...achievementData["TRAVEL"],

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -174,7 +174,7 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
               <b>Reputation:</b> <Reputation reputation={props.faction.playerReputation} />
             </Typography>
             <Typography>
-              <b>Favor:</b> <Favor favor={Math.floor(props.faction.favor)} />
+              <b>Favor:</b> <Favor favor={numeralWrapper.formatFavor(Math.floor(props.faction.favor))} />
             </Typography>
           </Box>
           <Box sx={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)" }}>
@@ -183,7 +183,7 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
               Sort by Reputation
             </Button>
             <Button onClick={() => switchSortOrder(PurchaseAugmentationsOrderSetting.Default)}>
-              Sort by Default Order
+              Sort by Default Order Sort by Default Order
             </Button>
             <Button onClick={() => switchSortOrder(PurchaseAugmentationsOrderSetting.Purchasable)}>
               Sort by Purchasable

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -171,7 +171,7 @@ const FactionElement = (props: IFactionProps): React.ReactElement => {
       {props.joined && (
         <Box display="grid" sx={{ alignItems: "center", justifyItems: "left", gridAutoFlow: "row" }}>
           <Typography sx={{ color: Settings.theme.rep }}>
-            {numeralWrapper.formatFavor(props.faction.favor)} favor
+            {numeralWrapper.formatFavor(Math.floor(props.faction.favor))} favor
           </Typography>
           <Typography sx={{ color: Settings.theme.rep }}>
             {numeralWrapper.formatReputation(props.faction.playerReputation)} rep

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1284,4 +1284,3 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
       },
   };
 }
-

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -10,7 +10,7 @@ import { killWorkerScript } from "../Netscript/killWorkerScript";
 import { CONSTANTS } from "../Constants";
 import { isString } from "../utils/helpers/isString";
 import { RunningScript } from "../Script/RunningScript";
-import { calculateAchievements } from "../Achievements/Achievements.ts";
+import { calculateAchievements } from "../Achievements/Achievements";
 
 import {
   AugmentationStats,
@@ -1275,7 +1275,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
           return;
         }
         
-        wd.backdoorInstalled = true
+        wd.backdoorInstalled = true;
         calculateAchievements();
         enterBitNode(Router, false, player.bitNodeN, nextBN);
         if (callbackScript)

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1251,12 +1251,14 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
         _ctx.helper.checkSingularityAccess();
         const nextBN = _ctx.helper.number("nextBN", _nextBN);
         const callbackScript = _ctx.helper.string("callbackScript", _callbackScript);
+        
+        const wd = GetServer(SpecialServers.WorldDaemon);
+        if (!(wd instanceof Server))
+          throw new Error("WorldDaemon was not a normal server. This is a bug contact dev.");
+        
         _ctx.helper.checkSingularityAccess();
 
         const hackingRequirements = (): boolean => {
-          const wd = GetServer(SpecialServers.WorldDaemon);
-          if (!(wd instanceof Server))
-            throw new Error("WorldDaemon was not a normal server. This is a bug contact dev.");
           if (player.hacking < wd.requiredHackingSkill) return false;
           if (!wd.hasAdminRights) return false;
           return true;
@@ -1271,7 +1273,8 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
           _ctx.log(() => "Requirements not met to destroy the world daemon");
           return;
         }
-
+        
+        wd.backdoorInstalled = true
         enterBitNode(Router, false, player.bitNodeN, nextBN);
         if (callbackScript)
           setTimeout(() => {

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -10,6 +10,7 @@ import { killWorkerScript } from "../Netscript/killWorkerScript";
 import { CONSTANTS } from "../Constants";
 import { isString } from "../utils/helpers/isString";
 import { RunningScript } from "../Script/RunningScript";
+import { calculateAchievements } from "../Achievements/Achievements.ts";
 
 import {
   AugmentationStats,
@@ -1275,6 +1276,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
         }
         
         wd.backdoorInstalled = true
+		calculateAchievements()
         enterBitNode(Router, false, player.bitNodeN, nextBN);
         if (callbackScript)
           setTimeout(() => {

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1276,7 +1276,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
         }
         
         wd.backdoorInstalled = true
-        calculateAchievements()
+        calculateAchievements();
         enterBitNode(Router, false, player.bitNodeN, nextBN);
         if (callbackScript)
           setTimeout(() => {

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1252,11 +1252,10 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
         _ctx.helper.checkSingularityAccess();
         const nextBN = _ctx.helper.number("nextBN", _nextBN);
         const callbackScript = _ctx.helper.string("callbackScript", _callbackScript);
-        
+
         const wd = GetServer(SpecialServers.WorldDaemon);
-        if (!(wd instanceof Server))
-          throw new Error("WorldDaemon was not a normal server. This is a bug contact dev.");
-        
+        if (!(wd instanceof Server)) throw new Error("WorldDaemon was not a normal server. This is a bug contact dev.");
+
         _ctx.helper.checkSingularityAccess();
 
         const hackingRequirements = (): boolean => {
@@ -1274,7 +1273,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
           _ctx.log(() => "Requirements not met to destroy the world daemon");
           return;
         }
-        
+
         wd.backdoorInstalled = true;
         calculateAchievements();
         enterBitNode(Router, false, player.bitNodeN, nextBN);
@@ -1285,3 +1284,4 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
       },
   };
 }
+

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1276,7 +1276,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
         }
         
         wd.backdoorInstalled = true
-		calculateAchievements()
+        calculateAchievements()
         enterBitNode(Router, false, player.bitNodeN, nextBN);
         if (callbackScript)
           setTimeout(() => {


### PR DESCRIPTION
fixes #3860 (and fixes #3777) so that destroyW0r1dD43m0n properly gives achievements
does two things to destroyW0r1dD43m0n:
- installs a backdoor to world daemon server to pass achievement checks 
- runs an achievement check before traveling to next bitnode 

i have made sure to follow the code of conduct very thoroughly 