### PR TITLE
NETSCRIPT: FIX #4055 Fix dynamic ram check

### DIFF
--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -299,6 +299,7 @@ function updateDynamicRam(ctx: NetscriptContext, ramCost: number): void {
       Sorry :(`,
     );
   }
+  throw new ScriptDeath(ws);
 }
 
 /** Validates the input v as being a CityName. Throws an error if it is not. */


### PR DESCRIPTION
Fixes #4055 Dynamic ram check was not throwing an error when it failed. Now it is.

Here's a test script showing that it doesn't work before this PR:
```javascript
export let main=ns=>{
  let player=ns["getPlayer"]();
  let server=ns["getServer"](ns["getCurrentServer"])
  let ram=ns["getScriptRam"](ns["getRunningScript"]().filename)
  ns.tprint("This script is using "+ram+"GB");
}
```

No error on current dev branch, correct error with this PR.