### PR TITLE
FILES: FIX #3979 Allow characters & and ' in filenames

### DIFF
--- a/src/Terminal/DirectoryHelpers.ts
+++ b/src/Terminal/DirectoryHelpers.ts
@@ -38,7 +38,7 @@ export function removeTrailingSlash(s: string): string {
 export function isValidFilename(filename: string): boolean {
   // Allows alphanumerics, hyphens, underscores, and percentage signs
   // Must have a file extension
-  const regex = /^[.a-zA-Z0-9_-]+[.][a-zA-Z0-9]+(?:-\d+(?:\.\d*)?%-INC)?$/;
+  const regex = /^[.&'a-zA-Z0-9_-]+\.[a-zA-Z0-9]+(?:-\d+(?:\.\d*)?%-INC)?$/;
 
   // match() returns null if no match is found
   return filename.match(regex) != null;


### PR DESCRIPTION
Fixes #3979 

Those characters are already used in coding contracts.