### PR TITLE
NETSCRIPT: FIX #3958 Remove old wrapper, fix new wrapper (v2)

### DIFF
--- a/src/Netscript/Environment.ts
+++ b/src/Netscript/Environment.ts
@@ -11,6 +11,12 @@ export class Environment {
   stopFlag = false;
 
   /**
+   * The currently running function
+   */
+
+  runningFn = "";
+
+  /**
    * Environment variables (currently only Netscript functions)
    */
   vars: NS | null = null;

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -394,7 +394,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
         )} (t=${numeralWrapper.formatThreads(threads)})`,
     );
 
-    return netscriptDelay(hackingTime * 1000, workerScript).then(function () {
+    return netscriptDelay("hack", hackingTime * 1000, workerScript).then(function () {
       const hackChance = calculateHackingChance(server, Player);
       const rand = Math.random();
       let expGainedOnSuccess = calculateHackingExpGain(server, Player) * threads;
@@ -757,7 +757,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
           throw ctx.makeRuntimeErrorMsg("Takes 1 argument.");
         }
         ctx.log(() => `Sleeping for ${time} milliseconds`);
-        return netscriptDelay(time, workerScript).then(function () {
+        return netscriptDelay("sleep", time, workerScript).then(function () {
           return Promise.resolve(true);
         });
       },
@@ -798,7 +798,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
               true,
             )} (t=${numeralWrapper.formatThreads(threads)}).`,
         );
-        return netscriptDelay(growTime * 1000, workerScript).then(function () {
+        return netscriptDelay("grow", growTime * 1000, workerScript).then(function () {
           const moneyBefore = server.moneyAvailable <= 0 ? 1 : server.moneyAvailable;
           processSingleServerGrowth(server, threads, Player, host.cpuCores);
           const moneyAfter = server.moneyAvailable;
@@ -892,7 +892,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
               true,
             )} (t=${numeralWrapper.formatThreads(threads)})`,
         );
-        return netscriptDelay(weakenTime * 1000, workerScript).then(function () {
+        return netscriptDelay("weaken", weakenTime * 1000, workerScript).then(function () {
           const host = GetServer(workerScript.hostname);
           if (host === null) {
             ctx.log(() => "Server is null, did it die?");
@@ -926,7 +926,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
       const end = StartSharing(
         workerScript.scriptRef.threads * calculateIntelligenceBonus(Player.skills.intelligence, 2),
       );
-      return netscriptDelay(10000, workerScript).finally(function () {
+      return netscriptDelay("share", 10000, workerScript).finally(function () {
         ctx.log(() => "Finished sharing this computer.");
         end();
       });

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -637,7 +637,7 @@ export function NetscriptSingularity(player: IPlayer, workerScript: WorkerScript
         () => `Installing backdoor on '${server.hostname}' in ${convertTimeMsToTimeElapsedString(installTime, true)}`,
       );
 
-      return netscriptDelay(installTime, workerScript).then(function () {
+      return netscriptDelay("singularity.installBackdoor", installTime, workerScript).then(function () {
         _ctx.log(() => `Successfully installed backdoor on '${server.hostname}'`);
 
         server.backdoorInstalled = true;

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -57,7 +57,7 @@ export function NetscriptStanek(
         }
         //Charge the fragment
         const time = staneksGift.inBonus() ? 200 : 1000;
-        return netscriptDelay(time, workerScript).then(function () {
+        return netscriptDelay("stanek.charge", time, workerScript).then(function () {
           staneksGift.charge(player, fragment, workerScript.scriptRef.threads);
           _ctx.log(() => `Charged fragment with ${_ctx.workerScript.scriptRef.threads} threads.`);
           return Promise.resolve();


### PR DESCRIPTION
Fixes #3958 . The previous `wrap`ped functions from NetscriptWorker.ts were not being used in v2. Since there is a new wrapper in APIWrapper.ts, I removed the wrapper from NetscriptWorker.ts. The erroring functionality that previously only existed in the NetscriptWorker.ts wrapper (error on dead script/concurrent functions other than asleep) has been moved to the new wrapper.

`netscriptDelay` is now the function that sets and clears `runningFn`, and `runningFn` is now part of `workerScript.env`. `netscriptDelay` now requires a function name to be passed to it so that it can set runningFn.