### PR TITLE
NETSCRIPT: Normalized Stock API logging

### DIFF
--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -163,7 +163,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
         const shares = helpers.number(ctx, "shares", _shares);
         checkTixApiAccess(ctx);
         const stock = getStockFromSymbol(ctx, symbol);
-        const res = buyStock(stock, shares, ctx.workerScript, {});
+        const res = buyStock(stock, shares, ctx, {});
         return res ? stock.getAskPrice() : 0;
       },
     sellStock:
@@ -173,7 +173,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
         const shares = helpers.number(ctx, "shares", _shares);
         checkTixApiAccess(ctx);
         const stock = getStockFromSymbol(ctx, symbol);
-        const res = sellStock(stock, shares, ctx.workerScript, {});
+        const res = sellStock(stock, shares, ctx, {});
 
         return res ? stock.getBidPrice() : 0;
       },
@@ -192,7 +192,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
           }
         }
         const stock = getStockFromSymbol(ctx, symbol);
-        const res = shortStock(stock, shares, ctx.workerScript, {});
+        const res = shortStock(stock, shares, ctx, {});
 
         return res ? stock.getBidPrice() : 0;
       },
@@ -211,7 +211,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
           }
         }
         const stock = getStockFromSymbol(ctx, symbol);
-        const res = sellShort(stock, shares, ctx.workerScript, {});
+        const res = sellShort(stock, shares, ctx, {});
 
         return res ? stock.getAskPrice() : 0;
       },
@@ -258,7 +258,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
           throw helpers.makeRuntimeErrorMsg(ctx, `Invalid position type: ${pos}`);
         }
 
-        return placeOrder(stock, shares, price, orderType, orderPos, ctx.workerScript);
+        return placeOrder(stock, shares, price, orderType, orderPos, ctx);
       },
     cancelOrder:
       (ctx: NetscriptContext) =>
@@ -314,7 +314,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
           type: orderType,
           pos: orderPos,
         };
-        return cancelOrder(params, ctx.workerScript);
+        return cancelOrder(params, ctx);
       },
     getOrders: (ctx: NetscriptContext) => (): StockOrder => {
       checkTixApiAccess(ctx);

--- a/src/StockMarket/BuyingAndSelling.tsx
+++ b/src/StockMarket/BuyingAndSelling.tsx
@@ -229,7 +229,7 @@ export function shortStock(
   }
   if (stock == null || isNaN(shares)) {
     if (workerScript) {
-      workerScript.log("stock.short", () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
+      workerScript.log("stock.shortStock", () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
     } else if (opts.suppressDialog !== true) {
       dialogBoxCreate(
         "Failed to initiate a short position in a stock. This is probably " +
@@ -247,7 +247,7 @@ export function shortStock(
   if (Player.money < totalPrice) {
     if (workerScript) {
       workerScript.log(
-        "stock.short",
+        "stock.shortStock",
         () =>
           "You do not have enough " +
           "money to purchase this short position. You need " +
@@ -268,7 +268,7 @@ export function shortStock(
   if (shares + stock.playerShares + stock.playerShortShares > stock.maxShares) {
     if (workerScript) {
       workerScript.log(
-        "stock.short",
+        "stock.shortStock",
         () =>
           `This '${shares + stock.playerShares + stock.playerShortShares}' short shares would exceed ${
             stock.symbol
@@ -301,7 +301,7 @@ export function shortStock(
         CONSTANTS.StockMarketCommission,
       )} ` +
       `in commission fees.`;
-    workerScript.log("stock.short", () => resultTxt);
+    workerScript.log("stock.shortStock", () => resultTxt);
   } else if (!opts.suppressDialog) {
     dialogBoxCreate(
       <>

--- a/src/StockMarket/BuyingAndSelling.tsx
+++ b/src/StockMarket/BuyingAndSelling.tsx
@@ -12,7 +12,6 @@ import {
 import { PositionTypes } from "./data/PositionTypes";
 
 import { CONSTANTS } from "../Constants";
-import { WorkerScript } from "../Netscript/WorkerScript";
 import { Player } from "../Player";
 
 import { numeralWrapper } from "../ui/numeralFormat";
@@ -21,6 +20,8 @@ import { Money } from "../ui/React/Money";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 
 import * as React from "react";
+import { NetscriptContext } from "../Netscript/APIWrapper";
+import { helpers } from "../Netscript/NetscriptHelpers";
 
 /**
  * Each function takes an optional config object as its last argument
@@ -34,14 +35,14 @@ interface IOptions {
  * Attempt to buy a stock in the long position
  * @param {Stock} stock - Stock to buy
  * @param {number} shares - Number of shares to buy
- * @param {WorkerScript} workerScript - If this is being called through Netscript
+ * @param {NetscriptContext} ctx - If this is being called through Netscript
  * @param opts - Optional configuration for this function's behavior. See top of file
  * @returns {boolean} - true if successful, false otherwise
  */
 export function buyStock(
   stock: Stock,
   shares: number,
-  workerScript: WorkerScript | null = null,
+  ctx: NetscriptContext | null = null,
   opts: IOptions = {},
 ): boolean {
   // Validate arguments
@@ -50,8 +51,8 @@ export function buyStock(
     return false;
   }
   if (stock == null || isNaN(shares)) {
-    if (workerScript) {
-      workerScript.log("stock.buyStock", () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
+    if (ctx) {
+      helpers.log(ctx, () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
     } else if (opts.suppressDialog !== true) {
       dialogBoxCreate("Failed to buy stock. This may be a bug, contact developer");
     }
@@ -65,9 +66,9 @@ export function buyStock(
     return false;
   }
   if (Player.money < totalPrice) {
-    if (workerScript) {
-      workerScript.log(
-        "stock.buyStock",
+    if (ctx) {
+      helpers.log(
+        ctx,
         () =>
           `You do not have enough money to purchase this position. You need ${numeralWrapper.formatMoney(totalPrice)}.`,
       );
@@ -84,9 +85,9 @@ export function buyStock(
 
   // Would this purchase exceed the maximum number of shares?
   if (shares + stock.playerShares + stock.playerShortShares > stock.maxShares) {
-    if (workerScript) {
-      workerScript.log(
-        "stock.buyStock",
+    if (ctx) {
+      helpers.log(
+        ctx,
         () =>
           `Purchasing '${shares + stock.playerShares + stock.playerShortShares}' shares would exceed ${
             stock.symbol
@@ -113,13 +114,13 @@ export function buyStock(
     opts.rerenderFn();
   }
 
-  if (workerScript) {
+  if (ctx) {
     const resultTxt = `Bought ${numeralWrapper.formatShares(shares)} shares of ${
       stock.symbol
     } for ${numeralWrapper.formatMoney(totalPrice)}. Paid ${numeralWrapper.formatMoney(
       CONSTANTS.StockMarketCommission,
     )} in commission fees.`;
-    workerScript.log("stock.buyStock", () => resultTxt);
+    helpers.log(ctx, () => resultTxt);
   } else if (opts.suppressDialog !== true) {
     dialogBoxCreate(
       <>
@@ -136,20 +137,20 @@ export function buyStock(
  * Attempt to sell a stock in the long position
  * @param {Stock} stock - Stock to sell
  * @param {number} shares - Number of shares to sell
- * @param {WorkerScript} workerScript - If this is being called through Netscript
+ * @param {NetscriptContext} ctx - If this is being called through Netscript
  * @param opts - Optional configuration for this function's behavior. See top of file
  * returns {boolean} - true if successfully sells given number of shares OR MAX owned, false otherwise
  */
 export function sellStock(
   stock: Stock,
   shares: number,
-  workerScript: WorkerScript | null = null,
+  ctx: NetscriptContext | null = null,
   opts: IOptions = {},
 ): boolean {
   // Sanitize/Validate arguments
   if (stock == null || shares < 0 || isNaN(shares)) {
-    if (workerScript) {
-      workerScript.log("stock.sellStock", () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
+    if (ctx) {
+      helpers.log(ctx, () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
     } else if (opts.suppressDialog !== true) {
       dialogBoxCreate(
         "Failed to sell stock. This is probably due to an invalid quantity. Otherwise, this may be a bug, contact developer",
@@ -175,8 +176,8 @@ export function sellStock(
     netProfit = 0;
   }
   Player.gainMoney(gains, "stock");
-  if (workerScript) {
-    workerScript.scriptRef.onlineMoneyMade += netProfit;
+  if (ctx) {
+    ctx.workerScript.scriptRef.onlineMoneyMade += netProfit;
     Player.scriptProdSinceLastAug += netProfit;
   }
 
@@ -191,11 +192,11 @@ export function sellStock(
     opts.rerenderFn();
   }
 
-  if (workerScript) {
+  if (ctx) {
     const resultTxt =
       `Sold ${numeralWrapper.formatShares(shares)} shares of ${stock.symbol}. ` +
       `After commissions, you gained a total of ${numeralWrapper.formatMoney(gains)}.`;
-    workerScript.log("stock.sellStock", () => resultTxt);
+    helpers.log(ctx, () => resultTxt);
   } else if (opts.suppressDialog !== true) {
     dialogBoxCreate(
       <>
@@ -212,14 +213,14 @@ export function sellStock(
  * Attempt to buy a stock in the short position
  * @param {Stock} stock - Stock to sell
  * @param {number} shares - Number of shares to short
- * @param {WorkerScript} workerScript - If this is being called through Netscript
+ * @param {NetscriptContext} ctx - If this is being called through Netscript
  * @param opts - Optional configuration for this function's behavior. See top of file
  * @returns {boolean} - true if successful, false otherwise
  */
 export function shortStock(
   stock: Stock,
   shares: number,
-  workerScript: WorkerScript | null = null,
+  ctx: NetscriptContext | null = null,
   opts: IOptions = {},
 ): boolean {
   // Validate arguments
@@ -228,8 +229,8 @@ export function shortStock(
     return false;
   }
   if (stock == null || isNaN(shares)) {
-    if (workerScript) {
-      workerScript.log("stock.shortStock", () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
+    if (ctx) {
+      helpers.log(ctx, () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
     } else if (opts.suppressDialog !== true) {
       dialogBoxCreate(
         "Failed to initiate a short position in a stock. This is probably " +
@@ -245,9 +246,9 @@ export function shortStock(
     return false;
   }
   if (Player.money < totalPrice) {
-    if (workerScript) {
-      workerScript.log(
-        "stock.shortStock",
+    if (ctx) {
+      helpers.log(
+        ctx,
         () =>
           "You do not have enough " +
           "money to purchase this short position. You need " +
@@ -266,9 +267,9 @@ export function shortStock(
 
   // Would this purchase exceed the maximum number of shares?
   if (shares + stock.playerShares + stock.playerShortShares > stock.maxShares) {
-    if (workerScript) {
-      workerScript.log(
-        "stock.shortStock",
+    if (ctx) {
+      helpers.log(
+        ctx,
         () =>
           `This '${shares + stock.playerShares + stock.playerShortShares}' short shares would exceed ${
             stock.symbol
@@ -294,14 +295,14 @@ export function shortStock(
     opts.rerenderFn();
   }
 
-  if (workerScript) {
+  if (ctx) {
     const resultTxt =
       `Bought a short position of ${numeralWrapper.formatShares(shares)} shares of ${stock.symbol} ` +
       `for ${numeralWrapper.formatMoney(totalPrice)}. Paid ${numeralWrapper.formatMoney(
         CONSTANTS.StockMarketCommission,
       )} ` +
       `in commission fees.`;
-    workerScript.log("stock.shortStock", () => resultTxt);
+    helpers.log(ctx, () => resultTxt);
   } else if (!opts.suppressDialog) {
     dialogBoxCreate(
       <>
@@ -318,19 +319,19 @@ export function shortStock(
  * Attempt to sell a stock in the short position
  * @param {Stock} stock - Stock to sell
  * @param {number} shares - Number of shares to sell
- * @param {WorkerScript} workerScript - If this is being called through Netscript
+ * @param {NetscriptContext} ctx - If this is being called through Netscript
  * @param opts - Optional configuration for this function's behavior. See top of file
  * @returns {boolean} true if successfully sells given amount OR max owned, false otherwise
  */
 export function sellShort(
   stock: Stock,
   shares: number,
-  workerScript: WorkerScript | null = null,
+  ctx: NetscriptContext | null = null,
   opts: IOptions = {},
 ): boolean {
   if (stock == null || isNaN(shares) || shares < 0) {
-    if (workerScript) {
-      workerScript.log("stock.sellShort", () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
+    if (ctx) {
+      helpers.log(ctx, () => `Invalid arguments: stock='${stock}' shares='${shares}'`);
     } else if (!opts.suppressDialog) {
       dialogBoxCreate(
         "Failed to sell a short position in a stock. This is probably " +
@@ -351,9 +352,9 @@ export function sellShort(
   const origCost = shares * stock.playerAvgShortPx;
   const totalGain = getSellTransactionGain(stock, shares, PositionTypes.Short);
   if (totalGain == null || isNaN(totalGain) || origCost == null) {
-    if (workerScript) {
-      workerScript.log(
-        "stock.sellShort",
+    if (ctx) {
+      helpers.log(
+        ctx,
         () => `Failed to sell short position in a stock. This is probably either due to invalid arguments, or a bug`,
       );
     } else if (!opts.suppressDialog) {
@@ -369,8 +370,8 @@ export function sellShort(
     profit = 0;
   }
   Player.gainMoney(totalGain, "stock");
-  if (workerScript) {
-    workerScript.scriptRef.onlineMoneyMade += profit;
+  if (ctx) {
+    ctx.workerScript.scriptRef.onlineMoneyMade += profit;
     Player.scriptProdSinceLastAug += profit;
   }
 
@@ -384,11 +385,11 @@ export function sellShort(
     opts.rerenderFn();
   }
 
-  if (workerScript) {
+  if (ctx) {
     const resultTxt =
       `Sold your short position of ${numeralWrapper.formatShares(shares)} shares of ${stock.symbol}. ` +
       `After commissions, you gained a total of ${numeralWrapper.formatMoney(totalGain)}`;
-    workerScript.log("stock.sellShort", () => resultTxt);
+    helpers.log(ctx, () => resultTxt);
   } else if (!opts.suppressDialog) {
     dialogBoxCreate(
       <>

--- a/src/StockMarket/StockMarket.tsx
+++ b/src/StockMarket/StockMarket.tsx
@@ -11,7 +11,6 @@ import { StockSymbols } from "./data/StockSymbols";
 
 import { CONSTANTS } from "../Constants";
 import { IMap } from "../types";
-import { EventEmitter } from "../utils/EventEmitter";
 
 import { numeralWrapper } from "../ui/numeralFormat";
 

--- a/src/StockMarket/StockMarket.tsx
+++ b/src/StockMarket/StockMarket.tsx
@@ -10,7 +10,6 @@ import { PositionTypes } from "./data/PositionTypes";
 import { StockSymbols } from "./data/StockSymbols";
 
 import { CONSTANTS } from "../Constants";
-import { WorkerScript } from "../Netscript/WorkerScript";
 import { IMap } from "../types";
 import { EventEmitter } from "../utils/EventEmitter";
 
@@ -18,6 +17,8 @@ import { numeralWrapper } from "../ui/numeralFormat";
 
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { Reviver } from "../utils/JSONReviver";
+import { NetscriptContext } from "../Netscript/APIWrapper";
+import { helpers } from "../Netscript/NetscriptHelpers";
 
 export let StockMarket: IStockMarket = {
   lastUpdate: 0,
@@ -33,19 +34,19 @@ export function placeOrder(
   price: number,
   type: OrderTypes,
   position: PositionTypes,
-  workerScript: WorkerScript | null = null,
+  ctx: NetscriptContext | null = null,
 ): boolean {
   if (!(stock instanceof Stock)) {
-    if (workerScript) {
-      workerScript.log("stock.placeOrder", () => `Invalid stock: '${stock}'`);
+    if (ctx) {
+      helpers.log(ctx, () => `Invalid stock: '${stock}'`);
     } else {
       dialogBoxCreate(`ERROR: Invalid stock passed to placeOrder() function`);
     }
     return false;
   }
   if (typeof shares !== "number" || typeof price !== "number") {
-    if (workerScript) {
-      workerScript.log("stock.placeOrder", () => `Invalid arguments: shares='${shares}' price='${price}'`);
+    if (ctx) {
+      helpers.log(ctx, () => `Invalid arguments: shares='${shares}' price='${price}'`);
     } else {
       dialogBoxCreate("ERROR: Invalid numeric value provided for either 'shares' or 'price' argument");
     }
@@ -85,7 +86,7 @@ export interface ICancelOrderParams {
   stock?: Stock;
   type?: OrderTypes;
 }
-export function cancelOrder(params: ICancelOrderParams, workerScript: WorkerScript | null = null): boolean {
+export function cancelOrder(params: ICancelOrderParams, ctx: NetscriptContext | null = null): boolean {
   if (StockMarket["Orders"] == null) {
     return false;
   }
@@ -120,14 +121,14 @@ export function cancelOrder(params: ICancelOrderParams, workerScript: WorkerScri
         params.pos === order.pos
       ) {
         stockOrders.splice(i, 1);
-        if (workerScript) {
-          workerScript.scriptRef.log("Successfully cancelled order: " + orderTxt);
+        if (ctx) {
+          helpers.log(ctx, ()=>"Successfully cancelled order: " + orderTxt);
         }
         return true;
       }
     }
-    if (workerScript) {
-      workerScript.scriptRef.log("Failed to cancel order: " + orderTxt);
+    if (ctx) {
+      helpers.log(ctx, ()=>"Failed to cancel order: " + orderTxt);
     }
     return false;
   }

--- a/src/StockMarket/StockMarket.tsx
+++ b/src/StockMarket/StockMarket.tsx
@@ -86,7 +86,7 @@ export interface ICancelOrderParams {
   stock?: Stock;
   type?: OrderTypes;
 }
-export function cancelOrder(params: ICancelOrderParams, ctx: NetscriptContext | null = null): boolean {
+export function cancelOrder(params: ICancelOrderParams, ctx?: NetscriptContext): boolean {
   if (StockMarket["Orders"] == null) {
     return false;
   }
@@ -122,13 +122,13 @@ export function cancelOrder(params: ICancelOrderParams, ctx: NetscriptContext | 
       ) {
         stockOrders.splice(i, 1);
         if (ctx) {
-          helpers.log(ctx, ()=>"Successfully cancelled order: " + orderTxt);
+          helpers.log(ctx, () => "Successfully cancelled order: " + orderTxt);
         }
         return true;
       }
     }
     if (ctx) {
-      helpers.log(ctx, ()=>"Failed to cancel order: " + orderTxt);
+      helpers.log(ctx, () => "Failed to cancel order: " + orderTxt);
     }
     return false;
   }

--- a/src/StockMarket/StockMarket.tsx
+++ b/src/StockMarket/StockMarket.tsx
@@ -34,7 +34,7 @@ export function placeOrder(
   price: number,
   type: OrderTypes,
   position: PositionTypes,
-  ctx: NetscriptContext | null = null,
+  ctx?: NetscriptContext,
 ): boolean {
   if (!(stock instanceof Stock)) {
     if (ctx) {
@@ -87,9 +87,7 @@ export interface ICancelOrderParams {
   type?: OrderTypes;
 }
 export function cancelOrder(params: ICancelOrderParams, ctx?: NetscriptContext): boolean {
-  if (StockMarket["Orders"] == null) {
-    return false;
-  }
+  if (StockMarket["Orders"] == null) return false;
   if (params.order && params.order instanceof Order) {
     const order = params.order;
     // An 'Order' object is passed in
@@ -121,15 +119,11 @@ export function cancelOrder(params: ICancelOrderParams, ctx?: NetscriptContext):
         params.pos === order.pos
       ) {
         stockOrders.splice(i, 1);
-        if (ctx) {
-          helpers.log(ctx, () => "Successfully cancelled order: " + orderTxt);
-        }
+        if (ctx) helpers.log(ctx, () => "Successfully cancelled order: " + orderTxt);
         return true;
       }
     }
-    if (ctx) {
-      helpers.log(ctx, () => "Failed to cancel order: " + orderTxt);
-    }
+    if (ctx) helpers.log(ctx, () => "Failed to cancel order: " + orderTxt);
     return false;
   }
   return false;
@@ -143,9 +137,7 @@ export function loadStockMarket(saveString: string): void {
       storedCycles: 0,
       ticksUntilCycle: 0,
     } as IStockMarket;
-  } else {
-    StockMarket = JSON.parse(saveString, Reviver);
-  }
+  } else StockMarket = JSON.parse(saveString, Reviver);
 }
 
 export function deleteStockMarket(): void {
@@ -159,9 +151,7 @@ export function deleteStockMarket(): void {
 
 export function initStockMarket(): void {
   for (const stk of Object.keys(StockMarket)) {
-    if (StockMarket.hasOwnProperty(stk)) {
-      delete StockMarket[stk];
-    }
+    if (StockMarket.hasOwnProperty(stk)) delete StockMarket[stk];
   }
 
   for (const metadata of InitStockMetadata) {
@@ -172,9 +162,7 @@ export function initStockMarket(): void {
   const orders: IOrderBook = {};
   for (const name of Object.keys(StockMarket)) {
     const stock = StockMarket[name];
-    if (!(stock instanceof Stock)) {
-      continue;
-    }
+    if (!(stock instanceof Stock)) continue;
     orders[stock.symbol] = [];
   }
   StockMarket["Orders"] = orders;
@@ -201,9 +189,7 @@ export function initSymbolToStockMap(): void {
 function stockMarketCycle(): void {
   for (const name of Object.keys(StockMarket)) {
     const stock = StockMarket[name];
-    if (!(stock instanceof Stock)) {
-      continue;
-    }
+    if (!(stock instanceof Stock)) continue;
 
     const roll = Math.random();
     if (roll < 0.45) {
@@ -231,9 +217,7 @@ export function processStockPrices(numCycles = 1): void {
   // We can process the update every 4 seconds as long as there are enough
   // stored cycles. This lets us account for offline time
   const timeNow = new Date().getTime();
-  if (timeNow - StockMarket.lastUpdate < 4e3) {
-    return;
-  }
+  if (timeNow - StockMarket.lastUpdate < 4e3) return;
 
   StockMarket.lastUpdate = timeNow;
   StockMarket.storedCycles -= cyclesPerStockUpdate;
@@ -243,16 +227,12 @@ export function processStockPrices(numCycles = 1): void {
     StockMarket.ticksUntilCycle = TicksPerCycle;
   }
   --StockMarket.ticksUntilCycle;
-  if (StockMarket.ticksUntilCycle <= 0) {
-    stockMarketCycle();
-  }
+  if (StockMarket.ticksUntilCycle <= 0) stockMarketCycle();
 
   const v = Math.random();
   for (const name of Object.keys(StockMarket)) {
     const stock = StockMarket[name];
-    if (!(stock instanceof Stock)) {
-      continue;
-    }
+    if (!(stock instanceof Stock)) continue;
     let av = (v * stock.mv) / 100;
     if (isNaN(av)) {
       av = 0.02;
@@ -311,5 +291,3 @@ export function initStockMarketFn(): void {
   initStockMarket();
   initSymbolToStockMap();
 }
-
-export const eventEmitterForUiReset = new EventEmitter<[]>();

--- a/src/StockMarket/ui/InfoAndPurchases.tsx
+++ b/src/StockMarket/ui/InfoAndPurchases.tsx
@@ -10,6 +10,7 @@ import { getStockMarket4SDataCost, getStockMarket4STixApiCost } from "../StockMa
 import { CONSTANTS } from "../../Constants";
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { Money } from "../../ui/React/Money";
+import { initStockMarket } from "../StockMarket";
 
 import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
@@ -22,7 +23,6 @@ import { StaticModal } from "../../ui/React/StaticModal";
 import { FactionNames } from "../../Faction/data/FactionNames";
 
 type IProps = {
-  initStockMarket: () => void;
   p: IPlayer;
   rerender: () => void;
 };
@@ -88,7 +88,7 @@ function PurchaseWseAccountButton(props: IProps): React.ReactElement {
       return;
     }
     props.p.hasWseAccount = true;
-    props.initStockMarket();
+    initStockMarket();
     props.p.loseMoney(CONSTANTS.WSEAccountCost, "stock");
     props.rerender();
   }

--- a/src/StockMarket/ui/StockMarketRoot.tsx
+++ b/src/StockMarket/ui/StockMarketRoot.tsx
@@ -9,10 +9,8 @@ import { StockTickers } from "./StockTickers";
 import { IStockMarket } from "../IStockMarket";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
-import { EventEmitter } from "../../utils/EventEmitter";
 
 type IProps = {
-  eventEmitterForReset?: EventEmitter<[]>;
   initStockMarket: () => void;
   p: IPlayer;
   stockMarket: IStockMarket;
@@ -32,7 +30,7 @@ export function StockMarketRoot(props: IProps): React.ReactElement {
     <>
       <InfoAndPurchases initStockMarket={props.initStockMarket} p={props.p} rerender={rerender} />
       {props.p.hasWseAccount && (
-        <StockTickers eventEmitterForReset={props.eventEmitterForReset} p={props.p} stockMarket={props.stockMarket} />
+        <StockTickers p={props.p} stockMarket={props.stockMarket} />
       )}
     </>
   );

--- a/src/StockMarket/ui/StockMarketRoot.tsx
+++ b/src/StockMarket/ui/StockMarketRoot.tsx
@@ -28,9 +28,7 @@ export function StockMarketRoot(props: IProps): React.ReactElement {
   return (
     <>
       <InfoAndPurchases p={props.p} rerender={rerender} />
-      {props.p.hasWseAccount && (
-        <StockTickers p={props.p} stockMarket={props.stockMarket} />
-      )}
+      {props.p.hasWseAccount && <StockTickers p={props.p} stockMarket={props.stockMarket} />}
     </>
   );
 }

--- a/src/StockMarket/ui/StockMarketRoot.tsx
+++ b/src/StockMarket/ui/StockMarketRoot.tsx
@@ -7,31 +7,14 @@ import { InfoAndPurchases } from "./InfoAndPurchases";
 import { StockTickers } from "./StockTickers";
 
 import { IStockMarket } from "../IStockMarket";
-import { Stock } from "../Stock";
-import { OrderTypes } from "../data/OrderTypes";
-import { PositionTypes } from "../data/PositionTypes";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { EventEmitter } from "../../utils/EventEmitter";
 
-type txFn = (stock: Stock, shares: number) => boolean;
-type placeOrderFn = (
-  stock: Stock,
-  shares: number,
-  price: number,
-  ordType: OrderTypes,
-  posType: PositionTypes,
-) => boolean;
-
 type IProps = {
-  buyStockLong: txFn;
-  buyStockShort: txFn;
   eventEmitterForReset?: EventEmitter<[]>;
   initStockMarket: () => void;
   p: IPlayer;
-  placeOrder: placeOrderFn;
-  sellStockLong: txFn;
-  sellStockShort: txFn;
   stockMarket: IStockMarket;
 };
 
@@ -49,16 +32,7 @@ export function StockMarketRoot(props: IProps): React.ReactElement {
     <>
       <InfoAndPurchases initStockMarket={props.initStockMarket} p={props.p} rerender={rerender} />
       {props.p.hasWseAccount && (
-        <StockTickers
-          buyStockLong={props.buyStockLong}
-          buyStockShort={props.buyStockShort}
-          eventEmitterForReset={props.eventEmitterForReset}
-          p={props.p}
-          placeOrder={props.placeOrder}
-          sellStockLong={props.sellStockLong}
-          sellStockShort={props.sellStockShort}
-          stockMarket={props.stockMarket}
-        />
+        <StockTickers eventEmitterForReset={props.eventEmitterForReset} p={props.p} stockMarket={props.stockMarket} />
       )}
     </>
   );

--- a/src/StockMarket/ui/StockMarketRoot.tsx
+++ b/src/StockMarket/ui/StockMarketRoot.tsx
@@ -13,8 +13,6 @@ import { PositionTypes } from "../data/PositionTypes";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { EventEmitter } from "../../utils/EventEmitter";
-import { ICancelOrderParams } from "../StockMarket";
-import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 type txFn = (stock: Stock, shares: number) => boolean;
 type placeOrderFn = (
@@ -28,7 +26,6 @@ type placeOrderFn = (
 type IProps = {
   buyStockLong: txFn;
   buyStockShort: txFn;
-  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   eventEmitterForReset?: EventEmitter<[]>;
   initStockMarket: () => void;
   p: IPlayer;
@@ -55,7 +52,6 @@ export function StockMarketRoot(props: IProps): React.ReactElement {
         <StockTickers
           buyStockLong={props.buyStockLong}
           buyStockShort={props.buyStockShort}
-          cancelOrder={props.cancelOrder}
           eventEmitterForReset={props.eventEmitterForReset}
           p={props.p}
           placeOrder={props.placeOrder}

--- a/src/StockMarket/ui/StockMarketRoot.tsx
+++ b/src/StockMarket/ui/StockMarketRoot.tsx
@@ -13,8 +13,8 @@ import { PositionTypes } from "../data/PositionTypes";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { EventEmitter } from "../../utils/EventEmitter";
-import { WorkerScript } from "../../Netscript/WorkerScript";
 import { ICancelOrderParams } from "../StockMarket";
+import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 type txFn = (stock: Stock, shares: number) => boolean;
 type placeOrderFn = (
@@ -28,7 +28,7 @@ type placeOrderFn = (
 type IProps = {
   buyStockLong: txFn;
   buyStockShort: txFn;
-  cancelOrder: (params: ICancelOrderParams, workerScript?: WorkerScript) => void;
+  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   eventEmitterForReset?: EventEmitter<[]>;
   initStockMarket: () => void;
   p: IPlayer;

--- a/src/StockMarket/ui/StockMarketRoot.tsx
+++ b/src/StockMarket/ui/StockMarketRoot.tsx
@@ -11,7 +11,6 @@ import { IStockMarket } from "../IStockMarket";
 import { IPlayer } from "../../PersonObjects/IPlayer";
 
 type IProps = {
-  initStockMarket: () => void;
   p: IPlayer;
   stockMarket: IStockMarket;
 };
@@ -28,7 +27,7 @@ export function StockMarketRoot(props: IProps): React.ReactElement {
   }, []);
   return (
     <>
-      <InfoAndPurchases initStockMarket={props.initStockMarket} p={props.p} rerender={rerender} />
+      <InfoAndPurchases p={props.p} rerender={rerender} />
       {props.p.hasWseAccount && (
         <StockTickers p={props.p} stockMarket={props.stockMarket} />
       )}

--- a/src/StockMarket/ui/StockTicker.tsx
+++ b/src/StockMarket/ui/StockTicker.tsx
@@ -14,6 +14,8 @@ import { Stock } from "../Stock";
 import { getBuyTransactionCost, getSellTransactionGain, calculateBuyMaxAmount } from "../StockMarketHelpers";
 import { OrderTypes } from "../data/OrderTypes";
 import { PositionTypes } from "../data/PositionTypes";
+import { placeOrder } from "../StockMarket";
+import { buyStock, shortStock, sellStock, sellShort } from "../BuyingAndSelling";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { numeralWrapper } from "../../ui/numeralFormat";
@@ -38,24 +40,10 @@ enum SelectorOrderType {
   Stop = "Stop Order",
 }
 
-type txFn = (stock: Stock, shares: number) => boolean;
-type placeOrderFn = (
-  stock: Stock,
-  shares: number,
-  price: number,
-  ordType: OrderTypes,
-  posType: PositionTypes,
-) => boolean;
-
 type IProps = {
-  buyStockLong: txFn;
-  buyStockShort: txFn;
   orders: Order[];
   p: IPlayer;
-  placeOrder: placeOrderFn;
   rerenderAllTickers: () => void;
-  sellStockLong: txFn;
-  sellStockShort: txFn;
   stock: Stock;
 };
 
@@ -138,9 +126,9 @@ export function StockTicker(props: IProps): React.ReactElement {
     switch (orderType) {
       case SelectorOrderType.Market: {
         if (position === PositionTypes.Short) {
-          props.buyStockShort(props.stock, shares);
+          shortStock(props.stock, shares);
         } else {
-          props.buyStockLong(props.stock, shares);
+          buyStock(props.stock, shares);
         }
         props.rerenderAllTickers();
         break;
@@ -150,7 +138,7 @@ export function StockTicker(props: IProps): React.ReactElement {
         setModalProps({
           text: "Enter the price for your Limit Order",
           placeText: "Place Buy Limit Order",
-          place: (price: number) => props.placeOrder(props.stock, shares, price, OrderTypes.LimitBuy, position),
+          place: (price: number) => placeOrder(props.stock, shares, price, OrderTypes.LimitBuy, position),
         });
         break;
       }
@@ -159,7 +147,7 @@ export function StockTicker(props: IProps): React.ReactElement {
         setModalProps({
           text: "Enter the price for your Stop Order",
           placeText: "Place Buy Stop Order",
-          place: (price: number) => props.placeOrder(props.stock, shares, price, OrderTypes.StopBuy, position),
+          place: (price: number) => placeOrder(props.stock, shares, price, OrderTypes.StopBuy, position),
         });
         break;
       }
@@ -178,9 +166,9 @@ export function StockTicker(props: IProps): React.ReactElement {
     switch (orderType) {
       case SelectorOrderType.Market: {
         if (position === PositionTypes.Short) {
-          props.buyStockShort(stock, maxShares);
+          shortStock(stock, maxShares);
         } else {
-          props.buyStockLong(stock, maxShares);
+          buyStock(stock, maxShares);
         }
         props.rerenderAllTickers();
         break;
@@ -234,9 +222,9 @@ export function StockTicker(props: IProps): React.ReactElement {
     switch (orderType) {
       case SelectorOrderType.Market: {
         if (position === PositionTypes.Short) {
-          props.sellStockShort(props.stock, shares);
+          sellShort(props.stock, shares);
         } else {
-          props.sellStockLong(props.stock, shares);
+          sellStock(props.stock, shares);
         }
         props.rerenderAllTickers();
         break;
@@ -246,7 +234,7 @@ export function StockTicker(props: IProps): React.ReactElement {
         setModalProps({
           text: "Enter the price for your Limit Order",
           placeText: "Place Sell Limit Order",
-          place: (price: number) => props.placeOrder(props.stock, shares, price, OrderTypes.LimitSell, position),
+          place: (price: number) => placeOrder(props.stock, shares, price, OrderTypes.LimitSell, position),
         });
         break;
       }
@@ -255,7 +243,7 @@ export function StockTicker(props: IProps): React.ReactElement {
         setModalProps({
           text: "Enter the price for your Stop Order",
           placeText: "Place Sell Stop Order",
-          place: (price: number) => props.placeOrder(props.stock, shares, price, OrderTypes.StopSell, position),
+          place: (price: number) => placeOrder(props.stock, shares, price, OrderTypes.StopSell, position),
         });
         break;
       }
@@ -270,9 +258,9 @@ export function StockTicker(props: IProps): React.ReactElement {
     switch (orderType) {
       case SelectorOrderType.Market: {
         if (position === PositionTypes.Short) {
-          props.sellStockShort(stock, stock.playerShortShares);
+          sellShort(stock, stock.playerShortShares);
         } else {
-          props.sellStockLong(stock, stock.playerShares);
+          sellStock(stock, stock.playerShares);
         }
         props.rerenderAllTickers();
         break;

--- a/src/StockMarket/ui/StockTicker.tsx
+++ b/src/StockMarket/ui/StockTicker.tsx
@@ -31,8 +31,6 @@ import Paper from "@mui/material/Paper";
 import Collapse from "@mui/material/Collapse";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import ExpandLess from "@mui/icons-material/ExpandLess";
-import { ICancelOrderParams } from "../StockMarket";
-import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 enum SelectorOrderType {
   Market = "Market Order",
@@ -52,7 +50,6 @@ type placeOrderFn = (
 type IProps = {
   buyStockLong: txFn;
   buyStockShort: txFn;
-  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   orders: Order[];
   p: IPlayer;
   placeOrder: placeOrderFn;
@@ -327,7 +324,7 @@ export function StockTicker(props: IProps): React.ReactElement {
             <StockTickerTxButton onClick={handleSellAllButtonClick} text={"Sell ALL"} />
           </Box>
           <StockTickerPositionText p={props.p} stock={props.stock} />
-          <StockTickerOrderList cancelOrder={props.cancelOrder} orders={props.orders} p={props.p} stock={props.stock} />
+          <StockTickerOrderList orders={props.orders} p={props.p} stock={props.stock} />
 
           <PlaceOrderModal
             text={modalProps.text}

--- a/src/StockMarket/ui/StockTicker.tsx
+++ b/src/StockMarket/ui/StockTicker.tsx
@@ -32,7 +32,7 @@ import Collapse from "@mui/material/Collapse";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import ExpandLess from "@mui/icons-material/ExpandLess";
 import { ICancelOrderParams } from "../StockMarket";
-import { WorkerScript } from "../../Netscript/WorkerScript";
+import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 enum SelectorOrderType {
   Market = "Market Order",
@@ -52,7 +52,7 @@ type placeOrderFn = (
 type IProps = {
   buyStockLong: txFn;
   buyStockShort: txFn;
-  cancelOrder: (params: ICancelOrderParams, workerScript?: WorkerScript) => void;
+  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   orders: Order[];
   p: IPlayer;
   placeOrder: placeOrderFn;

--- a/src/StockMarket/ui/StockTickerOrder.tsx
+++ b/src/StockMarket/ui/StockTickerOrder.tsx
@@ -12,10 +12,10 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import { ICancelOrderParams } from "../StockMarket";
-import { WorkerScript } from "../../Netscript/WorkerScript";
+import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 type IProps = {
-  cancelOrder: (params: ICancelOrderParams, workerScript?: WorkerScript) => void;
+  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   order: Order;
 };
 

--- a/src/StockMarket/ui/StockTickerOrder.tsx
+++ b/src/StockMarket/ui/StockTickerOrder.tsx
@@ -11,17 +11,15 @@ import { Money } from "../../ui/React/Money";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
-import { ICancelOrderParams } from "../StockMarket";
-import { NetscriptContext } from "../../Netscript/APIWrapper";
+import { cancelOrder } from "../StockMarket";
 
 type IProps = {
-  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   order: Order;
 };
 
 export function StockTickerOrder(props: IProps): React.ReactElement {
   function handleCancelOrderClick(): void {
-    props.cancelOrder({ order: props.order });
+    cancelOrder({ order: props.order });
   }
 
   const order = props.order;

--- a/src/StockMarket/ui/StockTickerOrderList.tsx
+++ b/src/StockMarket/ui/StockTickerOrderList.tsx
@@ -10,11 +10,8 @@ import { Order } from "../Order";
 import { Stock } from "../Stock";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
-import { ICancelOrderParams } from "../StockMarket";
-import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 type IProps = {
-  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   orders: Order[];
   p: IPlayer;
   stock: Stock;
@@ -24,7 +21,7 @@ export function StockTickerOrderList(props: IProps): React.ReactElement {
   const orders: React.ReactElement[] = [];
   for (let i = 0; i < props.orders.length; ++i) {
     const o = props.orders[i];
-    orders.push(<StockTickerOrder cancelOrder={props.cancelOrder} order={o} key={i} />);
+    orders.push(<StockTickerOrder order={o} key={i} />);
   }
 
   return <>{orders}</>;

--- a/src/StockMarket/ui/StockTickerOrderList.tsx
+++ b/src/StockMarket/ui/StockTickerOrderList.tsx
@@ -11,10 +11,10 @@ import { Stock } from "../Stock";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { ICancelOrderParams } from "../StockMarket";
-import { WorkerScript } from "../../Netscript/WorkerScript";
+import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 type IProps = {
-  cancelOrder: (params: ICancelOrderParams, workerScript?: WorkerScript) => void;
+  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   orders: Order[];
   p: IPlayer;
   stock: Stock;

--- a/src/StockMarket/ui/StockTickers.tsx
+++ b/src/StockMarket/ui/StockTickers.tsx
@@ -12,10 +12,8 @@ import { IStockMarket } from "../IStockMarket";
 import { Stock } from "../Stock";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
-import { EventEmitter } from "../../utils/EventEmitter";
 
 type IProps = {
-  eventEmitterForReset?: EventEmitter<[]>;
   p: IPlayer;
   stockMarket: IStockMarket;
 };

--- a/src/StockMarket/ui/StockTickers.tsx
+++ b/src/StockMarket/ui/StockTickers.tsx
@@ -15,8 +15,6 @@ import { PositionTypes } from "../data/PositionTypes";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { EventEmitter } from "../../utils/EventEmitter";
-import { ICancelOrderParams } from "../StockMarket";
-import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 type txFn = (stock: Stock, shares: number) => boolean;
 type placeOrderFn = (
@@ -30,7 +28,6 @@ type placeOrderFn = (
 type IProps = {
   buyStockLong: txFn;
   buyStockShort: txFn;
-  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   eventEmitterForReset?: EventEmitter<[]>;
   p: IPlayer;
   placeOrder: placeOrderFn;
@@ -92,7 +89,6 @@ export function StockTickers(props: IProps): React.ReactElement {
         <StockTicker
           buyStockLong={props.buyStockLong}
           buyStockShort={props.buyStockShort}
-          cancelOrder={props.cancelOrder}
           key={val.symbol}
           orders={orders}
           p={props.p}

--- a/src/StockMarket/ui/StockTickers.tsx
+++ b/src/StockMarket/ui/StockTickers.tsx
@@ -10,29 +10,13 @@ import { StockTickersConfig, TickerDisplayMode } from "./StockTickersConfig";
 
 import { IStockMarket } from "../IStockMarket";
 import { Stock } from "../Stock";
-import { OrderTypes } from "../data/OrderTypes";
-import { PositionTypes } from "../data/PositionTypes";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { EventEmitter } from "../../utils/EventEmitter";
 
-type txFn = (stock: Stock, shares: number) => boolean;
-type placeOrderFn = (
-  stock: Stock,
-  shares: number,
-  price: number,
-  ordType: OrderTypes,
-  posType: PositionTypes,
-) => boolean;
-
 type IProps = {
-  buyStockLong: txFn;
-  buyStockShort: txFn;
   eventEmitterForReset?: EventEmitter<[]>;
   p: IPlayer;
-  placeOrder: placeOrderFn;
-  sellStockLong: txFn;
-  sellStockShort: txFn;
   stockMarket: IStockMarket;
 };
 
@@ -86,18 +70,7 @@ export function StockTickers(props: IProps): React.ReactElement {
       }
 
       tickers.push(
-        <StockTicker
-          buyStockLong={props.buyStockLong}
-          buyStockShort={props.buyStockShort}
-          key={val.symbol}
-          orders={orders}
-          p={props.p}
-          placeOrder={props.placeOrder}
-          rerenderAllTickers={rerender}
-          sellStockLong={props.sellStockLong}
-          sellStockShort={props.sellStockShort}
-          stock={val}
-        />,
+        <StockTicker key={val.symbol} orders={orders} p={props.p} rerenderAllTickers={rerender} stock={val} />,
       );
     }
   }

--- a/src/StockMarket/ui/StockTickers.tsx
+++ b/src/StockMarket/ui/StockTickers.tsx
@@ -15,8 +15,8 @@ import { PositionTypes } from "../data/PositionTypes";
 
 import { IPlayer } from "../../PersonObjects/IPlayer";
 import { EventEmitter } from "../../utils/EventEmitter";
-import { WorkerScript } from "../../Netscript/WorkerScript";
 import { ICancelOrderParams } from "../StockMarket";
+import { NetscriptContext } from "../../Netscript/APIWrapper";
 
 type txFn = (stock: Stock, shares: number) => boolean;
 type placeOrderFn = (
@@ -30,7 +30,7 @@ type placeOrderFn = (
 type IProps = {
   buyStockLong: txFn;
   buyStockShort: txFn;
-  cancelOrder: (params: ICancelOrderParams, workerScript?: WorkerScript) => void;
+  cancelOrder: (params: ICancelOrderParams, ctx?: NetscriptContext) => void;
   eventEmitterForReset?: EventEmitter<[]>;
   p: IPlayer;
   placeOrder: placeOrderFn;

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -17,8 +17,7 @@ import { prestigeAugmentation } from "../Prestige";
 import { dialogBoxCreate } from "./React/DialogBox";
 import { GetAllServers } from "../Server/AllServers";
 import { Factions } from "../Faction/Factions";
-import { buyStock, sellStock, shortStock, sellShort } from "../StockMarket/BuyingAndSelling";
-import { eventEmitterForUiReset, initStockMarketFn, placeOrder, StockMarket } from "../StockMarket/StockMarket";
+import { eventEmitterForUiReset, initStockMarketFn, StockMarket } from "../StockMarket/StockMarket";
 
 import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
@@ -438,14 +437,9 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     case Page.StockMarket: {
       mainPage = (
         <StockMarketRoot
-          buyStockLong={buyStock}
-          buyStockShort={shortStock}
           eventEmitterForReset={eventEmitterForUiReset}
           initStockMarket={initStockMarketFn}
           p={player}
-          placeOrder={placeOrder}
-          sellStockLong={sellStock}
-          sellStockShort={sellShort}
           stockMarket={StockMarket}
         />
       );

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -18,13 +18,7 @@ import { dialogBoxCreate } from "./React/DialogBox";
 import { GetAllServers } from "../Server/AllServers";
 import { Factions } from "../Faction/Factions";
 import { buyStock, sellStock, shortStock, sellShort } from "../StockMarket/BuyingAndSelling";
-import {
-  cancelOrder,
-  eventEmitterForUiReset,
-  initStockMarketFn,
-  placeOrder,
-  StockMarket,
-} from "../StockMarket/StockMarket";
+import { eventEmitterForUiReset, initStockMarketFn, placeOrder, StockMarket } from "../StockMarket/StockMarket";
 
 import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
@@ -446,7 +440,6 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
         <StockMarketRoot
           buyStockLong={buyStock}
           buyStockShort={shortStock}
-          cancelOrder={cancelOrder}
           eventEmitterForReset={eventEmitterForUiReset}
           initStockMarket={initStockMarketFn}
           p={player}

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -17,7 +17,7 @@ import { prestigeAugmentation } from "../Prestige";
 import { dialogBoxCreate } from "./React/DialogBox";
 import { GetAllServers } from "../Server/AllServers";
 import { Factions } from "../Faction/Factions";
-import { initStockMarketFn, StockMarket } from "../StockMarket/StockMarket";
+import { StockMarket } from "../StockMarket/StockMarket";
 
 import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
@@ -437,7 +437,6 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     case Page.StockMarket: {
       mainPage = (
         <StockMarketRoot
-          initStockMarket={initStockMarketFn}
           p={player}
           stockMarket={StockMarket}
         />

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -17,7 +17,7 @@ import { prestigeAugmentation } from "../Prestige";
 import { dialogBoxCreate } from "./React/DialogBox";
 import { GetAllServers } from "../Server/AllServers";
 import { Factions } from "../Faction/Factions";
-import { eventEmitterForUiReset, initStockMarketFn, StockMarket } from "../StockMarket/StockMarket";
+import { initStockMarketFn, StockMarket } from "../StockMarket/StockMarket";
 
 import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
@@ -437,7 +437,6 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     case Page.StockMarket: {
       mainPage = (
         <StockMarketRoot
-          eventEmitterForReset={eventEmitterForUiReset}
           initStockMarket={initStockMarketFn}
           p={player}
           stockMarket={StockMarket}

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -435,12 +435,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.StockMarket: {
-      mainPage = (
-        <StockMarketRoot
-          p={player}
-          stockMarket={StockMarket}
-        />
-      );
+      mainPage = <StockMarketRoot p={player} stockMarket={StockMarket} />;
       break;
     }
     case Page.City: {


### PR DESCRIPTION
Reworked stock API functions to use `helpers.log` for logging to workerScript, so that function names do not need to be hardcoded and to match the base ns API.

Also UI: Streamline unnecessary prop passing in StockMarket react component structure

Addresses the same issue / can close #3999 