### PR TITLE
NETSCRIPT: Update netscript definition file for scp, write, read, and flags

### DIFF
--- a/src/NetscriptFunctions/Flags.ts
+++ b/src/NetscriptFunctions/Flags.ts
@@ -4,7 +4,7 @@ import { ScriptArg } from "../Netscript/ScriptArg";
 import { NetscriptContext } from "../Netscript/APIWrapper";
 
 type FlagType = StringConstructor | NumberConstructor | BooleanConstructor | StringConstructor[];
-type FlagsRet = { [key: string]: ScriptArg };
+type FlagsRet = { [key: string]: ScriptArg | string[] };
 export function Flags(ctx: NetscriptContext | string[]): (data: unknown) => FlagsRet {
   const vargs = Array.isArray(ctx) ? ctx : ctx.workerScript.args;
   return (schema: unknown): FlagsRet => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6014,7 +6014,7 @@ export interface NS {
    * @param handle - Filename to read from.
    * @returns Data in the specified text file.
    */
-  read(handle: string): PortData;
+  read(handle: string);
 
   /**
    * Get a copy of the data from a port without popping it.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7358,5 +7358,5 @@ interface AutocompleteData {
   servers: string[];
   scripts: string[];
   txts: string[];
-  flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg };
+  flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg | string[] };
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5980,11 +5980,11 @@ export interface NS {
    * then the data will be written in “append” mode which means that the data will be added at the
    * end of the file.
    *
-   * @param handle - Filename to be written to.
+   * @param filename - Name of the file to be written to.
    * @param data - Data to write.
    * @param mode - Defines the write mode.
    */
-  write(handle: string, data?: string[] | number | string, mode?: "w" | "a"): void;
+  write(filename: string, data?: string[] | number | string, mode?: "w" | "a"): void;
 
   /**
    * Attempt to write to a port.
@@ -6006,15 +6006,15 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * This function is used to read data from a text file (.txt).
+   * This function is used to read data from a text file (.txt) or script (.script, .js).
    *
-   * This function will return the data in the specified text
-   * file. If the text file does not exist, an empty string will be returned.
+   * This function will return the data in the specified file.
+   * If the file does not exist, an empty string will be returned.
    *
-   * @param handle - Filename to read from.
+   * @param filename - Name of the file to be read.
    * @returns Data in the specified text file.
    */
-  read(handle: string);
+  read(filename: string): string;
 
   /**
    * Get a copy of the data from a port without popping it.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6531,7 +6531,7 @@ export interface NS {
    * // {"_":[],"delay":0,"server":"foodnstuff","exclude":[],"help":true}
    * ```
    */
-  flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg };
+  flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg | string[] };
 
   /**
    * Share your computer with your factions.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5413,25 +5413,25 @@ export interface NS {
    * ```ts
    * // NS2:
    * //Copies foo.lit from the helios server to the home computer:
-   * await ns.scp("foo.lit", "home", "helios" );
+   * ns.scp("foo.lit", "home", "helios" );
    *
    * //Tries to copy three files from rothman-uni to home computer:
    * files = ["foo1.lit", "foo2.script", "foo3.script"];
-   * await ns.scp(files,  "home", "rothman-uni");
+   * ns.scp(files,  "home", "rothman-uni");
    * ```
    * @example
    * ```ts
    * //ns2, copies files from home to a target server
    * const server = ns.args[0];
    * const files = ["hack.js","weaken.js","grow.js"];
-   * await ns.scp(files, server, "home");
+   * ns.scp(files, server, "home");
    * ```
    * @param files - Filename or an array of filenames of script/literature files to copy.
-   * @param source - Host of the source server, which is the server from which the file will be copied. This argument is optional and if it’s omitted the source will be the current server.
    * @param destination - Host of the destination server, which is the server to which the file will be copied.
-   * @returns True if the script/literature file is successfully copied over and false otherwise. If the files argument is an array then this function will return true if at least one of the files in the array is successfully copied.
+   * @param source - Host of the source server, which is the server from which the file will be copied. This argument is optional and if it’s omitted the source will be the current server.
+   * @returns True if the file is successfully copied over and false otherwise. If the files argument is an array then this function will return false if any of the operations failed.
    */
-  scp(files: string | string[], destination: string, source?: string): Promise<boolean>;
+  scp(files: string | string[], destination: string, source?: string): boolean;
 
   /**
    * List files on a server.
@@ -5971,20 +5971,20 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * This function can be used to write data to a text file (.txt).
+   * This function can be used to write data to a text file (.txt) or a script (.js or .script).
    *
-   * This function will write data to that text file. If the specified text file does not exist,
+   * This function will write data to that file. If the specified file does not exist,
    * then it will be created. The third argument mode, defines how the data will be written to
-   * the text file. If *mode is set to “w”, then the data is written in “write” mode which means
-   * that it will overwrite all existing data on the text file. If mode is set to any other value
+   * the file. If *mode is set to “w”, then the data is written in “write” mode which means
+   * that it will overwrite all existing data on the file. If mode is set to any other value
    * then the data will be written in “append” mode which means that the data will be added at the
-   * end of the text file.
+   * end of the file.
    *
-   * @param handle - Filename of the text file that will be written to.
+   * @param handle - Filename to be written to.
    * @param data - Data to write.
-   * @param mode - Defines the write mode. Only valid when writing to text files.
+   * @param mode - Defines the write mode.
    */
-  write(handle: string, data?: string[] | number | string, mode?: "w" | "a"): Promise<void>;
+  write(handle: string, data?: string[] | number | string, mode?: "w" | "a"): void;
 
   /**
    * Attempt to write to a port.


### PR DESCRIPTION
An earlier PR made write and scp into synchronous functions, but I hadn't updated NetscriptDefinitions.d.ts to reflect the changes.

A couple small fixes also added:
1. Add an error message if ns.write is used with a filename that is not a valid script name and also isn't .txt. Previously it was just adding .txt to the end of whatever was provided, e.g. `ns.write("testfile.text", content)` would lead to a file named `testfile.text.txt`
2. Renamed the first parameter for `write` to match documentation.
3. Only one string typecheck is done for the filename in write. Previously, this was being typechecked with helpers.string and then again with a separate if statement.
4. (added 8/24) Combined @mycroftjr PR #4031  into this one. Also made the same changes on number 2 and 3 above to ns.read as well. Now fixes #4030.
5. Added fix for flags as well, fixes #4034 

The diff files make it look like I totally rewrote ns.read and ns.write. All I did was take out the top-level if statement that was not necessary (since the same check/throw for nonstrings is performed in helpers.string).