### PR TITLE
NETSCRIPT: Correct missing `!` for boolean coercion in `singularity.workForCompany()`.

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -780,7 +780,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       function (_companyName: unknown, _focus: unknown = true): boolean {
         helpers.checkSingularityAccess(ctx);
         const companyName = helpers.string(ctx, "companyName", _companyName);
-        const focus = !_focus;
+        const focus = !!_focus;
 
         // Make sure its a valid company
         if (companyName == null || companyName === "" || !(Companies[companyName] instanceof Company)) {


### PR DESCRIPTION
`singularity.workForCompany()` was negating its `_focus` argument, unlike similar functions, which used double-negation to coerce to boolean. This was almost certainly a typo, since before PR-#3967 it used `_ctx.helper.boolean()` without negation, just like the other singularity functions.