### PR TITLE
UI: FIX Script editor dirty indicator not updating on file save

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -593,6 +593,7 @@ export function Root(props: IProps): React.ReactElement {
             server.scripts,
           );
           if (Settings.SaveGameOnFileSave) saveObject.saveGame();
+          rerender();
           return;
         }
       }
@@ -612,6 +613,7 @@ export function Root(props: IProps): React.ReactElement {
         if (server.textFiles[i].fn === currentScript.fileName) {
           server.textFiles[i].write(currentScript.code);
           if (Settings.SaveGameOnFileSave) saveObject.saveGame();
+          rerender();
           return;
         }
       }
@@ -623,6 +625,7 @@ export function Root(props: IProps): React.ReactElement {
     }
 
     if (Settings.SaveGameOnFileSave) saveObject.saveGame();
+    rerender();
   }
 
   function reorder(list: Array<OpenScript>, startIndex: number, endIndex: number): OpenScript[] {


### PR DESCRIPTION
# UI: FIX Script editor dirty indicator not updating on file save

The file dirty indicator (* on the tab to show the file has unsaved changes) did not update on file save (`Ctrl+S` or `Save`  button).
It only updated when the editor was reloaded (e. g. going to the terminal and back to the edtior), by clicking on the tab, or when the file contents was changed to whatever was alread saved. See this video for illustration.

[bitburner-dirtyindicator-before.webm](https://user-images.githubusercontent.com/34600077/184543247-26741be1-3a6e-4169-acae-40e0cac9b8ac.webm)

## Solution

This PR fixes this, by triggering a rerender when the file is saved.

[bitburner-dirtyindicator-after.webm](https://user-images.githubusercontent.com/34600077/184543248-35870d55-5047-4cc3-9e1c-338807e064c1.webm)
