### PR TITLE
API: All the player sub-objects need to be copied for `getPlayer`.

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1911,10 +1911,9 @@ const base: InternalAPI<NS> = {
   },
   getPlayer: () => (): INetscriptPlayer => {
     const data = {
-      hp: Player.hp,
-      skills: Player.skills,
-      exp: Player.exp,
-      hacking_chance_mult: Player.mults.hacking_chance,
+      hp: JSON.parse(JSON.stringify(Player.hp)),
+      skills: JSON.parse(JSON.stringify(Player.skills)),
+      exp: JSON.parse(JSON.stringify(Player.exp)),
       mults: JSON.parse(JSON.stringify(Player.mults)),
       numPeopleKilled: Player.numPeopleKilled,
       money: Player.money,


### PR DESCRIPTION
Not just `mults`. Also, `hacking_chance_mult` still being at the base level appears to be a mistake.