### PR TITLE
NETSCRIPT: Unify internal error handling code

### DIFF
--- a/src/Augmentation/AugmentationHelpers.tsx
+++ b/src/Augmentation/AugmentationHelpers.tsx
@@ -126,15 +126,15 @@ function installAugmentations(force?: boolean): boolean {
     if (ownedAug.name === AugmentationNames.NeuroFluxGovernor) {
       level = ` - ${ownedAug.level}`;
     }
-    augmentationList += aug.name + level + "<br>";
+    augmentationList += aug.name + level + "\n";
   }
   Player.queuedAugmentations = [];
   if (!force) {
     dialogBoxCreate(
       "You slowly drift to sleep as scientists put you under in order " +
-        "to install the following Augmentations:<br>" +
+        "to install the following Augmentations:\n" +
         augmentationList +
-        "<br>You wake up in your home...you feel different...",
+        "\nYou wake up in your home...you feel different...",
     );
   }
   prestigeAugmentation();

--- a/src/Casino/Game.tsx
+++ b/src/Casino/Game.tsx
@@ -11,7 +11,7 @@ export function win(p: IPlayer, n: number): void {
 export function reachedLimit(p: IPlayer): boolean {
   const reached = p.getCasinoWinnings() > gainLimit;
   if (reached) {
-    dialogBoxCreate(<>Alright cheater get out of here. You're not allowed here anymore.</>);
+    dialogBoxCreate("Alright cheater get out of here. You're not allowed here anymore.");
   }
   return reached;
 }
@@ -24,7 +24,7 @@ export class Game<T, U> extends React.Component<T, U> {
   reachedLimit(p: IPlayer): boolean {
     const reached = p.getCasinoWinnings() > gainLimit;
     if (reached) {
-      dialogBoxCreate(<>Alright cheater get out of here. You're not allowed here anymore.</>);
+      dialogBoxCreate("Alright cheater get out of here. You're not allowed here anymore.");
     }
     return reached;
   }

--- a/src/Corporation/Corporation.tsx
+++ b/src/Corporation/Corporation.tsx
@@ -116,7 +116,7 @@ export class Corporation {
         if (isNaN(this.funds) || this.funds === Infinity || this.funds === -Infinity) {
           dialogBoxCreate(
             "There was an error calculating your Corporations funds and they got reset to 0. " +
-              "This is a bug. Please report to game developer.<br><br>" +
+              "This is a bug. Please report to game developer.\n\n" +
               "(Your funds have been set to $150b for the inconvenience)",
           );
           this.funds = 150e9;

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -843,14 +843,7 @@ export class Industry implements IIndustry {
                     sellAmt = eval(tmp);
                   } catch (e) {
                     dialogBoxCreate(
-                      "Error evaluating your sell amount for material " +
-                        mat.name +
-                        " in " +
-                        this.name +
-                        "'s " +
-                        city +
-                        " office. The sell amount " +
-                        "is being set to zero",
+                      `Error evaluating your sell amount for material ${mat.name} in ${this.name}'s ${city} office. The sell amount is being set to zero`,
                     );
                     sellAmt = 0;
                   }
@@ -897,27 +890,13 @@ export class Industry implements IIndustry {
                     amt = eval(amtStr);
                   } catch (e) {
                     dialogBoxCreate(
-                      "Calculating export for " +
-                        mat.name +
-                        " in " +
-                        this.name +
-                        "'s " +
-                        city +
-                        " division failed with " +
-                        "error: " +
-                        e,
+                      `Calculating export for ${mat.name} in ${this.name}'s ${city} division failed with error: ${e}`,
                     );
                     continue;
                   }
                   if (isNaN(amt)) {
                     dialogBoxCreate(
-                      "Error calculating export amount for " +
-                        mat.name +
-                        " in " +
-                        this.name +
-                        "'s " +
-                        city +
-                        " division.",
+                      `Error calculating export amount for ${mat.name} in ${this.name}'s ${city} division.`,
                     );
                     continue;
                   }
@@ -1190,13 +1169,7 @@ export class Industry implements IIndustry {
                 tmp = eval(tmp);
               } catch (e) {
                 dialogBoxCreate(
-                  "Error evaluating your sell price expression for " +
-                    product.name +
-                    " in " +
-                    this.name +
-                    "'s " +
-                    city +
-                    " office. Sell price is being set to MAX",
+                  `Error evaluating your sell price expression for ${product.name} in ${this.name}'s ${city} office. Sell price is being set to MAX`,
                 );
                 tmp = product.maxsll;
               }

--- a/src/Corporation/ui/modals/BribeFactionModal.tsx
+++ b/src/Corporation/ui/modals/BribeFactionModal.tsx
@@ -60,9 +60,7 @@ export function BribeFactionModal(props: IProps): React.ReactElement {
     const fac = Factions[selectedFaction];
     if (disabled) return;
     const rep = repGain(money);
-    dialogBoxCreate(
-      "You gained " + numeralWrapper.formatReputation(rep) + " reputation with " + fac.name + " by bribing them.",
-    );
+    dialogBoxCreate(`You gained ${numeralWrapper.formatReputation(rep)} reputation with ${fac.name} by bribing them.`);
     fac.playerReputation += rep;
     corp.funds = corp.funds - money;
     props.onClose();

--- a/src/Corporation/ui/modals/IssueNewSharesModal.tsx
+++ b/src/Corporation/ui/modals/IssueNewSharesModal.tsx
@@ -89,14 +89,11 @@ export function IssueNewSharesModal(props: IProps): React.ReactElement {
 
     let dialogContents =
       `Issued ${numeralWrapper.format(newShares, "0.000a")} new shares` +
-      ` and raised ${numeralWrapper.formatMoney(profit)}.`;
-    if (privateShares > 0) {
-      dialogContents += `<br>${numeralWrapper.format(
-        privateShares,
-        "0.000a",
-      )} of these shares were bought by private investors.`;
-    }
-    dialogContents += `<br><br>Stock price decreased to ${numeralWrapper.formatMoney(corp.sharePrice)}`;
+      ` and raised ${numeralWrapper.formatMoney(profit)}.` +
+      (privateShares > 0)
+        ? "\n" + numeralWrapper.format(privateShares, "0.000a") + "of these shares were bought by private investors."
+        : "";
+    dialogContents += `\n\nStock price decreased to ${numeralWrapper.formatMoney(corp.sharePrice)}`;
     dialogBoxCreate(dialogContents);
   }
 

--- a/src/Corporation/ui/modals/ResearchModal.tsx
+++ b/src/Corporation/ui/modals/ResearchModal.tsx
@@ -42,9 +42,7 @@ function Upgrade({ n, division }: INodeProps): React.ReactElement {
     }
 
     dialogBoxCreate(
-      `Researched ${n.text}. It may take a market cycle ` +
-        `(~${CorporationConstants.SecsPerMarketCycle} seconds) before the effects of ` +
-        `the Research apply.`,
+      `Researched ${n.text}. It may take a market cycle (~${CorporationConstants.SecsPerMarketCycle} seconds) before the effects of the Research apply.`,
     );
   }
 

--- a/src/Corporation/ui/modals/ThrowPartyModal.tsx
+++ b/src/Corporation/ui/modals/ThrowPartyModal.tsx
@@ -41,8 +41,7 @@ export function ThrowPartyModal(props: IProps): React.ReactElement {
 
       if (mult > 0) {
         dialogBoxCreate(
-          "You threw a party for the office! The morale and happiness " +
-            "of each employee increased by " +
+          "You threw a party for the office! The morale and happiness of each employee increased by " +
             numeralWrapper.formatPercentage(mult - 1),
         );
       }

--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -106,7 +106,7 @@ function initWebserver(): void {
         msg: "Home server does not exist.",
       };
     }
-    const { success, overwritten } = home.writeToScriptFile(Player, filename, code);
+    const { success, overwritten } = home.writeToScriptFile(filename, code);
     let script;
     if (success) {
       script = home.getScript(filename);

--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -94,12 +94,9 @@ export function purchaseAugmentation(aug: Augmentation, fac: Faction, sing = fal
       return "You purchased " + aug.name;
     } else if (!Settings.SuppressBuyAugmentationConfirmation) {
       dialogBoxCreate(
-        "You purchased " +
-          aug.name +
-          ". Its enhancements will not take " +
-          "effect until they are installed. To install your augmentations, go to the " +
-          "'Augmentations' tab on the left-hand navigation menu. Purchasing additional " +
-          "augmentations will now be more expensive.",
+        `You purchased ${aug.name}. Its enhancements will not take effect until they are installed.` +
+          "To install your augmentations, go to the 'Augmentations' tab on the left-hand navigation menu." +
+          "Purchasing additional augmentations will now be more expensive.",
       );
     }
   } else {

--- a/src/Hacknet/HacknetServer.ts
+++ b/src/Hacknet/HacknetServer.ts
@@ -19,7 +19,7 @@ import {
 import { createRandomIp } from "../utils/IPAddress";
 
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, Reviver } from "../utils/JSONReviver";
-import { IPlayer } from "../PersonObjects/IPlayer";
+import { Player } from "../Player";
 
 interface IConstructorParams {
   adminRights?: boolean;
@@ -123,9 +123,9 @@ export class HacknetServer extends BaseServer implements IHacknetNode {
     }
   }
 
-  updateRamUsed(ram: number, player: IPlayer): void {
-    super.updateRamUsed(ram, player);
-    this.updateHashRate(player.mults.hacknet_node_money);
+  updateRamUsed(ram: number): void {
+    super.updateRamUsed(ram);
+    this.updateHashRate(Player.mults.hacknet_node_money);
   }
 
   updateHashCapacity(): void {

--- a/src/Literature/LiteratureHelpers.ts
+++ b/src/Literature/LiteratureHelpers.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { Literatures } from "./Literatures";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 

--- a/src/Literature/LiteratureHelpers.tsx
+++ b/src/Literature/LiteratureHelpers.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Literatures } from "./Literatures";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 
@@ -7,5 +8,5 @@ export function showLiterature(fn: string): void {
     return;
   }
   const txt = `<i>${litObj.title}</i><br><br>${litObj.txt}`;
-  dialogBoxCreate(txt);
+  dialogBoxCreate(txt, true);
 }

--- a/src/Locations/LocationsHelpers.tsx
+++ b/src/Locations/LocationsHelpers.tsx
@@ -33,8 +33,8 @@ export function purchaseTorRouter(p: IPlayer): void {
   p.getHomeComputer().serversOnNetwork.push(darkweb.hostname);
   darkweb.serversOnNetwork.push(p.getHomeComputer().hostname);
   dialogBoxCreate(
-    "You have purchased a TOR router!<br>" +
-      "You now have access to the dark web from your home computer.<br>" +
+    "You have purchased a TOR router!\n" +
+      "You now have access to the dark web from your home computer.\n" +
       "Use the scan/scan-analyze commands to search for the dark web connection.",
   );
 }

--- a/src/Locations/ui/TravelAgencyRoot.tsx
+++ b/src/Locations/ui/TravelAgencyRoot.tsx
@@ -35,7 +35,7 @@ function travel(p: IPlayer, router: IRouter, to: CityName): void {
 
   p.loseMoney(cost, "other");
   p.travel(to);
-  dialogBoxCreate(<>You are now in {to}!</>);
+  dialogBoxCreate(`You are now in ${to}!`);
   router.toCity();
 }
 

--- a/src/Message/MessageHelpers.tsx
+++ b/src/Message/MessageHelpers.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Message } from "./Message";
 import { AugmentationNames } from "../Augmentation/data/AugmentationNames";
 import { Router } from "../ui/GameRoot";
@@ -22,15 +23,12 @@ function sendMessage(msg: Message, forced = false): void {
 function showMessage(name: MessageFilenames): void {
   const msg = Messages[name];
   if (!(msg instanceof Message)) throw new Error("trying to display unexistent message");
-  const txt =
-    "Message received from unknown sender: <br><br>" +
-    "<i>" +
-    msg.msg +
-    "</i><br><br>" +
-    "This message was saved as " +
-    msg.filename +
-    " onto your home computer.";
-  dialogBoxCreate(txt);
+  dialogBoxCreate(
+    <>
+      Message received from unknown sender:<i>{msg.msg}</i>This message was saved as {msg.filename} onto your home
+      computer.
+    </>,
+  );
 }
 
 //Adds a message to a server
@@ -127,20 +125,20 @@ const Messages: Record<MessageFilenames, Message> = {
     MessageFilenames.Jumper0,
     "I know you can sense it. I know you're searching for it. " +
       "It's why you spend night after " +
-      "night at your computer. <br><br>It's real, I've seen it. And I can " +
-      "help you find it. But not right now. You're not ready yet.<br><br>" +
-      "Use this program to track your progress<br><br>" +
-      "The fl1ght.exe program was added to your home computer<br><br>" +
+      "night at your computer. \n\nIt's real, I've seen it. And I can " +
+      "help you find it. But not right now. You're not ready yet.\n\n" +
+      "Use this program to track your progress\n\n" +
+      "The fl1ght.exe program was added to your home computer\n\n" +
       "-jump3R",
   ),
 
   [MessageFilenames.Jumper1]: new Message(
     MessageFilenames.Jumper1,
     `Soon you will be contacted by a hacking group known as ${FactionNames.NiteSec}. ` +
-      "They can help you with your search. <br><br>" +
+      "They can help you with your search. \n\n" +
       "You should join them, garner their favor, and " +
       "exploit them for their Augmentations. But do not trust them. " +
-      "They are not what they seem. No one is.<br><br>" +
+      "They are not what they seem. No one is.\n\n" +
       "-jump3R",
   ),
 
@@ -148,21 +146,21 @@ const Messages: Record<MessageFilenames, Message> = {
     MessageFilenames.Jumper2,
     "Do not try to save the world. There is no world to save. If " +
       "you want to find the truth, worry only about yourself. Ethics and " +
-      `morals will get you killed. <br><br>Watch out for a hacking group known as ${FactionNames.NiteSec}.` +
-      "<br><br>-jump3R",
+      `morals will get you killed. \n\nWatch out for a hacking group known as ${FactionNames.NiteSec}.` +
+      "\n\n-jump3R",
   ),
 
   [MessageFilenames.Jumper3]: new Message(
     MessageFilenames.Jumper3,
     "You must learn to walk before you can run. And you must " +
-      `run before you can fly. Look for ${FactionNames.TheBlackHand}. <br><br>` +
-      "I.I.I.I <br><br>-jump3R",
+      `run before you can fly. Look for ${FactionNames.TheBlackHand}. \n\n` +
+      "I.I.I.I \n\n-jump3R",
   ),
 
   [MessageFilenames.Jumper4]: new Message(
     MessageFilenames.Jumper4,
     "To find what you are searching for, you must understand the bits. " +
-      "The bits are all around us. The runners will help you.<br><br>" +
+      "The bits are all around us. The runners will help you.\n\n" +
       "-jump3R",
   ),
 
@@ -171,8 +169,8 @@ const Messages: Record<MessageFilenames, Message> = {
     MessageFilenames.CyberSecTest,
     "We've been watching you. Your skills are very impressive. But you're wasting " +
       "your talents. If you join us, you can put your skills to good use and change " +
-      "the world for the better. If you join us, we can unlock your full potential. <br><br>" +
-      "But first, you must pass our test. Find and install the backdoor on our server. <br><br>" +
+      "the world for the better. If you join us, we can unlock your full potential. \n\n" +
+      "But first, you must pass our test. Find and install the backdoor on our server. \n\n" +
       `-${FactionNames.CyberSec}`,
   ),
 
@@ -181,17 +179,17 @@ const Messages: Record<MessageFilenames, Message> = {
     "People say that the corrupted governments and corporations rule the world. " +
       "Yes, maybe they do. But do you know who everyone really fears? People " +
       "like us. Because they can't hide from us. Because they can't fight shadows " +
-      "and ideas with bullets. <br><br>" +
-      "Join us, and people will fear you, too. <br><br>" +
+      "and ideas with bullets. \n\n" +
+      "Join us, and people will fear you, too. \n\n" +
       "Find and install the backdoor on our server, avmnite-02h. Then, we will contact you again." +
-      `<br><br>-${FactionNames.NiteSec}`,
+      `\n\n-${FactionNames.NiteSec}`,
   ),
 
   [MessageFilenames.BitRunnersTest]: new Message(
     MessageFilenames.BitRunnersTest,
     "We know what you are doing. We know what drives you. We know " +
-      "what you are looking for. <br><br> " +
-      "We can help you find the answers.<br><br>" +
+      "what you are looking for. \n\n " +
+      "We can help you find the answers.\n\n" +
       "run4theh111z",
   ),
 
@@ -199,18 +197,18 @@ const Messages: Record<MessageFilenames, Message> = {
   [MessageFilenames.TruthGazer]: new Message(
     MessageFilenames.TruthGazer,
     //"THE TRUTH CAN NO LONGER ESCAPE YOUR GAZE"
-    "@&*($#@&__TH3__#@A&#@*)__TRU1H__(*)&*)($#@&()E&R)W&<br>" +
-      "%@*$^$()@&$)$*@__CAN__()(@^#)@&@)#__N0__(#@&#)@&@&(<br>" +
-      "*(__LON6ER__^#)@)(()*#@)@__ESCAP3__)#(@(#@*@()@(#*$<br>" +
+    "@&*($#@&__TH3__#@A&#@*)__TRU1H__(*)&*)($#@&()E&R)W&\n" +
+      "%@*$^$()@&$)$*@__CAN__()(@^#)@&@)#__N0__(#@&#)@&@&(\n" +
+      "*(__LON6ER__^#)@)(()*#@)@__ESCAP3__)#(@(#@*@()@(#*$\n" +
       "()@)#$*%)$#()$#__Y0UR__(*)$#()%(&(%)*!)($__GAZ3__#(",
   ),
 
   [MessageFilenames.RedPill]: new Message(
     MessageFilenames.RedPill,
     //"FIND THE-CAVE"
-    "@)(#V%*N)@(#*)*C)@#%*)*V)@#(*%V@)(#VN%*)@#(*%<br>" +
-      ")@B(*#%)@)M#B*%V)____FIND___#$@)#%(B*)@#(*%B)<br>" +
-      "@_#(%_@#M(BDSPOMB__THE-CAVE_#)$(*@#$)@#BNBEGB<br>" +
+    "@)(#V%*N)@(#*)*C)@#%*)*V)@#(*%V@)(#VN%*)@#(*%\n" +
+      ")@B(*#%)@)M#B*%V)____FIND___#$@)#%(B*)@#(*%B)\n" +
+      "@_#(%_@#M(BDSPOMB__THE-CAVE_#)$(*@#$)@#BNBEGB\n" +
       "DFLSMFVMV)#@($*)@#*$MV)@#(*$V)M#(*$)M@(#*VM$)",
   ),
 };

--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -41,7 +41,7 @@ function wrapFunction(
   const functionPath = tree.join(".");
   const functionName = tree.pop();
   if (typeof functionName !== "string") {
-    throw helpers.makeRuntimeRejectMsg(workerScript, "Failure occured while wrapping netscript api");
+    throw helpers.makeBasicErrorMsg(workerScript, "Failure occured while wrapping netscript api");
   }
   const ctx = {
     workerScript,

--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -40,7 +40,7 @@ function wrapFunction(
   const functionPath = tree.join(".");
   const functionName = tree.pop();
   if (typeof functionName !== "string") {
-    throw helpers.makeBasicErrorMsg(workerScript, "Failure occured while wrapping netscript api");
+    throw helpers.makeBasicErrorMsg(workerScript, "Failure occured while wrapping netscript api", "INITIALIZATION");
   }
   const ctx = {
     workerScript,

--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -1,6 +1,5 @@
 import { getRamCost } from "./RamCostGenerator";
 import type { WorkerScript } from "./WorkerScript";
-import { Player } from "../Player";
 import { helpers } from "./NetscriptHelpers";
 import { ScriptArg } from "./ScriptArg";
 import { NSEnums } from "src/ScriptEditor/NetscriptDefinitions";
@@ -50,7 +49,7 @@ function wrapFunction(
   };
   function wrappedFunction(...args: unknown[]): unknown {
     helpers.checkEnvFlags(ctx);
-    helpers.updateDynamicRam(ctx, getRamCost(Player, ...tree, ctx.function));
+    helpers.updateDynamicRam(ctx, getRamCost(...tree, ctx.function));
     return func(ctx)(...args);
   }
   const parent = getNestedProperty(wrappedAPI, tree);

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -686,9 +686,9 @@ function createPublicRunningScript(runningScript: RunningScript): IRunningScript
  * @param {string} callingFn - Name of calling function. For logging purposes
  * @returns {boolean} True if the server is a Hacknet Server, false otherwise
  */
-function failOnHacknetServer(ctx: NetscriptContext, server: BaseServer, callingFn = ""): boolean {
+function failOnHacknetServer(ctx: NetscriptContext, server: BaseServer): boolean {
   if (server instanceof HacknetServer) {
-    ctx.workerScript.log(callingFn, () => `Does not work on Hacknet Servers`);
+    log(ctx, () => `Does not work on Hacknet Servers`);
     return true;
   } else {
     return false;

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -131,11 +131,11 @@ function argsToString(args: unknown[]): string {
 }
 
 /** Creates an error message string containing hostname, scriptname, and the error message msg */
-function makeBasicErrorMsg(workerScript: WorkerScript, msg: string): string {
+function makeBasicErrorMsg(workerScript: WorkerScript, msg: string, type = "RUNTIME"): string {
   for (const scriptUrl of workerScript.scriptRef.dependencies) {
     msg = msg.replace(new RegExp(scriptUrl.url, "g"), scriptUrl.filename);
   }
-  return msg;
+  return `${type} ERROR\n${workerScript.name}@${workerScript.hostname} (PID - ${workerScript.pid})\n\n${msg}`;
 }
 
 /** Creates an error message string with a stack trace. */
@@ -204,7 +204,7 @@ function makeRuntimeErrorMsg(ctx: NetscriptContext, msg: string): string {
   }
 
   log(ctx, () => msg);
-  let rejectMsg = `RUNTIME ERROR\n${ws.name}@${ws.hostname} (PID - ${ws.pid})\n\n${caller}: ${msg}`;
+  let rejectMsg = `${caller}: ${msg}`;
   if (userstack.length !== 0) rejectMsg += `\n\nStack:\n${userstack.join("\n")}`;
   return makeBasicErrorMsg(ws, rejectMsg);
 }

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -1,13 +1,12 @@
-import { IPlayer } from "src/PersonObjects/IPlayer";
+import { Player } from "../Player";
 import { IMap } from "../types";
 
 import { NS as INS } from "../ScriptEditor/NetscriptDefinitions";
-
 import { INetscriptExtra } from "../NetscriptFunctions/Extra";
 
 type RamCostTree<API> = {
   [Property in keyof API]: API[Property] extends () => void
-    ? number | ((p: IPlayer) => void)
+    ? number | (() => void)
     : API[Property] extends object
     ? RamCostTree<API[Property]>
     : never;
@@ -89,10 +88,10 @@ export const RamCostConstants: IMap<number> = {
   ScriptStanekAcceptGift: 2,
 };
 
-function SF4Cost(cost: number): (player: IPlayer) => number {
-  return (player: IPlayer): number => {
-    if (player.bitNodeN === 4) return cost;
-    const sf4 = player.sourceFileLvl(4);
+function SF4Cost(cost: number): () => number {
+  return () => {
+    if (Player.bitNodeN === 4) return cost;
+    const sf4 = Player.sourceFileLvl(4);
     if (sf4 <= 1) return cost * 16;
     if (sf4 === 2) return cost * 4;
     return cost;
@@ -611,7 +610,7 @@ export const RamCosts: IMap<any> = SourceRamCosts;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _typecheck: RamCostTree<INS & INetscriptExtra> = SourceRamCosts;
 
-export function getRamCost(player: IPlayer, ...args: string[]): number {
+export function getRamCost(...args: string[]): number {
   if (args.length === 0) {
     console.warn(`No arguments passed to getRamCost()`);
     return 0;
@@ -637,7 +636,7 @@ export function getRamCost(player: IPlayer, ...args: string[]): number {
   }
 
   if (typeof curr === "function") {
-    return curr(player);
+    return curr();
   }
 
   console.warn(`Unexpected type (${curr}) for value [${args}]`);

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -10,7 +10,7 @@ import { WorkerScriptStartStopEventEmitter } from "./WorkerScriptStartStopEventE
 import { RunningScript } from "../Script/RunningScript";
 import { GetServer } from "../Server/AllServers";
 
-import { dialogBoxCreate } from "../ui/React/DialogBox";
+import { errorDialog } from "../ui/React/DialogBox";
 import { AddRecentScript } from "./RecentScripts";
 import { Player } from "../Player";
 
@@ -59,12 +59,7 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
       ws.env.stopFlag = false;
       ws.atExit();
     } catch (e: unknown) {
-      let message = e instanceof ScriptDeath ? e.errorMessage : String(e);
-      message = message.replace(/.*\|DELIMITER\|/, "");
-      dialogBoxCreate(
-        `Error trying to call atExit for script ${[ws.name, ...ws.args].join(" ")} on ${ws.hostname}\n ${message}`,
-      );
-      console.error(e);
+      errorDialog(e, `Error during atExit ${ws.name}@${ws.hostname} (PID - ${ws.pid}\n\n`);
     }
     ws.atExit = undefined;
   }

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -12,7 +12,6 @@ import { GetServer } from "../Server/AllServers";
 
 import { errorDialog } from "../ui/React/DialogBox";
 import { AddRecentScript } from "./RecentScripts";
-import { Player } from "../Player";
 
 export type killScriptParams = WorkerScript | number | { runningScript: RunningScript; hostname: string };
 
@@ -95,8 +94,8 @@ function removeWorkerScript(workerScript: WorkerScript): void {
 
   // Recalculate ram used on that server
 
-  server.updateRamUsed(0, Player);
-  for (const rs of server.runningScripts) server.updateRamUsed(server.ramUsed + rs.ramUsage * rs.threads, Player);
+  server.updateRamUsed(0);
+  for (const rs of server.runningScripts) server.updateRamUsed(server.ramUsed + rs.ramUsage * rs.threads);
 
   // Delete script from global pool (workerScripts)
   workerScripts.delete(workerScript.pid);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1778,7 +1778,7 @@ const base: InternalAPI<NS> = {
     (ctx: NetscriptContext) =>
     (_message: unknown): void => {
       const message = helpers.string(ctx, "message", _message);
-      dialogBoxCreate(message);
+      dialogBoxCreate(message, true);
     },
   toast:
     (ctx: NetscriptContext) =>

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1110,7 +1110,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 0;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerMoneyAvailable")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 0;
       }
       if (server.hostname == "home") {
@@ -1130,7 +1130,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 1;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerSecurityLevel")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 1;
       }
       helpers.log(
@@ -1149,7 +1149,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 1;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerBaseSecurityLevel")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 1;
       }
       helpers.log(
@@ -1167,7 +1167,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 1;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerMinSecurityLevel")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 1;
       }
       helpers.log(
@@ -1185,7 +1185,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 1;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerRequiredHackingLevel")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 1;
       }
       helpers.log(
@@ -1203,7 +1203,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 0;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerMaxMoney")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 0;
       }
       helpers.log(ctx, () => `returned ${numeralWrapper.formatMoney(server.moneyMax)} for '${server.hostname}'`);
@@ -1218,7 +1218,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 1;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerGrowth")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 1;
       }
       helpers.log(ctx, () => `returned ${server.serverGrowth} for '${server.hostname}'`);
@@ -1233,7 +1233,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "Cannot be executed on this server.");
         return 5;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getServerNumPortsRequired")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return 5;
       }
       helpers.log(ctx, () => `returned ${server.numOpenPortsRequired} for '${server.hostname}'`);
@@ -1679,7 +1679,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "invalid for this kind of server");
         return Infinity;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getHackTime")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return Infinity;
       }
 
@@ -1694,7 +1694,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "invalid for this kind of server");
         return Infinity;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getGrowTime")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return Infinity;
       }
 
@@ -1709,7 +1709,7 @@ const base: InternalAPI<NS> = {
         helpers.log(ctx, () => "invalid for this kind of server");
         return Infinity;
       }
-      if (helpers.failOnHacknetServer(ctx, server, "getWeakenTime")) {
+      if (helpers.failOnHacknetServer(ctx, server)) {
         return Infinity;
       }
 

--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -71,7 +71,7 @@ export async function executeJSScript(
   const ns = workerScript.env.vars;
 
   if (!loadedModule) {
-    throw helpers.makeRuntimeRejectMsg(
+    throw helpers.makeBasicErrorMsg(
       workerScript,
       `${script.filename} cannot be run because the script module won't load`,
     );
@@ -79,18 +79,19 @@ export async function executeJSScript(
   // TODO: putting await in a non-async function yields unhelpful
   // "SyntaxError: unexpected reserved word" with no line number information.
   if (!loadedModule.main) {
-    throw helpers.makeRuntimeRejectMsg(
+    throw helpers.makeBasicErrorMsg(
       workerScript,
       `${script.filename} cannot be run because it does not have a main function.`,
     );
   }
   if (!ns) {
-    throw helpers.makeRuntimeRejectMsg(
+    throw helpers.makeBasicErrorMsg(
       workerScript,
       `${script.filename} cannot be run because the NS object hasn't been constructed properly.`,
     );
   }
-  return loadedModule.main(ns);
+  await loadedModule.main(ns);
+  return;
 }
 
 function isDependencyOutOfDate(filename: string, scripts: Script[], scriptModuleSequenceNumber: number): boolean {

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -24,7 +24,7 @@ import { Settings } from "./Settings/Settings";
 
 import { generate } from "escodegen";
 
-import { dialogBoxCreate, errorDialog } from "./ui/React/DialogBox";
+import { dialogBoxCreate } from "./ui/React/DialogBox";
 import { arrayToString } from "./utils/helpers/arrayToString";
 import { roundToTwo } from "./utils/helpers/roundToTwo";
 
@@ -33,7 +33,7 @@ import { simple as walksimple } from "acorn-walk";
 import { areFilesEqual } from "./Terminal/DirectoryHelpers";
 import { Terminal } from "./Terminal";
 import { ScriptArg } from "./Netscript/ScriptArg";
-import { helpers } from "./Netscript/NetscriptHelpers";
+import { handleUnknownError } from "./Netscript/NetscriptHelpers";
 
 export const NetscriptPorts: Map<number, IPort> = new Map();
 
@@ -346,16 +346,7 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
       workerScript.log("", () => "Script finished running");
     })
     .catch(function (e) {
-      if (typeof e === "string") {
-        const headerText = helpers.makeBasicErrorMsg(workerScript, "", "");
-        //Add header info if it is not present;
-        if (!e.includes(headerText)) e = helpers.makeBasicErrorMsg(workerScript, e);
-      } else if (e instanceof SyntaxError) {
-        e = helpers.makeBasicErrorMsg(workerScript, `${e.message} (sorry we can't be more helpful)`, "SYNTAX");
-      } else if (e instanceof Error) {
-        e = helpers.makeBasicErrorMsg(workerScript, `${e.message}${e.stack ? `\nstack:\n${e.stack.toString()}` : ""}`);
-      }
-      errorDialog(e);
+      handleUnknownError(e, workerScript);
       workerScript.log("", () => (e instanceof ScriptDeath ? "Script killed." : "Script crashed due to an error."));
       killWorkerScript(workerScript);
     });

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -62,7 +62,6 @@ async function startNetscript2Script(workerScript: WorkerScript): Promise<void> 
     throw `${script.filename} cannot be run because it does not have a main function.`;
   if (!ns) throw `${script.filename} cannot be run because the NS object hasn't been constructed properly.`;
   await loadedModule.main(ns);
-  return;
 }
 
 async function startNetscript1Script(workerScript: WorkerScript): Promise<void> {

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -12,7 +12,7 @@ import { generateNextPid } from "./Netscript/Pid";
 import { CONSTANTS } from "./Constants";
 import { Interpreter } from "./ThirdParty/JSInterpreter";
 import { NetscriptFunctions } from "./NetscriptFunctions";
-import { executeJSScript, Node } from "./NetscriptJSEvaluator";
+import { compile, Node } from "./NetscriptJSEvaluator";
 import { IPort } from "./NetscriptPort";
 import { RunningScript } from "./Script/RunningScript";
 import { getRamUsageFromRunningScript } from "./Script/RunningScriptHelpers";
@@ -31,7 +31,6 @@ import { roundToTwo } from "./utils/helpers/roundToTwo";
 import { parse } from "acorn";
 import { simple as walksimple } from "acorn-walk";
 import { areFilesEqual } from "./Terminal/DirectoryHelpers";
-import { Player } from "./Player";
 import { Terminal } from "./Terminal";
 import { ScriptArg } from "./Netscript/ScriptArg";
 
@@ -49,14 +48,26 @@ export function prestigeWorkerScripts(): void {
   workerScripts.clear();
 }
 
-// JS script promises need a little massaging to have the same guarantees as netscript
-// promises. This does said massaging and kicks the script off. It returns a promise
-// that resolves or rejects when the corresponding worker script is done.
-const startNetscript2Script = (workerScript: WorkerScript): Promise<void> =>
-  executeJSScript(Player, workerScript.getServer().scripts, workerScript);
+async function startNetscript2Script(workerScript: WorkerScript): Promise<void> {
+  const scripts = workerScript.getServer().scripts;
+  const script = workerScript.getScript();
+  if (script === null) throw "workerScript had no associated script. This is a bug.";
+  const loadedModule = await compile(script, scripts);
+  workerScript.ramUsage = script.ramUsage;
+  const ns = workerScript.env.vars;
 
-function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
+  if (!loadedModule) throw `${script.filename} cannot be run because the script module won't load`;
+  // TODO: Better error for "unexpected reserved word" when using await in non-async function?
+  if (typeof loadedModule.main !== "function")
+    throw `${script.filename} cannot be run because it does not have a main function.`;
+  if (!ns) throw `${script.filename} cannot be run because the NS object hasn't been constructed properly.`;
+  await loadedModule.main(ns);
+  return;
+}
+
+async function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
   const code = workerScript.code;
+  let errorToThrow: unknown;
 
   //Process imports
   let codeWithImports, codeLineOffset;
@@ -65,10 +76,7 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
     codeWithImports = importProcessingRes.code;
     codeLineOffset = importProcessingRes.lineOffset;
   } catch (e: unknown) {
-    dialogBoxCreate(`Error processing Imports in ${workerScript.name} on ${workerScript.hostname}:\n\n${e}`);
-    workerScript.env.stopFlag = true;
-    killWorkerScript(workerScript);
-    return Promise.resolve();
+    throw `Error processing Imports in ${workerScript.name}@${workerScript.hostname}:\n\n${e}`;
   }
 
   interface BasicObject {
@@ -77,20 +85,13 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
   function wrapNS1Layer(int: Interpreter, intLayer: unknown, nsLayer = workerScript.env.vars as BasicObject) {
     for (const [name, entry] of Object.entries(nsLayer)) {
       if (typeof entry === "function") {
-        // Async functions need to be wrapped. See JS-Interpreter documentation
         const wrapper = async (...args: unknown[]) => {
-          // This async wrapper is sent a resolver function as an extra arg.
-          // See JSInterpreter.js:3209
           try {
+            // Sent a resolver function as an extra arg. See createAsyncFunction JSInterpreter.js:3209
             const callback = args.pop() as (value: unknown) => void;
-            const result = await entry(...args.map(int.pseudoToNative));
-            return callback(int.nativeToPseudo(result));
+            callback(int.nativeToPseudo(await entry(...args.map(int.pseudoToNative))));
           } catch (e: unknown) {
-            // NS1 interpreter doesn't cleanly handle throwing. Need to show dialog here.
-            errorDialog(e, `RUNTIME ERROR:\n${workerScript.name}@${workerScript.hostname}\n\n`);
-            workerScript.env.stopFlag = true;
-            killWorkerScript(workerScript);
-            return;
+            errorToThrow = e;
           }
         };
         int.setProperty(intLayer, name, int.createAsyncFunction(wrapper));
@@ -109,31 +110,16 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
   try {
     interpreter = new Interpreter(codeWithImports, wrapNS1Layer, codeLineOffset);
   } catch (e: unknown) {
-    dialogBoxCreate(`Syntax ERROR in ${workerScript.name} on ${workerScript.hostname}:\n\n${String(e)}`);
-    workerScript.env.stopFlag = true;
-    killWorkerScript(workerScript);
-    return Promise.resolve();
+    throw `Syntax ERROR in ${workerScript.name}@${workerScript.hostname}:\n\n${String(e)}`;
   }
 
-  return new Promise((resolve) => {
-    function runInterpreter(): void {
-      if (workerScript.env.stopFlag) resolve();
-
-      let more = true;
-      let i = 0;
-      while (i < 3 && more) {
-        more = more && interpreter.step();
-        i++;
-      }
-
-      if (more) {
-        setTimeout(runInterpreter, Settings.CodeInstructionRunTime);
-      } else {
-        resolve();
-      }
-    }
-    runInterpreter();
-  });
+  let more = true;
+  while (more) {
+    if (errorToThrow) throw errorToThrow;
+    if (workerScript.env.stopFlag) return;
+    for (let i = 0; more && i < 3; i++) more = interpreter.step();
+    if (more) await new Promise((r) => setTimeout(r, Settings.CodeInstructionRunTime));
+  }
 }
 
 /*  Since the JS Interpreter used for Netscript 1.0 only supports ES5, the keyword
@@ -326,7 +312,7 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
     return false;
   }
 
-  server.updateRamUsed(roundToTwo(server.ramUsed + ramUsage), Player);
+  server.updateRamUsed(roundToTwo(server.ramUsed + ramUsage));
 
   // Get the pid
   const pid = generateNextPid();
@@ -346,20 +332,10 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
   workerScripts.set(pid, workerScript);
   WorkerScriptStartStopEventEmitter.emit();
 
-  // Start the script's execution
-  let scriptExecution: Promise<void> | null = null; // Script's resulting promise
-  if (workerScript.name.endsWith(".js")) {
-    scriptExecution = startNetscript2Script(workerScript);
-  } else {
-    scriptExecution = startNetscript1Script(workerScript);
-    if (!(scriptExecution instanceof Promise)) {
-      return false;
-    }
-  }
-
-  // Once the code finishes (either resolved or rejected, doesnt matter), set its
-  // running status to false
-  scriptExecution
+  // Start the script's execution using the correct function for file type
+  (workerScript.name.endsWith(".js") ? startNetscript2Script : startNetscript1Script)(workerScript)
+    // Once the code finishes (either resolved or rejected, doesnt matter), set its
+    // running status to false
     .then(function () {
       // On natural death, the earnings are transfered to the parent if it still exists.
       if (parent && !parent.env.stopFlag) {
@@ -370,13 +346,15 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
       workerScript.log("", () => "Script finished running");
     })
     .catch(function (e) {
-      errorDialog(e, `RUNTIME ERROR\n${workerScript.name}@${workerScript.hostname} (PID - ${workerScript.pid})\n\n`);
-      let logText = "Script crashed due to an error.";
-      if (e instanceof ScriptDeath) logText = "Script killed.";
-      workerScript.log("", () => logText);
+      let initialText = `ERROR\n${workerScript.name}@${workerScript.hostname} (PID - ${workerScript.pid})\n\n`;
+      if (e instanceof SyntaxError) e = `SYNTAX ${initialText}${e.message} (sorry we can't be more helpful)`;
+      else if (e instanceof Error) {
+        e = `RUNTIME ${initialText}${e.message}${e.stack ? `\nstack:\n${e.stack.toString()}` : ""}`;
+      }
+      errorDialog(e, typeof e === "string" && e.includes(initialText) ? "" : initialText);
+      workerScript.log("", () => (e instanceof ScriptDeath ? "Script killed." : "Script crashed due to an error."));
       killWorkerScript(workerScript);
     });
-
   return true;
 }
 

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -346,7 +346,7 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
       workerScript.log("", () => "Script finished running");
     })
     .catch(function (e) {
-      let initialText = `ERROR\n${workerScript.name}@${workerScript.hostname} (PID - ${workerScript.pid})\n\n`;
+      const initialText = `ERROR\n${workerScript.name}@${workerScript.hostname} (PID - ${workerScript.pid})\n\n`;
       if (e instanceof SyntaxError) e = `SYNTAX ${initialText}${e.message} (sorry we can't be more helpful)`;
       else if (e instanceof Error) {
         e = `RUNTIME ${initialText}${e.message}${e.stack ? `\nstack:\n${e.stack.toString()}` : ""}`;

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -24,10 +24,9 @@ import { Settings } from "./Settings/Settings";
 
 import { generate } from "escodegen";
 
-import { dialogBoxCreate } from "./ui/React/DialogBox";
+import { dialogBoxCreate, errorDialog } from "./ui/React/DialogBox";
 import { arrayToString } from "./utils/helpers/arrayToString";
 import { roundToTwo } from "./utils/helpers/roundToTwo";
-import { isString } from "./utils/helpers/isString";
 
 import { parse } from "acorn";
 import { simple as walksimple } from "acorn-walk";
@@ -35,7 +34,6 @@ import { areFilesEqual } from "./Terminal/DirectoryHelpers";
 import { Player } from "./Player";
 import { Terminal } from "./Terminal";
 import { ScriptArg } from "./Netscript/ScriptArg";
-import { helpers } from "./Netscript/NetscriptHelpers";
 
 export const NetscriptPorts: Map<number, IPort> = new Map();
 
@@ -54,39 +52,8 @@ export function prestigeWorkerScripts(): void {
 // JS script promises need a little massaging to have the same guarantees as netscript
 // promises. This does said massaging and kicks the script off. It returns a promise
 // that resolves or rejects when the corresponding worker script is done.
-function startNetscript2Script(workerScript: WorkerScript): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    executeJSScript(Player, workerScript.getServer().scripts, workerScript)
-      .then(() => {
-        resolve();
-      })
-      .catch((e) => reject(e));
-  }).catch((e) => {
-    if (e instanceof Error) {
-      if (e instanceof SyntaxError) {
-        workerScript.errorMessage = helpers.makeRuntimeRejectMsg(
-          workerScript,
-          e.message + " (sorry we can't be more helpful)",
-        );
-      } else {
-        workerScript.errorMessage = helpers.makeRuntimeRejectMsg(
-          workerScript,
-          e.message + ((e.stack && "\nstack:\n" + e.stack.toString()) || ""),
-        );
-      }
-      throw new ScriptDeath(workerScript);
-    } else if (helpers.isScriptErrorMessage(e)) {
-      workerScript.errorMessage = e;
-      throw new ScriptDeath(workerScript);
-    } else if (e instanceof ScriptDeath) {
-      throw e;
-    }
-
-    // Don't know what to do with it, let's try making an error message out of it
-    workerScript.errorMessage = helpers.makeRuntimeRejectMsg(workerScript, "" + e);
-    throw new ScriptDeath(workerScript);
-  });
-}
+const startNetscript2Script = (workerScript: WorkerScript): Promise<void> =>
+  executeJSScript(Player, workerScript.getServer().scripts, workerScript);
 
 function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
   const code = workerScript.code;
@@ -98,18 +65,16 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
     codeWithImports = importProcessingRes.code;
     codeLineOffset = importProcessingRes.lineOffset;
   } catch (e: unknown) {
-    dialogBoxCreate("Error processing Imports in " + workerScript.name + ":<br>" + String(e));
+    dialogBoxCreate(`Error processing Imports in ${workerScript.name} on ${workerScript.hostname}:\n\n${e}`);
     workerScript.env.stopFlag = true;
     killWorkerScript(workerScript);
     return Promise.resolve();
   }
 
-  function wrapNS1Layer(int: Interpreter, intLayer: unknown, path: string[] = []) {
-    //TODO: Better typing layers of interpreter scope and ns
-    interface BasicObject {
-      [key: string]: any;
-    }
-    const nsLayer = path.reduce((prev, newPath) => prev[newPath], workerScript.env.vars as BasicObject);
+  interface BasicObject {
+    [key: string]: any;
+  }
+  function wrapNS1Layer(int: Interpreter, intLayer: unknown, nsLayer = workerScript.env.vars as BasicObject) {
     for (const [name, entry] of Object.entries(nsLayer)) {
       if (typeof entry === "function") {
         // Async functions need to be wrapped. See JS-Interpreter documentation
@@ -121,21 +86,11 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
             const result = await entry(...args.map(int.pseudoToNative));
             return callback(int.nativeToPseudo(result));
           } catch (e: unknown) {
-            // TODO: Unify error handling, this was stolen from previous async handler
-            if (typeof e === "string") {
-              console.error(e);
-              const errorTextArray = e.split("|DELIMITER|");
-              const hostname = errorTextArray[1];
-              const scriptName = errorTextArray[2];
-              const errorMsg = errorTextArray[3];
-              let msg = `${scriptName}@${hostname}<br>`;
-              msg += "<br>";
-              msg += errorMsg;
-              dialogBoxCreate(msg);
-              workerScript.env.stopFlag = true;
-              killWorkerScript(workerScript);
-              return;
-            }
+            // NS1 interpreter doesn't cleanly handle throwing. Need to show dialog here.
+            errorDialog(e, `RUNTIME ERROR:\n${workerScript.name}@${workerScript.hostname}\n\n`);
+            workerScript.env.stopFlag = true;
+            killWorkerScript(workerScript);
+            return;
           }
         };
         int.setProperty(intLayer, name, int.createAsyncFunction(wrapper));
@@ -145,7 +100,7 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
       } else {
         // new object layer, e.g. bladeburner
         int.setProperty(intLayer, name, int.nativeToPseudo({}));
-        wrapNS1Layer(int, (intLayer as BasicObject).properties[name], [...path, name]);
+        wrapNS1Layer(int, (intLayer as BasicObject).properties[name], nsLayer[name]);
       }
     }
   }
@@ -154,54 +109,30 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
   try {
     interpreter = new Interpreter(codeWithImports, wrapNS1Layer, codeLineOffset);
   } catch (e: unknown) {
-    dialogBoxCreate("Syntax ERROR in " + workerScript.name + ":<br>" + String(e));
+    dialogBoxCreate(`Syntax ERROR in ${workerScript.name} on ${workerScript.hostname}:\n\n${String(e)}`);
     workerScript.env.stopFlag = true;
     killWorkerScript(workerScript);
     return Promise.resolve();
   }
 
-  return new Promise(function (resolve, reject) {
+  return new Promise((resolve) => {
     function runInterpreter(): void {
-      try {
-        if (workerScript.env.stopFlag) {
-          return reject(new ScriptDeath(workerScript));
-        }
+      if (workerScript.env.stopFlag) resolve();
 
-        let more = true;
-        let i = 0;
-        while (i < 3 && more) {
-          more = more && interpreter.step();
-          i++;
-        }
-
-        if (more) {
-          setTimeout(runInterpreter, Settings.CodeInstructionRunTime);
-        } else {
-          resolve();
-        }
-      } catch (_e: unknown) {
-        let e = String(_e);
-        if (!helpers.isScriptErrorMessage(e)) {
-          e = helpers.makeRuntimeRejectMsg(workerScript, e);
-        }
-        workerScript.errorMessage = e;
-        return reject(new ScriptDeath(workerScript));
+      let more = true;
+      let i = 0;
+      while (i < 3 && more) {
+        more = more && interpreter.step();
+        i++;
       }
-    }
 
-    try {
-      runInterpreter();
-    } catch (e: unknown) {
-      if (isString(e)) {
-        workerScript.errorMessage = e;
-        return reject(new ScriptDeath(workerScript));
-      } else if (e instanceof ScriptDeath) {
-        return reject(e);
+      if (more) {
+        setTimeout(runInterpreter, Settings.CodeInstructionRunTime);
       } else {
-        console.error(e);
-        return reject(new ScriptDeath(workerScript));
+        resolve();
       }
     }
+    runInterpreter();
   });
 }
 
@@ -430,58 +361,19 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
   // running status to false
   scriptExecution
     .then(function () {
-      workerScript.env.stopFlag = true;
       // On natural death, the earnings are transfered to the parent if it still exists.
-      if (parent !== undefined && !parent.env.stopFlag) {
+      if (parent && !parent.env.stopFlag) {
         parent.scriptRef.onlineExpGained += runningScriptObj.onlineExpGained;
         parent.scriptRef.onlineMoneyMade += runningScriptObj.onlineMoneyMade;
       }
-
       killWorkerScript(workerScript);
       workerScript.log("", () => "Script finished running");
     })
     .catch(function (e) {
-      if (e instanceof Error) {
-        dialogBoxCreate("Script runtime unknown error. This is a bug please contact game developer");
-        console.error("Evaluating workerscript returns an Error. THIS SHOULDN'T HAPPEN: " + e.toString());
-        return;
-      } else if (e instanceof ScriptDeath) {
-        if (helpers.isScriptErrorMessage(workerScript.errorMessage)) {
-          const errorTextArray = workerScript.errorMessage.split("|DELIMITER|");
-          if (errorTextArray.length != 4) {
-            console.error("ERROR: Something wrong with Error text in evaluator...");
-            console.error("Error text: " + workerScript.errorMessage);
-            return;
-          }
-          const hostname = errorTextArray[1];
-          const scriptName = errorTextArray[2];
-          const errorMsg = errorTextArray[3];
-
-          let msg = `RUNTIME ERROR<br>${scriptName}@${hostname} (PID - ${workerScript.pid})<br>`;
-          if (workerScript.args.length > 0) {
-            msg += `Args: ${arrayToString(workerScript.args)}<br>`;
-          }
-          msg += "<br>";
-          msg += errorMsg;
-
-          dialogBoxCreate(msg);
-          workerScript.log("", () => "Script crashed with runtime error");
-        } else {
-          workerScript.log("", () => "Script killed");
-          return; // Already killed, so stop here
-        }
-      } else if (helpers.isScriptErrorMessage(e)) {
-        dialogBoxCreate("Script runtime unknown error. This is a bug please contact game developer");
-        console.error(
-          "ERROR: Evaluating workerscript returns only error message rather than WorkerScript object. THIS SHOULDN'T HAPPEN: " +
-            e.toString(),
-        );
-        return;
-      } else {
-        dialogBoxCreate("An unknown script died for an unknown reason. This is a bug please contact game dev");
-        console.error(e);
-      }
-
+      errorDialog(e, `RUNTIME ERROR\n${workerScript.name}@${workerScript.hostname} (PID - ${workerScript.pid})\n\n`);
+      let logText = "Script crashed due to an error.";
+      if (e instanceof ScriptDeath) logText = "Script killed.";
+      workerScript.log("", () => logText);
       killWorkerScript(workerScript);
     });
 

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -1,4 +1,3 @@
-import { Player } from "../Player";
 import { isScriptFilename } from "../Script/isScriptFilename";
 import { GetServer } from "../Server/AllServers";
 import { isValidFilePath } from "../Terminal/DirectoryHelpers";
@@ -29,7 +28,7 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => void | R
     const server = GetServer(fileData.server);
     if (!server) return error("Server hostname invalid", msg);
 
-    if (isScriptFilename(fileData.filename)) server.writeToScriptFile(Player, fileData.filename, fileData.content);
+    if (isScriptFilename(fileData.filename)) server.writeToScriptFile(fileData.filename, fileData.content);
     // Assume it's a text file
     else server.writeToTextFile(fileData.filename, fileData.content);
 

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -27,7 +27,6 @@ import { AwardNFG, v1APIBreak } from "./utils/v1APIBreak";
 import { AugmentationNames } from "./Augmentation/data/AugmentationNames";
 import { PlayerOwnedAugmentation } from "./Augmentation/PlayerOwnedAugmentation";
 import { LocationName } from "./Locations/data/LocationNames";
-import { SxProps } from "@mui/system";
 import { PlayerObject } from "./PersonObjects/Player/PlayerObject";
 import { pushGameSaved } from "./Electron";
 import { defaultMonacoTheme } from "./ScriptEditor/ui/themes";
@@ -759,27 +758,14 @@ function createScamUpdateText(): void {
   }
 }
 
-const resets: SxProps = {
-  "& h1, & h2, & h3, & h4, & p, & a, & ul": {
-    margin: 0,
-    color: Settings.theme.primary,
-    whiteSpace: "initial",
-  },
-  "& ul": {
-    paddingLeft: "1.5em",
-    lineHeight: 1.5,
-  },
-};
-
 function createNewUpdateText(): void {
   setTimeout(
     () =>
       dialogBoxCreate(
-        "New update!<br>" +
+        "New update!\n" +
           "Please report any bugs/issues through the GitHub repository " +
-          "or the Bitburner subreddit (reddit.com/r/bitburner).<br><br>" +
+          "or the Bitburner subreddit (reddit.com/r/bitburner).\n\n" +
           CONSTANTS.LatestUpdate,
-        resets,
       ),
     1000,
   );
@@ -788,11 +774,10 @@ function createNewUpdateText(): void {
 function createBetaUpdateText(): void {
   dialogBoxCreate(
     "You are playing on the beta environment! This branch of the game " +
-      "features the latest developments in the game. This version may be unstable.<br>" +
+      "features the latest developments in the game. This version may be unstable.\n" +
       "Please report any bugs/issues through the github repository (https://github.com/danielyxie/bitburner/issues) " +
-      "or the Bitburner subreddit (reddit.com/r/bitburner).<br><br>" +
+      "or the Bitburner subreddit (reddit.com/r/bitburner).\n\n" +
       CONSTANTS.LatestUpdate,
-    resets,
   );
 }
 

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -9,7 +9,6 @@ import { ScriptUrl } from "./ScriptUrl";
 
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, Reviver } from "../utils/JSONReviver";
 import { roundToTwo } from "../utils/helpers/roundToTwo";
-import { IPlayer } from "../PersonObjects/IPlayer";
 import { ScriptModule } from "./ScriptModule";
 
 let globalModuleSequenceNumber = 0;
@@ -52,13 +51,13 @@ export class Script {
   // hostname of server that this script is on.
   server = "";
 
-  constructor(player: IPlayer | null = null, fn = "", code = "", server = "", otherScripts: Script[] = []) {
+  constructor(fn = "", code = "", server = "", otherScripts: Script[] = []) {
     this.filename = fn;
     this.code = code;
     this.server = server; // hostname of server this script is on
     this.moduleSequenceNumber = ++globalModuleSequenceNumber;
-    if (this.code !== "" && player !== null) {
-      this.updateRamUsage(player, otherScripts);
+    if (this.code !== "") {
+      this.updateRamUsage(otherScripts);
     }
   }
 
@@ -94,13 +93,13 @@ export class Script {
    * @param {string} code - The new contents of the script
    * @param {Script[]} otherScripts - Other scripts on the server. Used to process imports
    */
-  saveScript(player: IPlayer, filename: string, code: string, hostname: string, otherScripts: Script[]): void {
+  saveScript(filename: string, code: string, hostname: string, otherScripts: Script[]): void {
     // Update code and filename
     this.code = Script.formatCode(code);
 
     this.filename = filename;
     this.server = hostname;
-    this.updateRamUsage(player, otherScripts);
+    this.updateRamUsage(otherScripts);
     this.markUpdated();
     for (const dependent of this.dependents) {
       const [dependentScript] = otherScripts.filter(
@@ -114,8 +113,8 @@ export class Script {
    * Calculates and updates the script's RAM usage based on its code
    * @param {Script[]} otherScripts - Other scripts on the server. Used to process imports
    */
-  updateRamUsage(player: IPlayer, otherScripts: Script[]): void {
-    const res = calculateRamUsage(player, this.code, otherScripts);
+  updateRamUsage(otherScripts: Script[]): void {
+    const res = calculateRamUsage(this.code, otherScripts);
     if (res.cost > 0) {
       this.ramUsage = roundToTwo(res.cost);
       this.ramUsageEntries = res.entries;

--- a/src/Script/ScriptModule.ts
+++ b/src/Script/ScriptModule.ts
@@ -1,6 +1,6 @@
 import { AutocompleteData, NS } from "../ScriptEditor/NetscriptDefinitions";
 
 export interface ScriptModule {
-  main?: (ns: NS) => Promise<void>;
+  main?: (ns: NS) => unknown;
   autocomplete?: (data: AutocompleteData, flags: string[]) => unknown;
 }

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -252,7 +252,7 @@ export function Root(props: IProps): React.ReactElement {
       return;
     }
     const codeCopy = newCode + "";
-    const ramUsage = calculateRamUsage(props.player, codeCopy, props.player.getCurrentServer().scripts);
+    const ramUsage = calculateRamUsage(codeCopy, props.player.getCurrentServer().scripts);
     if (ramUsage.cost > 0) {
       const entries = ramUsage.entries?.sort((a, b) => b.cost - a.cost) ?? [];
       const entriesDisp = [];
@@ -466,7 +466,6 @@ export function Root(props: IProps): React.ReactElement {
       for (let i = 0; i < server.scripts.length; i++) {
         if (scriptToSave.fileName == server.scripts[i].filename) {
           server.scripts[i].saveScript(
-            props.player,
             scriptToSave.fileName,
             scriptToSave.code,
             props.player.currentServer,
@@ -480,13 +479,7 @@ export function Root(props: IProps): React.ReactElement {
 
       //If the current script does NOT exist, create a new one
       const script = new Script();
-      script.saveScript(
-        props.player,
-        scriptToSave.fileName,
-        scriptToSave.code,
-        props.player.currentServer,
-        server.scripts,
-      );
+      script.saveScript(scriptToSave.fileName, scriptToSave.code, props.player.currentServer, server.scripts);
       server.scripts.push(script);
     } else if (scriptToSave.isTxt) {
       for (let i = 0; i < server.textFiles.length; ++i) {
@@ -555,7 +548,6 @@ export function Root(props: IProps): React.ReactElement {
       for (let i = 0; i < server.scripts.length; i++) {
         if (currentScript.fileName == server.scripts[i].filename) {
           server.scripts[i].saveScript(
-            props.player,
             currentScript.fileName,
             currentScript.code,
             props.player.currentServer,
@@ -569,13 +561,7 @@ export function Root(props: IProps): React.ReactElement {
 
       //If the current script does NOT exist, create a new one
       const script = new Script();
-      script.saveScript(
-        props.player,
-        currentScript.fileName,
-        currentScript.code,
-        props.player.currentServer,
-        server.scripts,
-      );
+      script.saveScript(currentScript.fileName, currentScript.code, props.player.currentServer, server.scripts);
       server.scripts.push(script);
     } else if (currentScript.isTxt) {
       for (let i = 0; i < server.textFiles.length; ++i) {

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -12,7 +12,6 @@ import { isScriptFilename } from "../Script/isScriptFilename";
 
 import { createRandomIp } from "../utils/IPAddress";
 import { compareArrays } from "../utils/helpers/compareArrays";
-import { IPlayer } from "../PersonObjects/IPlayer";
 import { ScriptArg } from "../Netscript/ScriptArg";
 
 interface IConstructorParams {
@@ -245,7 +244,7 @@ export class BaseServer {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  updateRamUsed(ram: number, player: IPlayer): void {
+  updateRamUsed(ram: number): void {
     this.ramUsed = ram;
   }
 
@@ -266,7 +265,7 @@ export class BaseServer {
    * Write to a script file
    * Overwrites existing files. Creates new files if the script does not eixst
    */
-  writeToScriptFile(player: IPlayer, fn: string, code: string): writeResult {
+  writeToScriptFile(fn: string, code: string): writeResult {
     const ret = { success: false, overwritten: false };
     if (!isValidFilePath(fn) || !isScriptFilename(fn)) {
       return ret;
@@ -277,7 +276,7 @@ export class BaseServer {
       if (fn === this.scripts[i].filename) {
         const script = this.scripts[i];
         script.code = code;
-        script.updateRamUsage(player, this.scripts);
+        script.updateRamUsage(this.scripts);
         script.markUpdated();
         ret.overwritten = true;
         ret.success = true;
@@ -286,7 +285,7 @@ export class BaseServer {
     }
 
     // Otherwise, create a new script
-    const newScript = new Script(player, fn, code, this.hostname, this.scripts);
+    const newScript = new Script(fn, code, this.hostname, this.scripts);
     this.scripts.push(newScript);
     ret.success = true;
     return ret;

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -324,7 +324,7 @@ export function prestigeHomeComputer(player: IPlayer, homeComp: Server): void {
 
   //Update RAM usage on all scripts
   homeComp.scripts.forEach(function (script) {
-    script.updateRamUsage(player, homeComp.scripts);
+    script.updateRamUsage(homeComp.scripts);
   });
 
   homeComp.messages.length = 0; //Remove .lit and .msg files

--- a/src/Terminal/commands/cp.ts
+++ b/src/Terminal/commands/cp.ts
@@ -89,7 +89,7 @@ export function cp(
       return;
     }
 
-    const sRes = server.writeToScriptFile(player, dst, sourceScript.code);
+    const sRes = server.writeToScriptFile(dst, sourceScript.code);
     if (!sRes.success) {
       terminal.error(`cp failed`);
       return;

--- a/src/Terminal/commands/scp.ts
+++ b/src/Terminal/commands/scp.ts
@@ -94,7 +94,7 @@ export function scp(
       return;
     }
 
-    const sRes = destServer.writeToScriptFile(player, scriptname, sourceScript.code);
+    const sRes = destServer.writeToScriptFile(scriptname, sourceScript.code);
     if (!sRes.success) {
       terminal.error(`scp failed`);
       return;

--- a/src/Terminal/commands/wget.ts
+++ b/src/Terminal/commands/wget.ts
@@ -28,7 +28,7 @@ export function wget(
     function (data: unknown) {
       let res;
       if (isScriptFilename(target)) {
-        res = server.writeToScriptFile(player, target, String(data));
+        res = server.writeToScriptFile(target, String(data));
       } else {
         res = server.writeToTextFile(target, String(data));
       }

--- a/src/Terminal/determineAllPossibilitiesForTabCompletion.ts
+++ b/src/Terminal/determineAllPossibilitiesForTabCompletion.ts
@@ -286,7 +286,7 @@ export async function determineAllPossibilitiesForTabCompletion(
     });
     if (!script) return; // Doesn't exist.
     //Will return the already compiled module if recompilation not needed.
-    const loadedModule = await compile(p, script, currServ.scripts);
+    const loadedModule = await compile(script, currServ.scripts);
     if (!loadedModule || !loadedModule.autocomplete) return; // Doesn't have an autocomplete function.
 
     const runArgs = { "--tail": Boolean, "-t": Number };

--- a/src/Terminal/determineAllPossibilitiesForTabCompletion.ts
+++ b/src/Terminal/determineAllPossibilitiesForTabCompletion.ts
@@ -285,8 +285,14 @@ export async function determineAllPossibilitiesForTabCompletion(
       return processFilepath(script.filename) === fn || script.filename === "/" + fn;
     });
     if (!script) return; // Doesn't exist.
-    //Will return the already compiled module if recompilation not needed.
-    const loadedModule = await compile(script, currServ.scripts);
+    let loadedModule;
+    try {
+      //Will return the already compiled module if recompilation not needed.
+      loadedModule = await compile(script, currServ.scripts);
+    } catch (e) {
+      //fail silently if the script fails to compile (e.g. syntax error)
+      return;
+    }
     if (!loadedModule || !loadedModule.autocomplete) return; // Doesn't have an autocomplete function.
 
     const runArgs = { "--tail": Boolean, "-t": Number };

--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -125,7 +125,9 @@ export function TerminalRoot({ terminal, router, player }: IProps): React.ReactE
                     paragraph={false}
                     onClick={() => terminal.connectToServer(player, item.hostname)}
                   >
-                    <Typography sx={{ textDecoration: 'underline', "&:hover": { textDecoration: 'none'} }}>{item.hostname}</Typography>
+                    <Typography sx={{ textDecoration: "underline", "&:hover": { textDecoration: "none" } }}>
+                      {item.hostname}
+                    </Typography>
                   </MuiLink>
                 </>
               )}

--- a/src/UncaughtPromiseHandler.ts
+++ b/src/UncaughtPromiseHandler.ts
@@ -1,7 +1,11 @@
-import { errorDialog } from "./ui/React/DialogBox";
+import { handleUnknownError } from "./Netscript/NetscriptHelpers";
 
 export function setupUncaughtPromiseHandler(): void {
-  window.addEventListener("unhandledrejection", (e) =>
-    errorDialog(e.reason, "UNCAUGHT PROMISE ERROR\nYou forgot to await a promise\nmaybe hack / grow / weaken ?\n"),
-  );
+  window.addEventListener("unhandledrejection", (e) => {
+    handleUnknownError(
+      e.reason,
+      null,
+      "UNCAUGHT PROMISE ERROR\nYou forgot to await a promise\nmaybe hack / grow / weaken ?\n\n",
+    );
+  });
 }

--- a/src/UncaughtPromiseHandler.ts
+++ b/src/UncaughtPromiseHandler.ts
@@ -1,24 +1,7 @@
-import { ScriptDeath } from "./Netscript/ScriptDeath";
-import { helpers } from "./Netscript/NetscriptHelpers";
-import { dialogBoxCreate } from "./ui/React/DialogBox";
+import { errorDialog } from "./ui/React/DialogBox";
 
 export function setupUncaughtPromiseHandler(): void {
-  window.addEventListener("unhandledrejection", function (e) {
-    if (helpers.isScriptErrorMessage(e.reason)) {
-      const errorTextArray = e.reason.split("|DELIMITER|");
-      const hostname = errorTextArray[1];
-      const scriptName = errorTextArray[2];
-      const errorMsg = errorTextArray[3];
-
-      let msg = `UNCAUGHT PROMISE ERROR<br>You forgot to await a promise<br>${scriptName}@${hostname}<br>`;
-      msg += "<br>";
-      msg += errorMsg;
-      dialogBoxCreate(msg);
-    } else if (e.reason instanceof ScriptDeath) {
-      const msg =
-        `UNCAUGHT PROMISE ERROR<br>You forgot to await a promise<br>${e.reason.name}@${e.reason.hostname} (PID - ${e.reason.pid})<br>` +
-        `Maybe hack / grow / weaken ?`;
-      dialogBoxCreate(msg);
-    }
-  });
+  window.addEventListener("unhandledrejection", (e) =>
+    errorDialog(e.reason, "UNCAUGHT PROMISE ERROR\nYou forgot to await a promise\nmaybe hack / grow / weaken ?\n"),
+  );
 }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
 
-import { IPlayer } from "../PersonObjects/IPlayer";
-import { IEngine } from "../IEngine";
-import { ITerminal } from "../Terminal/ITerminal";
+import { Player } from "../Player";
+import { Engine } from "../engine";
+import { Terminal } from "../Terminal";
 import { installAugmentations } from "../Augmentation/AugmentationHelpers";
 import { saveObject } from "../SaveObject";
 import { onExport } from "../ExportBonus";
@@ -84,12 +84,6 @@ import { V2Modal } from "../utils/V2Modal";
 
 const htmlLocation = location;
 
-interface IProps {
-  terminal: ITerminal;
-  player: IPlayer;
-  engine: IEngine;
-}
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
@@ -148,20 +142,20 @@ export let Router: IRouter = {
   toImportSave: uninitialized,
 };
 
-function determineStartPage(player: IPlayer): Page {
+function determineStartPage(): Page {
   if (RecoveryMode) return Page.Recovery;
-  if (player.currentWork !== null) return Page.Work;
+  if (Player.currentWork !== null) return Page.Work;
   return Page.Terminal;
 }
 
-export function GameRoot({ player, engine, terminal }: IProps): React.ReactElement {
+export function GameRoot(): React.ReactElement {
   const classes = useStyles();
   const [{ files, vim }, setEditorOptions] = useState({ files: {}, vim: false });
-  const [page, setPage] = useState(determineStartPage(player));
+  const [page, setPage] = useState(determineStartPage());
   const setRerender = useState(0)[1];
   const [augPage, setAugPage] = useState<boolean>(false);
   const [faction, setFaction] = useState<Faction>(
-    isFactionWork(player.currentWork) ? Factions[player.currentWork.factionName] : (undefined as unknown as Faction),
+    isFactionWork(Player.currentWork) ? Factions[Player.currentWork.factionName] : (undefined as unknown as Faction),
   );
   if (faction === undefined && page === Page.Faction)
     throw new Error("Trying to go to a page without the proper setup");
@@ -243,7 +237,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       setPage(Page.City);
     },
     toTravel: () => {
-      player.gotoLocation(LocationName.TravelAgency);
+      Player.gotoLocation(LocationName.TravelAgency);
       setPage(Page.Travel);
     },
     toBitVerse: (flume: boolean, quick: boolean) => {
@@ -347,7 +341,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.Terminal: {
-      mainPage = <TerminalRoot terminal={terminal} router={Router} player={player} />;
+      mainPage = <TerminalRoot terminal={Terminal} router={Router} player={Player} />;
       break;
     }
     case Page.Sleeves: {
@@ -366,8 +360,8 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       mainPage = (
         <ScriptEditorRoot
           files={files}
-          hostname={player.getCurrentServer().hostname}
-          player={player}
+          hostname={Player.getCurrentServer().hostname}
+          player={Player}
           router={Router}
           vim={vim}
         />
@@ -379,7 +373,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.Hacknet: {
-      mainPage = <HacknetRoot player={player} />;
+      mainPage = <HacknetRoot player={Player} />;
       break;
     }
     case Page.CreateProgram: {
@@ -387,7 +381,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.Factions: {
-      mainPage = <FactionsRoot player={player} router={Router} />;
+      mainPage = <FactionsRoot player={Player} router={Router} />;
       break;
     }
     case Page.Faction: {
@@ -395,7 +389,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.Milestones: {
-      mainPage = <MilestonesRoot player={player} />;
+      mainPage = <MilestonesRoot player={Player} />;
       break;
     }
     case Page.Tutorial: {
@@ -411,7 +405,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.DevMenu: {
-      mainPage = <DevMenuRoot player={player} engine={engine} router={Router} />;
+      mainPage = <DevMenuRoot player={Player} engine={Engine} router={Router} />;
       break;
     }
     case Page.Gang: {
@@ -431,11 +425,11 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
       break;
     }
     case Page.Travel: {
-      mainPage = <TravelAgencyRoot p={player} router={Router} />;
+      mainPage = <TravelAgencyRoot p={Player} router={Router} />;
       break;
     }
     case Page.StockMarket: {
-      mainPage = <StockMarketRoot p={player} stockMarket={StockMarket} />;
+      mainPage = <StockMarketRoot p={Player} stockMarket={StockMarket} />;
       break;
     }
     case Page.City: {
@@ -450,12 +444,12 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
     case Page.Options: {
       mainPage = (
         <GameOptionsRoot
-          player={player}
+          player={Player}
           router={Router}
           save={() => saveObject.saveGame()}
           export={() => {
             // Apply the export bonus before saving the game
-            onExport(player);
+            onExport(Player);
             saveObject.exportGame();
           }}
           forceKill={killAllScripts}
@@ -469,7 +463,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
         <AugmentationsRoot
           exportGameFn={() => {
             // Apply the export bonus before saving the game
-            onExport(player);
+            onExport(Player);
             saveObject.exportGame();
           }}
           installAugmentationsFn={() => {
@@ -496,7 +490,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
   }
 
   return (
-    <Context.Player.Provider value={player}>
+    <Context.Player.Provider value={Player}>
       <Context.Router.Provider value={Router}>
         <ErrorBoundary key={errorBoundaryKey} router={Router} softReset={softReset}>
           <BypassWrapper content={bypassGame ? mainPage : null}>
@@ -511,7 +505,7 @@ export function GameRoot({ player, engine, terminal }: IProps): React.ReactEleme
               {withSidebar ? (
                 <Box display="flex" flexDirection="row" width="100%">
                   <SidebarRoot
-                    player={player}
+                    player={Player}
                     router={Router}
                     page={page}
                     opened={sidebarOpened}

--- a/src/ui/LoadingScreen.tsx
+++ b/src/ui/LoadingScreen.tsx
@@ -3,9 +3,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
 
-import { Terminal } from "../Terminal";
 import { load } from "../db";
-import { Player } from "../Player";
 import { Engine } from "../engine";
 import { GameRoot } from "./GameRoot";
 
@@ -57,7 +55,7 @@ export function LoadingScreen(): React.ReactElement {
   }, []);
 
   return loaded ? (
-    <GameRoot terminal={Terminal} engine={Engine} player={Player} />
+    <GameRoot />
   ) : (
     <Grid container direction="column" justifyContent="center" alignItems="center" style={{ minHeight: "100vh" }}>
       <Grid item>

--- a/src/ui/React/DialogBox.tsx
+++ b/src/ui/React/DialogBox.tsx
@@ -22,10 +22,5 @@ export function errorDialog(e: unknown, initialText = "") {
     errorText = "An unknown error was thrown, see console.";
     console.error(e);
   }
-
-  if (!initialText && e instanceof ScriptDeath) {
-    const basicHeader = `ERROR\n${e.name}@${e.hostname} (PID - ${e.pid})\n\n`;
-    if (e.errorMessage.includes(basicHeader)) initialText = basicHeader;
-  }
   dialogBoxCreate(initialText + errorText);
 }

--- a/src/ui/React/DialogBox.tsx
+++ b/src/ui/React/DialogBox.tsx
@@ -23,9 +23,9 @@ export function errorDialog(e: unknown, initialText = "") {
     console.error(e);
   }
 
-  if (!initialText) {
-    if (e instanceof ScriptDeath) initialText = `${e.name}@${e.hostname} (PID - ${e.pid})\n\n`;
+  if (!initialText && e instanceof ScriptDeath) {
+    const basicHeader = `ERROR\n${e.name}@${e.hostname} (PID - ${e.pid})\n\n`;
+    if (e.errorMessage.includes(basicHeader)) initialText = basicHeader;
   }
-
   dialogBoxCreate(initialText + errorText);
 }

--- a/src/ui/React/DialogBox.tsx
+++ b/src/ui/React/DialogBox.tsx
@@ -2,25 +2,7 @@ import { AlertEvents } from "./AlertManager";
 
 import React from "react";
 import { Typography } from "@mui/material";
-import { ScriptDeath } from "../../Netscript/ScriptDeath";
 
 export function dialogBoxCreate(txt: string | JSX.Element): void {
   AlertEvents.emit(typeof txt === "string" ? <Typography component="span">{txt}</Typography> : txt);
-}
-
-export function errorDialog(e: unknown, initialText = "") {
-  let errorText = "";
-  if (typeof e === "string") errorText = e;
-  else if (e instanceof ScriptDeath) {
-    if (!e.errorMessage) return; //No need for a dialog for an empty ScriptDeath
-    errorText = e.errorMessage;
-    if (!e.errorMessage.includes(`${e.name}@${e.hostname}`)) {
-      initialText += `${e.name}@${e.hostname} (PID - ${e.pid})\n\n`;
-    }
-  } else if (e instanceof Error) errorText = "Original error message:\n" + e.message;
-  else {
-    errorText = "An unknown error was thrown, see console.";
-    console.error(e);
-  }
-  dialogBoxCreate(initialText + errorText);
 }

--- a/src/ui/React/DialogBox.tsx
+++ b/src/ui/React/DialogBox.tsx
@@ -3,6 +3,14 @@ import { AlertEvents } from "./AlertManager";
 import React from "react";
 import { Typography } from "@mui/material";
 
-export function dialogBoxCreate(txt: string | JSX.Element): void {
-  AlertEvents.emit(typeof txt === "string" ? <Typography component="span">{txt}</Typography> : txt);
+export function dialogBoxCreate(txt: string | JSX.Element, html = false): void {
+  AlertEvents.emit(
+    typeof txt !== "string" ? (
+      txt
+    ) : html ? (
+      <div dangerouslySetInnerHTML={{ __html: txt }}></div>
+    ) : (
+      <Typography component="span">{txt}</Typography>
+    ),
+  );
 }

--- a/src/ui/React/DialogBox.tsx
+++ b/src/ui/React/DialogBox.tsx
@@ -14,8 +14,10 @@ export function errorDialog(e: unknown, initialText = "") {
   else if (e instanceof ScriptDeath) {
     if (!e.errorMessage) return; //No need for a dialog for an empty ScriptDeath
     errorText = e.errorMessage;
-  } else if (e instanceof SyntaxError) errorText = e.message + " (sorry we can't be more helpful)";
-  else if (e instanceof Error) errorText = e.message + (e.stack ? `\nstack:\n${e.stack.toString()}` : "");
+    if (!e.errorMessage.includes(`${e.name}@${e.hostname}`)) {
+      initialText += `${e.name}@${e.hostname} (PID - ${e.pid})\n\n`;
+    }
+  } else if (e instanceof Error) errorText = "Original error message:\n" + e.message;
   else {
     errorText = "An unknown error was thrown, see console.";
     console.error(e);

--- a/src/ui/React/DialogBox.tsx
+++ b/src/ui/React/DialogBox.tsx
@@ -1,13 +1,29 @@
 import { AlertEvents } from "./AlertManager";
 
 import React from "react";
-import { SxProps } from "@mui/system";
 import { Typography } from "@mui/material";
+import { ScriptDeath } from "../../Netscript/ScriptDeath";
 
-export function dialogBoxCreate(txt: string | JSX.Element, styles?: SxProps): void {
-  if (typeof txt !== "string") {
-    AlertEvents.emit(txt);
-  } else {
-    AlertEvents.emit(<Typography component="span" sx={styles} dangerouslySetInnerHTML={{ __html: txt }} />);
+export function dialogBoxCreate(txt: string | JSX.Element): void {
+  AlertEvents.emit(typeof txt === "string" ? <Typography component="span">{txt}</Typography> : txt);
+}
+
+export function errorDialog(e: unknown, initialText = "") {
+  let errorText = "";
+  if (typeof e === "string") errorText = e;
+  else if (e instanceof ScriptDeath) {
+    if (!e.errorMessage) return; //No need for a dialog for an empty ScriptDeath
+    errorText = e.errorMessage;
+  } else if (e instanceof SyntaxError) errorText = e.message + " (sorry we can't be more helpful)";
+  else if (e instanceof Error) errorText = e.message + (e.stack ? `\nstack:\n${e.stack.toString()}` : "");
+  else {
+    errorText = "An unknown error was thrown, see console.";
+    console.error(e);
   }
+
+  if (!initialText) {
+    if (e instanceof ScriptDeath) initialText = `${e.name}@${e.hostname} (PID - ${e.pid})\n\n`;
+  }
+
+  dialogBoxCreate(initialText + errorText);
 }

--- a/src/utils/v1APIBreak.ts
+++ b/src/utils/v1APIBreak.ts
@@ -126,7 +126,7 @@ export function v1APIBreak(): void {
     for (const script of server.scripts) {
       if (!hasChanges(script.code)) continue;
       const prefix = script.filename.includes("/") ? "/BACKUP_" : "BACKUP_";
-      backups.push(new Script(Player, prefix + script.filename, script.code, script.server));
+      backups.push(new Script(prefix + script.filename, script.code, script.server));
       script.code = convert(script.code);
     }
     server.scripts = server.scripts.concat(backups);


### PR DESCRIPTION
Errors are handled a bunch of different places, and inconsistently.
* Once in the NS1 wrapper function in startNetscript1Script (NetscriptWorker.ts)
* Once in startNetscript2Script (NetscriptWorker.ts)
* Once in createAndAddWorkerScript (NetscriptWorker.ts)
* Again in the atExit handler in killWorkerScript.ts
* And finally in UncaughtPromiseHandler.ts

All with separate error handling code.

For displaying errors, now there is one handleUnknownError function in NetscriptHelpers.js, which is used in just three locations to catch all errors (createAndAddWorkerScript, atExit handler, and UncaughtPromiseHandler). The first two instances above have been reworked to always properly throw their errors to createAndAddWorkerScript, so the handling for within the main execution of a script can all be handled in that one location.

Modifications were made to startNetscript1Script so that it actually throws an error when an error is encountered, previously it was returning a resolved promise but manually displaying an error dialog box.

Initial version added a new handler to DialogBox.tsx. Since I was modifying this, I also changed dialogBoxCreate to no longer do the dangerouslySetInnerHTML thing it was doing before. Now it just expects regular strings (not strings of HTML). For styled output it will still accept TSX. This is one of the reasons this PR touches so many files, any reference to dialogBoxCreate that used an html string needed to be modified to be a regular string (i.e. `<br>` changed to `\n`, `&nbsp;` changed to `\u00a0`). This also means that errors which contain html content will not be rendered as HTML, they will be rendered as plaintext.

After removing the error handling code from it, startNetscript2Script was basically just a wrapper for executeJSScript. So I  just reworked executeJSScript slightly to take just a workerScript as an input, and moved it to NetscriptWorker.ts as a replacement for startNetscript2Script. Changing the params to work required importing Player directly at RamCostGenerator.ts and removing player from a bunch of parameter chains throughout multiple files, most of which were just for the purpose of delivering Player to RamCostGenerator. During some troubleshooting for these changes, I also removed the prop passing of Terminal/Engine/Player from LoadingScreen to GameRoot. Now GameRoot imports those items.

Errors no longer use the |DELIMITER| format they previously did, but there is still checking to add header information to an error if it isn't already present.

I also renamed makeRuntimeRejectMsg to makeBasicErrorMsg, and now it also adds this header info. It also will optionally accept a ScriptDeath as an input instead of a WorkerScript to produce this header info.

Also, there is a new field for both ErrorMsg functions to specify the type of error. For instance, if an error is thrown due to an invalid type provided for a parameter, the error will say "TYPE ERROR" instead of "RUNTIME ERROR". Other types I have added are:
Dynamic ram check failure: "RAM USAGE ERROR"
netscriptDelay concurrency failure: "CONCURRENCY ERROR"
singularity error for not having SF4/being in BN4: "API ACCESS ERROR"