### PR TITLE
DOCS: Correct documentation for `run()` with 0 threads.

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5178,8 +5178,7 @@ export interface NS {
    * PID stands for Process ID. The PID is a unique identifier for each script.
    * The PID will always be a positive integer.
    *
-   * Running this function with a numThreads argument of 0 will return 0 without running the script.
-   * However, running this function with a negative numThreads argument will cause a runtime error.
+   * Running this function with a numThreads argument of 0 or less will cause a runtime error.
    *
    * @example
    * ```ts
@@ -5226,7 +5225,7 @@ export interface NS {
    * PID stands for Process ID. The PID is a unique identifier for each script.
    * The PID will always be a positive integer.
    *
-   * Running this function with 0 or a negative numThreads argument will cause a runtime error.
+   * Running this function with a numThreads argument of 0 or less will cause a runtime error.
    *
    * @example
    * ```ts
@@ -5271,6 +5270,8 @@ export interface NS {
    * on the local server.
    *
    * Because this function immediately terminates the script, it does not have a return value.
+   *
+   * Running this function with a numThreads argument of 0 or less will cause a runtime error.
    *
    * @example
    * ```ts


### PR DESCRIPTION
For consistency, the same phrasing has been applied to the documentation for `exec()` and `spawn()`.