### PR TITLE
API: Corp functions now return copy of constant arrays instead of the original

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -873,20 +873,25 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
   return {
     ...warehouseAPI,
     ...officeAPI,
-    getMaterialNames: () => (): string[] => {
-      return CorporationConstants.AllMaterials;
+    getMaterialNames: (ctx: NetscriptContext) => (): string[] => {
+      checkAccess(ctx);
+      return [...CorporationConstants.AllMaterials];
     },
-    getIndustryTypes: () => (): string[] => {
-      return CorporationConstants.AllIndustryTypes;
+    getIndustryTypes: (ctx: NetscriptContext) => (): string[] => {
+      checkAccess(ctx);
+      return [...CorporationConstants.AllIndustryTypes];
     },
-    getUnlockables: () => (): string[] => {
-      return CorporationConstants.AllUnlocks;
+    getUnlockables: (ctx: NetscriptContext) => (): string[] => {
+      checkAccess(ctx);
+      return [...CorporationConstants.AllUnlocks];
     },
-    getUpgradeNames: () => (): string[] => {
-      return CorporationConstants.AllUpgrades;
+    getUpgradeNames: (ctx: NetscriptContext) => (): string[] => {
+      checkAccess(ctx);
+      return [...CorporationConstants.AllUpgrades];
     },
-    getResearchNames: () => (): string[] => {
-      return CorporationConstants.AllResearch;
+    getResearchNames: (ctx: NetscriptContext) => (): string[] => {
+      checkAccess(ctx);
+      return [...CorporationConstants.AllResearch];
     },
     expandIndustry:
       (ctx: NetscriptContext) =>


### PR DESCRIPTION
Corp functions `getMaterialNames`, `getIndustryTypes`, `getUnlockables`, `getUpgradeNames` and `getResearchNames` returned the original arrays, which if modified, modified the original array instead of just the returned array. This array could be used as a global variable and resets on prestige. Changed the functions to return copies of the original so that the arrays can be manipulated without affecting the original.