### PR TITLE
SLEEVES: FIX #4063 fix crash when player tries to assign more than 3 sleeves to Bladeburner contracts

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -20,6 +20,8 @@ import { Company } from "../../Company/Company";
 import { CompanyPosition } from "../../Company/CompanyPosition";
 import { CompanyPositions } from "../../Company/CompanyPositions";
 
+import { Contracts } from "../../Bladeburner/data/Contracts";
+
 import { CONSTANTS } from "../../Constants";
 
 import { Faction } from "../../Faction/Faction";
@@ -447,11 +449,12 @@ export class Sleeve extends Person {
         this.startWork(p, new SleeveSupportWork(p));
         return true;
       case "Take on contracts":
+        if (!Contracts[contract]) return false;
         this.startWork(p, new SleeveBladeburnerWork({ type: "Contracts", name: contract }));
         return true;
     }
 
-    return true;
+    return false;
   }
 
   recruitmentSuccessChance(p: IPlayer): number {


### PR DESCRIPTION
Not sure if there was a better way to check if a provided contract type was valid.
Fixes #4063 