### PR TITLE
INFILTRATION: Corrected ns formula for infiltration rewards

### DIFF
--- a/src/NetscriptFunctions/Infiltration.ts
+++ b/src/NetscriptFunctions/Infiltration.ts
@@ -38,9 +38,9 @@ export function NetscriptInfiltration(): InternalAPI<IInfiltration> {
     return {
       location: JSON.parse(JSON.stringify(location)),
       reward: {
-        tradeRep: calculateTradeInformationRepReward(player, reward, maxLevel, difficulty),
-        sellCash: calculateSellInformationCashReward(player, reward, maxLevel, difficulty),
-        SoARep: calculateInfiltratorsRepReward(player, Factions[FactionNames.ShadowsOfAnarchy], difficulty),
+        tradeRep: calculateTradeInformationRepReward(player, reward, maxLevel, startingSecurityLevel),
+        sellCash: calculateSellInformationCashReward(player, reward, maxLevel, startingSecurityLevel),
+        SoARep: calculateInfiltratorsRepReward(player, Factions[FactionNames.ShadowsOfAnarchy], startingSecurityLevel),
       },
       difficulty: difficulty,
     };


### PR DESCRIPTION
In commit 
7c5097ee83d9e2d185960a9c96739a78981bd600 the author extracted the functionality for infiltration rewards into a NS function and made it accessible via formulas.

The exposed function does however not use the same input parameters as the Victory screen after infiltration since he uses the difficulty and not the starting difficulty.

Difficulty is clamped to [0;3], so the formulas api showed for high difficulty servers a vastly lower result.


![unknown](https://user-images.githubusercontent.com/5598040/187102013-32010ace-09fd-433a-9856-7bb81fa79a75.png)
