### PR TITLE
MISC: Sleeve crime gain bitnode multiplier fix

### DIFF
--- a/doc/source/basicgameplay/augmentations.rst
+++ b/doc/source/basicgameplay/augmentations.rst
@@ -10,8 +10,9 @@ user's physical and mental faculties.
 
 Augmentations provide persistent upgrades in the form of multipliers.
 These multipliers apply to a wide variety of things such as stats,
-experience gain, and hacking, just to name a few. Your multipliers
-can be viewed in the 'Character' page (:ref:`keyboard shortcut <shortcuts>` Alt + c).
+experience gain, and hacking, just to name a few. The effects of 
+Autmentations stack multiplicatively. Your multiplierscan be viewed in 
+the 'Character' page (:ref:`keyboard shortcut <shortcuts>` Alt + c).
 
 How to acquire Augmentations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,4 +76,6 @@ will cause the Augmentations to get progressively more expensive. When
 you purchase an Augmentation, the price of purchasing another Augmentation
 doubles. This multiplier stacks for each Augmentation you
 purchase. Once you install your purchased Augmentations, their costs
-are reset back to the original prices.
+are reset back to the original prices. You can only purchase each augmentation 
+once, with the exception of NeuroFlux Governor, which can be purchased infinitely
+at increasing cost.

--- a/doc/source/basicgameplay/companies.rst
+++ b/doc/source/basicgameplay/companies.rst
@@ -11,12 +11,3 @@ While working for a company, you can click "Do something else simultaneously" to
 to do things while you continue to work in the background. There is a 20% penalty to the 
 related gains. Clicking the "Focus" button under the overview will return you to the 
 current work.   
-
-Reputation is required to apply for a promotion. This reputation is not counted towards
-your career until the shift ends, either due to the time spent or clicking the 
-"Stop Working" button. For most jobs there is a penalty of 50% of the reputation gained
-if you stop your shift early. 
-
-Information about all Companies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-TODO

--- a/doc/source/basicgameplay/crimes.rst
+++ b/doc/source/basicgameplay/crimes.rst
@@ -13,7 +13,12 @@ Basic Mechanics
 When you visit the 'Slums' you will see a list of buttons that show all of the
 available crimes. Simply select one of the options to begin attempting that
 crime. Attempting to commit a crime takes a certain amount of time. This time
-varies between crimes. During this time, you cannot do anything else.
+varies between crimes. 
+
+While doing criemes, you can click “Do something else simultaneously” 
+to be able to do things while you continue to do crimes in the background. There is a 
+20% penalty to the related gains. Clicking the “Focus” button under the overview 
+will return you to the current task.
 
 Crimes are not always successful. Your rate of success is determined by your
 stats (and Augmentation multipliers) and can be seen on the crime-selection
@@ -27,15 +32,27 @@ Harder crimes are typically more profitable, and also give more EXP.
 Crime details
 ^^^^^^^^^^^^^
 Available crimes, and their descriptions, which all begin with "attempt to..."
+
 Shoplift	…shoplift from a low-end retailer
+
 Rob store 	…commit armed robbery on a high-end store
+
 Mug someone 	…mug a random person on the street
+
 Larceny 	…rob property from someone's house
+
 Deal Drugs 	…deal drugs
+
 Bond Forgery 	…forge corporate bonds
+
 Traffick illegal Arms 	…smuggle illegal arms into the city
+
 Homicide 	…murder a random person on the street
+
 Grand theft Auto 	…commit grand theft auto
+
 Kidnap and Ransom 	…kidnap and ransom a high-profile-target
+
 Assassinate 	…assassinate a high-profile target
+
 Heist 	…pull off the ultimate heist

--- a/doc/source/basicgameplay/factions.rst
+++ b/doc/source/basicgameplay/factions.rst
@@ -127,34 +127,34 @@ List of Factions and their Requirements
 | Megacorporations    | Faction Name   | Requirements                            | Joining this Faction prevents |
 |                     |                |                                         | you from joining:             |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | ECorp          | * Have 200k reputation with             |                               |
+|                     | ECorp          | * Have 400k reputation with             |                               |
 |                     |                |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | MegaCorp       | * Have 200k reputation with             |                               |
+|                     | MegaCorp       | * Have 400k reputation with             |                               |
 |                     |                |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | KuaiGong       | * Have 200k reputation with             |                               |
+|                     | KuaiGong       | * Have 400k reputation with             |                               |
 |                     | International  |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | Four Sigma     | * Have 200k reputation with             |                               |
+|                     | Four Sigma     | * Have 400k reputation with             |                               |
 |                     |                |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | NWO            | * Have 200k reputation with             |                               |
+|                     | NWO            | * Have 400k reputation with             |                               |
 |                     |                |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | Blade          | * Have 200k reputation with             |                               |
+|                     | Blade          | * Have 400k reputation with             |                               |
 |                     | Industries     |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | OmniTek        | * Have 200k reputation with             |                               |
+|                     | OmniTek        | * Have 400k reputation with             |                               |
 |                     | Incorporated   |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | Bachman &      | * Have 200k reputation with             |                               |
+|                     | Bachman &      | * Have 400k reputation with             |                               |
 |                     | Associates     |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | Clarke         | * Have 200k reputation with             |                               |
+|                     | Clarke         | * Have 400k reputation with             |                               |
 |                     | Incorporated   |   the Corporation                       |                               |
 +                     +----------------+-----------------------------------------+-------------------------------+
-|                     | Fulcrum Secret | * Have 250k reputation with             |                               |
+|                     | Fulcrum Secret | * Have 400k reputation with             |                               |
 |                     | Technologies   |   the Corporation                       |                               |
 |                     |                | * Install a backdoor on the             |                               |
 |                     |                |   fulcrumassets server                  |                               |

--- a/doc/source/gamefrozen.rst
+++ b/doc/source/gamefrozen.rst
@@ -19,6 +19,53 @@ Then, to fix your script, make sure you have a sleep or any other timed function
         await ns.sleep(1000); // Add a 1s sleep to prevent freezing
     }
 
+Also make sure that each while loop gets to `await`ed function or `break`, for example the next snippet has a sleep 
+function, but it nor any possible conditional breaks are never reached and therefore will crash the game::
+
+    while(true) {
+        let currentMoney = ns.getServerMoneyAvailable("n00dles");
+        let maxMoney = ns.getServerMaxMoney("n00dles");
+        if (currentMoney < maxMoney/2){
+            await ns.grow("n00dles");
+        }
+        if (currentMoney === maxMoney){
+            break;
+        }
+    }
+
+If `n00dles` current money is, for example, 75% of the maximum money, the script will not reach neither `grow` nor `break` and crashes the game.
+Adding a sleep like in the first example, or changing the code so that `await`ed function or `break` is always reached, would prevent the crash.
+
+Common infinite loop when translating the server purchasing script in starting guide to :ref:`netscriptjs` is to have a 
+while loop, that's condition's change is conditional::
+
+    var ram = 8;
+    var i = 0;
+
+    while (i < ns.getPurchasedServerLimit()) {
+        if (ns.getServerMoneyAvailable("home") > ns.getPurchasedServerCost(ram)) {
+            var hostname = ns.purchaseServer("pserv-" + i, ram);
+            ns.scp("early-hack-template.script", hostname);
+            ns.exec("early-hack-template.script", hostname, 3);
+            ++i;
+        }
+    }
+
+if player does not currently have enough money to purchase a server, the `if`'s condition will be false and `++i` will not be reached.
+Since the script doesn't have `sleep` and value `i` will not change without the `if` being true, this will crash the game. Adding a `sleep`
+that is always reached would prevent the crash.
+
+Blackscreen
+-----------
+
+If the game window becomes a black screen without the game itself crashing, this is caused by 
+the game running too many concurrent scripts (the game runs on a browser and each tab can only 
+use so much ram until it crashes). Depending on which scripts are running and your hardware,
+this number can vary between 50000 to 100000 instances (in version 2.0.2. In prior versions this number 
+was about 1/5th of that). To prevent this from happening make sure to multithread the scripts as much as 
+possible.
+
+
 Bug
 ---
 

--- a/doc/source/guidesandtips/gettingstartedguideforbeginnerprogrammers.rst
+++ b/doc/source/guidesandtips/gettingstartedguideforbeginnerprogrammers.rst
@@ -860,6 +860,8 @@ Random Tips
 * At this stage in the game, your combat stats (strength, defense, etc.) are not nearly
   as useful as your hacking stat. Do not invest too much time or money into gaining combat
   stat exp.
+* As a rule of thumb, your hacking target should be the server with highest max money that's
+  required hacking level is under 1/3 of your hacking level. 
 
 
 

--- a/doc/source/guidesandtips/recommendedbitnodeorder.rst
+++ b/doc/source/guidesandtips/recommendedbitnodeorder.rst
@@ -15,6 +15,7 @@ BitNode-1: Source Genesis
 Description
     The first BitNode created by the Enders to imprison the minds of humans. It became
     the prototype and testing-grounds for all of the BitNodes that followed.
+
     This is the first BitNode that you play through. It has no special
     modifications or mechanics.
 
@@ -34,6 +35,8 @@ Difficulty
 BitNode-2: Rise of the Underworld
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Description
+    From the shadows, they rose.
+
     Organized crime groups quickly filled the void of power left behind from the collapse of
     Western government in the 2050s. As society and civlization broke down, people quickly
     succumbed to the innate human impulse of evil and savagery. The organized crime
@@ -71,10 +74,12 @@ BitNode-3: Corporatocracy
 Description
     Our greatest illusion is that a healthy society can revolve around a
     single-minded pursuit of wealth.
+
     Sometime in the early 21st century economic and political globalization turned
     the world into a corporatocracy, and it never looked back. Now, the privileged
     elite will happily bankrupt their own countrymen, decimate their own community,
     and evict their neighbors from houses in their desperate bid to increase their wealth.
+    
     In this BitNode you can create and manage your own corporation. Running a successful corporation
     has the potential of generating massive profits. All other forms of income are reduced by 75%. Furthermore:
 
@@ -334,6 +339,7 @@ Description
     The 2050s was defined by the massive amounts of violent civil unrest and anarchic rebellion that rose all around the world. It was this period
     of disorder that eventually lead to the governmental reformation of many global superpowers, most notably
     the USA and China. But just as the world was slowly beginning to recover from these dark times, financial catastrophe hit.
+
     In many countries, the high cost of trying to deal with the civil disorder bankrupted the governments. In all of this chaos and confusion, hackers
     were able to steal billions of dollars from the world's largest electronic banks, prompting an international banking crisis as
     governments were unable to bail out insolvent banks. Now, the world is slowly crumbling in the middle of the biggest economic crisis of all time.
@@ -345,7 +351,7 @@ Description
     * The growth rate of servers is significantly reduced
     * Weakening a server is twice as effective
     * Company wages are decreased by 50%
-    * Corporation valuations are 99% lower and are therefore significantly less profitable
+    * Corporation valuations are 90% lower and are therefore significantly less profitable
     * Hacknet Node production is significantly decreased
     * Crime and Infiltration are more lucrative
     * Augmentations are twice as expensive
@@ -381,6 +387,47 @@ Source-File
 Difficulty
     Initially very easy, but then it (obviously) becomes harder as you continue to do it.
 
+BitNode-13: They're lunatics
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Description
+    With the invention of Augmentations in the 2040s a religious group known as the Church of the Machine God has rallied far more support than anyone would have hoped.
+
+    Their leader, Allison "Mother" Stanek is said to have created her own Augmentation whose power goes beyond any other. Find her in Chongqing and gain her trust.
+
+    In this BitNode:
+
+    * Your hacking stat is reduced by 75% and exp by 90%
+    * Your combat stats are reduced by 30%
+    * Class and gym exp gains halved
+    * The starting and maximum amount of money available on servers is decreased
+    * The starting security on servers is significantly increased
+    * Hacking money is decreased by 80%
+    * Company wages are decreased by 60% and exp gains by 50%
+    * Hacknet Node production is decreased by 60%
+    * Crime money is decreased by 60% and exp gains by 50%
+    * Stockmarket data costs are increased 10-fold
+    * Corporation valuations are 99.9% lower and are therefore extremely less profitable
+    * The rank you gain from Bladeburner contracts/operations is reduced by 55%
+    * Bladeburner skills cost twice as many skill points
+    * Coding contracts rewards reduced by 60%
+    * Gangs gain are reduced significantly and offer low amount of Augmentations
+    * Size of Stanek's Gift is increased by 1 size
+
+Source-File
+    :Max Level: 3
+
+    Destroying this BitNode will give you Source-File 13, or if you already have this Source-File it will upgrade its level up to a maximum of 3. 
+    This Source-File lets the Church of the Machine God appear in other BitNodes.
+
+    Each level of this Source-File increases the size of Stanek's Gift.
+
+    * Level 1: 5x5
+    * Level 2: 6x6
+    * Level 3: 7x7
+
+Difficulty
+    Hard
+
 Recommended BitNodes
 --------------------
 As a player, you are not forced to tackle the BitNodes in any particular order. You are
@@ -390,9 +437,43 @@ are the recommended BitNodes for different things:
 
 For fast progression
 ^^^^^^^^^^^^^^^^^^^^
-.. note:: This does not recommend the absolute fastest path, as I don't know what
-          exactly the fastest path is. But it does recommend the BitNodes that are
-          commonly considered to be optimal by players.
+.. note:: These paths do not recommend the absolute fastest path, since speed of progression is 
+    highly dependant on playing style. Path 1 is the recommended path according to the discord community.
+
+Path 1 (new):
+
+1. (Optional) Repeat **BitNode-1: Source Genesis** until you max out its Source-File. Its Source-File
+   is extremely powerful, as it raises all multipliers by a significant amount. This also a let's you 
+   get used to augments and other features resetting.
+
+2. Do **BitNode-3: Corporatocracy** once to unlock the Corporation mechanic. This mechanic
+   has highest profit potential in the game.
+
+3. Do **BitNode-10: Digital Carbon** once to unlock sleeves and grafting. Sleeves are useful in all nodes
+   and grafting can be useful in future BitNodes (especially 8). It's recommended to buy all sleeves and 
+   their memory during the first run.
+
+    The ordering of the next three is dependant on playing style and wants/needs.
+
+4. Do **BitNode-5: Artificial Intelligence** once or twice. The intelligence stat it unlocks
+   will gradually build up as you continue to play the game, and will be helpful
+   in the future. The Source-File also provides hacking multipliers, which are
+   strong because hacking is typically one of the best ways of earning money.
+
+5. Do **BitNode-4: The Singularity**. Its Source-File does not directly make you
+   more powerful in any way, but it does unlock the `Singularity API <https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.singularity.md>`_ which
+   let you automate significantly more aspects of the game. Consider repeating until Level 3, 
+   since each level decreases the RAM cost of Singularity functions.
+
+6. Do **BitNode-2: Rise of the Underworld** once to unlock the gang mechanic. This mechanic
+   has high profit potential and offers large amounts of Augmentations in a single faction.
+   Having sleeves (Source-File 10) greatly reduces the time it takes to get access to gangs 
+   outside this BitNode.
+
+7. Do **BitNode-9: Hacktocracy** to unlock the Hacknet Server mechanic. You can
+   consider repeating it as well, as its Level 2 and 3 effects are pretty helpful as well.
+
+Path 2 (old):
 
 1. Repeat **BitNode-1: Source Genesis** until you max out its Source-File. Its Source-File
    is extremely powerful, as it raises all multipliers by a significant amount.
@@ -478,6 +559,9 @@ simple money-generator to a more interesting mechanic.
 
 **BitNode-10: Digital Carbon** unlocks two new mechanics: Re-Sleeving and
 Duplicate Sleeves.
+
+**BitNode-13: They're lunatics** unlocks Stanek's Gift. This gift can improve skills, 
+hacknet production and costs, working and crime gains as well hacking power and speed.
 
 For a Challenge
 ^^^^^^^^^^^^^^^

--- a/doc/source/netscript/basicfunctions/scp.rst
+++ b/doc/source/netscript/basicfunctions/scp.rst
@@ -5,10 +5,10 @@ scp() Netscript Function
 
     :RAM cost: 0.6 GB
     :param string/array files: Filename or an array of filenames of script/literature files to copy
+    :param string destination: Hostname of the destination server, which is the server to which the file will be copied.
     :param string source:
         Hostname of the source server, which is the server from which the file will be copied.
         This argument is optional and if it's omitted the source will be the current server.
-    :param string destination: Hostname of the destination server, which is the server to which the file will be copied.
     :returns: ``true`` if the copy was a success.
 
     Copies a script or literature (.lit) file(s) to another server. The
@@ -26,8 +26,8 @@ scp() Netscript Function
         scp("hack-template.script", "foodnstuff"); // returns: true
 
         //Copies "foo.lit" from the helios server to the "home" computer
-        scp("foo.lit", "helios", "home"); // returns: true
+        scp("foo.lit", "home", "helios"); // returns: true
 
         //Tries to copy three files from "rothman-uni" to "home" computer
         files = ["foo1.lit", "foo2.script", "foo3.script"];
-        scp(files, "rothman-uni", "home"); // returns: true
+        scp(files, "home", "rothman-uni"); // returns: true

--- a/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
@@ -7,6 +7,7 @@ import { Crimes } from "../../../Crime/Crimes";
 import { Crime } from "../../../Crime/Crime";
 import { newWorkStats, scaleWorkStats, WorkStats } from "../../../Work/WorkStats";
 import { CONSTANTS } from "../../../Constants";
+import { BitNodeMultipliers } from "../../../BitNode/BitNodeMultipliers";
 
 export const isSleeveCrimeWork = (w: Work | null): w is SleeveCrimeWork => w !== null && w.type === WorkType.CRIME;
 
@@ -27,14 +28,14 @@ export class SleeveCrimeWork extends Work {
   getExp(): WorkStats {
     const crime = this.getCrime();
     return newWorkStats({
-      money: crime.money,
-      hackExp: crime.hacking_exp,
-      strExp: crime.strength_exp,
-      defExp: crime.defense_exp,
-      dexExp: crime.dexterity_exp,
-      agiExp: crime.agility_exp,
-      chaExp: crime.charisma_exp,
-      intExp: crime.intelligence_exp,
+      money: crime.money*BitNodeMultipliers.CrimeMoney,
+      hackExp: crime.hacking_exp*BitNodeMultipliers.CrimeExpGain,
+      strExp: crime.strength_exp*BitNodeMultipliers.CrimeExpGain,
+      defExp: crime.defense_exp*BitNodeMultipliers.CrimeExpGain,
+      dexExp: crime.dexterity_exp*BitNodeMultipliers.CrimeExpGain,
+      agiExp: crime.agility_exp*BitNodeMultipliers.CrimeExpGain,
+      chaExp: crime.charisma_exp*BitNodeMultipliers.CrimeExpGain,
+      intExp: crime.intelligence_exp*BitNodeMultipliers.CrimeExpGain,
     });
   }
 


### PR DESCRIPTION
Sleeve rework broke sleeve's crime gains connection to bitnode multipliers. Added simple fix for this.