### PR TITLE
GANG: Added weight to GangMemberTask construction call

### DIFF
--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -554,7 +554,7 @@ function gangMember(ctx: NetscriptContext, m: unknown): GangMember {
 }
 
 function gangTask(ctx: NetscriptContext, t: unknown): GangMemberTask {
-  if (!roughlyIs(new GangMemberTask("", "", false, false, {}), t))
+  if (!roughlyIs(new GangMemberTask("", "", false, false, { hackWeight: 100 }), t))
     throw makeRuntimeErrorMsg(ctx, `task should be a GangMemberTask.`);
   return t as GangMemberTask;
 }


### PR DESCRIPTION
Added hackWeight: 100 to GangMember Task construction call to prevent error messages from the constructor checks. 
Since we only compare with roughlyIs() this will have no impact on functionality
