### PR TITLE
NETSCRIPT: FIX #4037 ns1 wraps deeper layers correctly.

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -95,11 +95,6 @@ export class WorkerScript {
   ramUsage = 0;
 
   /**
-   * Whether or not this workerScript is currently running
-   */
-  running = false;
-
-  /**
    * Reference to underlying RunningScript object
    */
   scriptRef: RunningScript;

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -745,7 +745,6 @@ const base: InternalAPI<NS> = {
 
       helpers.log(ctx, () => `Will execute '${scriptname}' in ${spawnDelay} seconds`);
 
-      ctx.workerScript.running = false; // Prevent workerScript from "finishing execution naturally"
       if (killWorkerScript(ctx.workerScript)) {
         helpers.log(ctx, () => "Exiting...");
       }
@@ -820,7 +819,6 @@ const base: InternalAPI<NS> = {
       return scriptsKilled > 0;
     },
   exit: (ctx: NetscriptContext) => (): void => {
-    ctx.workerScript.running = false; // Prevent workerScript from "finishing execution naturally"
     if (killWorkerScript(ctx.workerScript)) {
       helpers.log(ctx, () => "Exiting...");
     } else {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -702,7 +702,7 @@ const base: InternalAPI<NS> = {
         throw helpers.makeRuntimeErrorMsg(ctx, "Could not find server. This is a bug. Report to dev.");
       }
 
-      return runScriptFromScript(Player, "run", scriptServer, scriptname, args, ctx.workerScript, threads);
+      return runScriptFromScript("run", scriptServer, scriptname, args, ctx.workerScript, threads);
     },
   exec:
     (ctx: NetscriptContext) =>
@@ -718,7 +718,7 @@ const base: InternalAPI<NS> = {
         throw helpers.makeRuntimeErrorMsg(ctx, `Invalid thread count. Must be numeric and > 0, is ${threads}`);
       }
       const server = helpers.getServer(ctx, hostname);
-      return runScriptFromScript(Player, "exec", server, scriptname, args, ctx.workerScript, threads);
+      return runScriptFromScript("exec", server, scriptname, args, ctx.workerScript, threads);
     },
   spawn:
     (ctx: NetscriptContext) =>
@@ -740,7 +740,7 @@ const base: InternalAPI<NS> = {
           throw helpers.makeRuntimeErrorMsg(ctx, "Could not find server. This is a bug. Report to dev");
         }
 
-        return runScriptFromScript(Player, "spawn", scriptServer, scriptname, args, ctx.workerScript, threads);
+        return runScriptFromScript("spawn", scriptServer, scriptname, args, ctx.workerScript, threads);
       }, spawnDelay * 1e3);
 
       helpers.log(ctx, () => `Will execute '${scriptname}' in ${spawnDelay} seconds`);

--- a/src/NetscriptFunctions/CodingContract.ts
+++ b/src/NetscriptFunctions/CodingContract.ts
@@ -37,7 +37,7 @@ export function NetscriptCodingContract(): InternalAPI<ICodingContract> {
           throw new Error("The answer provided was not a number, string, or array");
 
         // Convert answer to string.
-        const answerStr = typeof answer === 'string' ? answer : JSON.stringify(answer);
+        const answerStr = typeof answer === "string" ? answer : JSON.stringify(answer);
         const creward = contract.reward;
         if (creward === null) throw new Error("Somehow solved a contract that didn't have a reward");
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -92,7 +92,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         }
         const runningScriptObj = new RunningScript(script, []); // No args
         runningScriptObj.threads = 1; // Only 1 thread
-        startWorkerScript(player, runningScriptObj, home);
+        startWorkerScript(runningScriptObj, home);
       }
     }
   };

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -235,8 +235,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           runAfterReset(cbScript);
         }, 0);
 
-        // Prevent ctx.workerScript from "finishing execution naturally"
-        ctx.workerScript.running = false;
         killWorkerScript(ctx.workerScript);
       },
     installAugmentations: (ctx: NetscriptContext) =>
@@ -255,7 +253,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           runAfterReset(cbScript);
         }, 0);
 
-        ctx.workerScript.running = false; // Prevent ctx.workerScript from "finishing execution naturally"
         killWorkerScript(ctx.workerScript);
         return true;
       },

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -76,7 +76,7 @@ export function runScript(
     const runningScript = new RunningScript(script, args);
     runningScript.threads = numThreads;
 
-    const success = startWorkerScript(player, runningScript, server);
+    const success = startWorkerScript(runningScript, server);
     if (!success) {
       terminal.error(`Failed to start script`);
       return;

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -278,7 +278,7 @@ const Engine: {
       Player.gainMoney(offlineHackingIncome, "hacking");
       // Process offline progress
 
-      loadAllRunningScripts(Player); // This also takes care of offline production for those scripts
+      loadAllRunningScripts(); // This also takes care of offline production for those scripts
 
       if (Player.currentWork !== null) {
         Player.focus = true;

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -15,7 +15,6 @@ import { workerScripts } from "../../Netscript/WorkerScripts";
 import { startWorkerScript } from "../../NetscriptWorker";
 import { GetServer } from "../../Server/AllServers";
 import { findRunningScript } from "../../Script/ScriptHelpers";
-import { Player } from "../../Player";
 import { debounce } from "lodash";
 import { Settings } from "../../Settings/Settings";
 import { ANSIITypography } from "./ANSIITypography";

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -159,7 +159,7 @@ function LogWindow(props: IProps): React.ReactElement {
     if (server === null) return;
     const s = findRunningScript(script.filename, script.args, server);
     if (s === null) {
-      startWorkerScript(Player, script, server);
+      startWorkerScript(script, server);
     } else {
       setScript(s);
     }


### PR DESCRIPTION
Fixes #4037 
Bulk of the changes are in NetscriptWorker.ts, the separate function wrappers were unified and hardcoded category lists were removed. Modifications have also been made so that deeper layers of the ns object are actually wrapped using a custom wrapper, allowing async functions to continue to work.

Still needs more testing, since I don't have a lot of ns1 scripts to test with. But based on console.logging the scope object and some basic testing already performed, both synchronous and asynchronous functions seem to be working properly now no matter where they are in the ns object tree.

Changes in other files are due to function parameter changes. I noticed a difference in parameters between startNetscript1Script and startNetscript2Script. startNetscript2Script was taking in player as a parameter, even though Player was already imported in the file NetscriptWorker.ts (unnecessary parameter).
  * Removed player as a parameter for startNetscript2Script, just used Player directly.
  * This also removed player as a needed parameter at createAndAddWorkerScript
  * This removed the need for player as a parameter at loadAllRunningScripts and startWorkerScript
  * etc. and these parameter changes cascade out to some other files.

In general I think sending player down a long parameter chain doesn't make sense when it can just be imported directly where it's actually used. It's actually not needed in NetscriptWorker either, but removing it entirely from NetscriptWorker would have modified a lot more files so I kept the changes more minimal since that's not the focus of this PR. I'll do a separate PR that focuses more directly on removing inefficient passing of variables /  props on a broader scale.