### PR TITLE
NETSCRIPT: FIX #2376 ns.exit now exits immediately

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -836,7 +836,7 @@ const base: InternalAPI<NS> = {
     },
   exit: (ctx: NetscriptContext) => (): never => {
     helpers.log(ctx, () => "Exiting...");
-    ctx.workerScript.env.stopFlag = true;
+    killWorkerScript(ctx.workerScript);
     throw new ScriptDeath(ctx.workerScript);
   },
   scp:

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -79,6 +79,7 @@ import { CalculateShareMult, StartSharing } from "./NetworkShare/Share";
 import { recentScripts } from "./Netscript/RecentScripts";
 import { InternalAPI, NetscriptContext, wrapAPI } from "./Netscript/APIWrapper";
 import { INetscriptExtra } from "./NetscriptFunctions/Extra";
+import { ScriptDeath } from "./Netscript/ScriptDeath";
 
 export type NSFull = NS & INetscriptExtra;
 
@@ -833,12 +834,10 @@ const base: InternalAPI<NS> = {
 
       return scriptsKilled > 0;
     },
-  exit: (ctx: NetscriptContext) => (): void => {
-    if (killWorkerScript(ctx.workerScript)) {
-      helpers.log(ctx, () => "Exiting...");
-    } else {
-      helpers.log(ctx, () => "Failed. This is a bug. Report to dev.");
-    }
+  exit: (ctx: NetscriptContext) => (): never => {
+    helpers.log(ctx, () => "Exiting...");
+    ctx.workerScript.env.stopFlag = true;
+    throw new ScriptDeath(ctx.workerScript);
   },
   scp:
     (ctx: NetscriptContext) =>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5424,7 +5424,7 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    */
-  exit(): void;
+  exit(): never;
 
   /**
    * Copy file between servers.


### PR DESCRIPTION
Fixes #2376

If multiple async contexts are running simultaneously in the same script, the other contexts will not be immediately exited (limitation of js) but they will still fail as soon as they hit an ns function. The current execution context is immediately ended due to the throw (unless a try block is used).


Here is the test script used to verify operation.
```js
export let main=async ns=>{
  ns.exit();
  console.log("Does this run?"); //No, it does not
}
```