### PR TITLE
RFA: NetscriptDefinitions retains export strings

### DIFF
--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -131,7 +131,6 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => void | R
   },
 
   getDefinitionFile: function (msg: RFAMessage): RFAMessage {
-    const source = (libSource + "").replace(/export /g, "");
-    return new RFAMessage({ result: source, id: msg.id });
+    return new RFAMessage({ result: libSource + "", id: msg.id });
   },
 };


### PR DESCRIPTION
Fixes the missing `export`s in NetscriptDefinitions sent through RFA. Should resolve the issues regarding importing the file after downloading it through filesync.