### PR TITLE
SLEEVES: FIX #4051 Sleeves no longer crash when player quits company sleeve was working

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -596,7 +596,8 @@ export function quitJob(this: IPlayer, company: string): void {
   }
   for (const sleeve of this.sleeves) {
     if (sleeve.currentWork instanceof SleeveCompanyWork && sleeve.currentWork.companyName === company){
-      sleeve.currentWork.finish(this);
+      sleeve.stopWork(this);
+      dialogBoxCreate(`You quit ${company} while one of your sleeves was working there. The sleeve is now idle.`)
     }
   }
   delete this.jobs[company];

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -23,6 +23,7 @@ import { Locations } from "../../Locations/Locations";
 import { CityName } from "../../Locations/data/CityNames";
 import { LocationName } from "../../Locations/data/LocationNames";
 import { Sleeve } from "../Sleeve/Sleeve";
+import { SleeveCompanyWork } from "../Sleeve/Work/SleeveCompanyWork";
 import {
   calculateSkill as calculateSkillF,
   calculateSkillProgress as calculateSkillProgressF,
@@ -592,6 +593,11 @@ export function getNextCompanyPosition(
 export function quitJob(this: IPlayer, company: string): void {
   if (isCompanyWork(this.currentWork) && this.currentWork.companyName === company) {
     this.finishWork(true);
+  }
+  for (const sleeve of this.sleeves) {
+    if (sleeve.currentWork instanceof SleeveCompanyWork && sleeve.currentWork.companyName === company){
+      sleeve.currentWork.finish(this);
+    }
   }
   delete this.jobs[company];
 }


### PR DESCRIPTION
Fixes #4051 

Also displays a dialog informing the player that they have caused one of their sleeves to idle.
![image](https://user-images.githubusercontent.com/84951833/187155674-972a9c08-c582-4563-b4f7-7773f4f2e7b6.png)
