### PR TITLE
NETSCRIPT: fix #3992 allow null duration in toast ns function

### DIFF
--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -139,7 +139,7 @@ function initAppNotifier(): void {
     toast: (message: string, type: ToastVariant, duration = 2000) => SnackbarEvents.emit(message, type, duration),
   };
 
-  // Will be consumud by the electron wrapper.
+  // Will be consumed by the electron wrapper.
   window.appNotifier = funcs;
 }
 
@@ -173,7 +173,7 @@ function initSaveFunctions(): void {
     pushSaveData: (base64save: string, automatic = false): void => Router.toImportSave(base64save, automatic),
   };
 
-  // Will be consumud by the electron wrapper.
+  // Will be consumed by the electron wrapper.
   window.appSaveFns = funcs;
 }
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1849,7 +1849,7 @@ const base: InternalAPI<NS> = {
     (_message: unknown, _variant: unknown = ToastVariant.SUCCESS, _duration: unknown = 2000): void => {
       const message = helpers.string(ctx, "message", _message);
       const variant = helpers.string(ctx, "variant", _variant);
-      const duration = helpers.number(ctx, "duration", _duration);
+      const duration = _duration === null ? null : helpers.number(ctx, "duration", _duration);
       if (!checkEnum(ToastVariant, variant))
         throw new Error(`variant must be one of ${Object.values(ToastVariant).join(", ")}`);
       SnackbarEvents.emit(message, variant, duration);

--- a/src/ui/React/Snackbar.tsx
+++ b/src/ui/React/Snackbar.tsx
@@ -43,7 +43,7 @@ export function SnackbarProvider(props: IProps): React.ReactElement {
   );
 }
 
-export const SnackbarEvents = new EventEmitter<[string | React.ReactNode, ToastVariant, number]>();
+export const SnackbarEvents = new EventEmitter<[string | React.ReactNode, ToastVariant, number | null]>();
 
 export function Snackbar(): React.ReactElement {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();


### PR DESCRIPTION
extend SnackbarEvents typing to allow null in third argument
also remove typos in Electron.tsx init functions comments

fixes #3992

Scripts to test:

```
// NS1
toast("Test", undefined, null)

// NS2
export async function main(ns) {
    ns.toast("Test", undefined, null)
}
```