### PR TITLE
RFA: Fix type of RFAMessages with non-String results

### DIFF
--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -1,14 +1,12 @@
 export class RFAMessage {
   jsonrpc = "2.0"; // Transmits version of JSON-RPC. Compliance maybe allows some funky interaction with external tools?
   public method?: string; // Is defined when it's a request/notification, otherwise undefined
-  public result?: string | Array<string> | number; // Is defined when it's a response, otherwise undefined
+  public result?: ResultType; // Is defined when it's a response, otherwise undefined
   public params?: FileMetadata; // Optional parameters to method
   public error?: string; // Only defined on error
   public id?: number; // ID to keep track of request -> response interaction, undefined with notifications, defined with request/response
 
-  constructor(
-    obj: { method?: string; result?: string | Array<string> | number; params?: FileMetadata; error?: string; id?: number } = {},
-  ) {
+  constructor(obj: { method?: string; result?: ResultType; params?: FileMetadata; error?: string; id?: number } = {}) {
     this.method = obj.method;
     this.result = obj.result;
     this.params = obj.params;
@@ -17,6 +15,7 @@ export class RFAMessage {
   }
 }
 
+type ResultType = string | number | Array<string> | Array<FileContent>;
 type FileMetadata = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -1,13 +1,13 @@
 export class RFAMessage {
   jsonrpc = "2.0"; // Transmits version of JSON-RPC. Compliance maybe allows some funky interaction with external tools?
   public method?: string; // Is defined when it's a request/notification, otherwise undefined
-  public result?: string | number; // Is defined when it's a response, otherwise undefined
+  public result?: string | Array<string> | number; // Is defined when it's a response, otherwise undefined
   public params?: FileMetadata; // Optional parameters to method
   public error?: string; // Only defined on error
   public id?: number; // ID to keep track of request -> response interaction, undefined with notifications, defined with request/response
 
   constructor(
-    obj: { method?: string; result?: string | number; params?: FileMetadata; error?: string; id?: number } = {},
+    obj: { method?: string; result?: string | Array<string> | number; params?: FileMetadata; error?: string; id?: number } = {},
   ) {
     this.method = obj.method;
     this.result = obj.result;

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -93,7 +93,7 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => void | R
       ...server.scripts.map((scr): string => scr.filename),
     ];
 
-    return new RFAMessage({ result: JSON.stringify(fileNameList), id: msg.id });
+    return new RFAMessage({ result: fileNameList, id: msg.id });
   },
 
   getAllFiles: function (msg: RFAMessage): RFAMessage {
@@ -111,7 +111,7 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => void | R
       }),
     ];
 
-    return new RFAMessage({ result: JSON.stringify(fileList), id: msg.id });
+    return new RFAMessage({ result: fileList, id: msg.id });
   },
 
   calculateRam: function (msg: RFAMessage): RFAMessage {


### PR DESCRIPTION
non-String result values were incorrectly parsed as JSON twice, instead of being their originally intended types.
This pull fixes that.