### PR TITLE
Remove "based" from positive adjectives in infil

### DIFF
--- a/src/Infiltration/ui/BribeGame.tsx
+++ b/src/Infiltration/ui/BribeGame.tsx
@@ -151,7 +151,7 @@ const positive = [
   "patient",
   "dynamic",
   "loyal",
-  "based",
+  "straightforward"
 ];
 
 const negative = [


### PR DESCRIPTION
This slang term has had three different meanings in my lifetime alone. It's far too regional and cohort-sensitive to be universally understood to be a positive word.

Note that I don't have the same objections to "cringe," introduced in the same commit, as it has obviously negative connotations that don't require understanding the slang version.