### PR TITLE
Coding Contracts: Don't stringify answer if already a string

### DIFF
--- a/src/NetscriptFunctions/CodingContract.ts
+++ b/src/NetscriptFunctions/CodingContract.ts
@@ -37,7 +37,7 @@ export function NetscriptCodingContract(): InternalAPI<ICodingContract> {
           throw new Error("The answer provided was not a number, string, or array");
 
         // Convert answer to string.
-        const answerStr = JSON.stringify(answer);
+        const answerStr = typeof answer === 'string' ? answer : JSON.stringify(answer);
         const creward = contract.reward;
         if (creward === null) throw new Error("Somehow solved a contract that didn't have a reward");
 


### PR DESCRIPTION
Was doing this:
![image](https://user-images.githubusercontent.com/2285037/186440556-70a6793e-a20e-43a6-b9ff-1800b9a6c036.png)

Fix:
![image](https://user-images.githubusercontent.com/2285037/186441195-3a4ad78a-d320-48b6-9177-34c9a4e8881a.png)
