### PR TITLE
NETSCRIPT: FIX #3963 Prevent bladeburner.setActionLevel from setting invalid action levels

### DIFF
--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -250,7 +250,7 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
         checkBladeburnerAccess(ctx);
         const action = getBladeburnerActionObject(ctx, type, name);
         if (level < 1 || level > action.maxLevel) {
-          helpers.makeRuntimeErrorMsg(ctx, `Level must be between 1 and ${action.maxLevel}, is ${level}`);
+          throw helpers.makeRuntimeErrorMsg(ctx, `Level must be between 1 and ${action.maxLevel}, is ${level}`);
         }
         action.level = level;
       },


### PR DESCRIPTION
closes #3963

Adds a previously missing `throw` to allow `bladeburner.setActionLevel()` to properly produce errors and prevent invalid action levels from being set.

Bug was thoroughly tested with screenshot proof. See the mentioned issue for details. I am not set up to test this fix in-game, so please forgive me if I end up wasting anyone's time with this pull request.