### PR TITLE
NETSCRIPT: FIX #2931 atExit now allows synchronous ns functions

### DIFF
--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -62,7 +62,7 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
       let message = e instanceof ScriptDeath ? e.errorMessage : String(e);
       message = message.replace(/.*\|DELIMITER\|/, "");
       dialogBoxCreate(
-        `Error trying to call atExit for script ${ws.name} on ${ws.hostname} ${ws.scriptRef.args}\n` + message,
+        `Error trying to call atExit for script ${[ws.name, ...ws.args].join(" ")} on ${ws.hostname}\n ${message}`,
       );
       console.log(e);
     }


### PR DESCRIPTION
Fixes #2391
Fixed #4011 

Should also be able to close #2588.

After a script is killed, the stopFlag is briefly set to false for a synchronous run of the atExit function. Once that is complete, the stopFlag is set back to true and any subsequent ns functions ran from the script will fail. This means that synchronous ns functions are allowed in atExit (like tprint) but asynchronous functions are not allowed/will not work.

The error message handling at this point has also been improved. I used this test script to generate an error message:

```javascript
export let main=ns=>ns.atExit(()=>ns.getServer(ns.args[0]));
```

Here is a comparison of old and new error messages with `run atExitTest.js gibson`:

![image](https://user-images.githubusercontent.com/84951833/185008934-37b05bfb-89c6-4c4d-bcf5-f446f3fc1212.png)

Old above, new below:

![image](https://user-images.githubusercontent.com/84951833/185008671-7ca4ac49-5169-4394-bb37-7560e411c75e.png)
