### PR TITLE
API: More ports (previously max 20, now practically unlimited)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -124,7 +124,7 @@ export const CONSTANTS: {
   // NeuroFlux Governor Augmentation cost multiplier
   NeuroFluxGovernorLevelMult: 1.14,
 
-  NumNetscriptPorts: Infinity,
+  NumNetscriptPorts: Number.MAX_SAFE_INTEGER,
 
   // Server-related constants
   HomeComputerMaxRam: 1073741824, // 2 ^ 30

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -124,7 +124,7 @@ export const CONSTANTS: {
   // NeuroFlux Governor Augmentation cost multiplier
   NeuroFluxGovernorLevelMult: 1.14,
 
-  NumNetscriptPorts: 20,
+  NumNetscriptPorts: Infinity,
 
   // Server-related constants
   HomeComputerMaxRam: 1073741824, // 2 ^ 30

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -613,7 +613,7 @@ function getRunningScriptByArgs(
     throw helpers.makeRuntimeRejectMsg(
       ctx.workerScript,
       `Invalid scriptArgs argument passed into getRunningScript() from ${ctx.function}(). ` +
-      `This is probably a bug. Please report to game developer`,
+        `This is probably a bug. Please report to game developer`,
     );
   }
 

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -20,7 +20,7 @@ import { convertTimeMsToTimeElapsedString } from "../utils/StringHelperFunctions
 import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
 import { CONSTANTS } from "../Constants";
 import { influenceStockThroughServerHack } from "../StockMarket/PlayerInfluencing";
-import { IPort } from "../NetscriptPort";
+import { IPort, NetscriptPort } from "../NetscriptPort";
 import { NetscriptPorts } from "../NetscriptWorker";
 import { IPlayer } from "../PersonObjects/IPlayer";
 import { FormulaGang } from "../Gang/formulas/formulas";
@@ -492,10 +492,16 @@ function getValidPort(ctx: NetscriptContext, port: number): IPort {
       `Trying to use an invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
     );
   }
-  const iport = NetscriptPorts[port - 1];
+  let iport = NetscriptPorts.get(port);
   if (iport == null || !(iport instanceof Object)) {
-    throw makeRuntimeErrorMsg(ctx, `Could not find port: ${port}. This is a bug. Report to dev.`);
+    NetscriptPorts.set(port, NetscriptPort());
   }
+  // Try again.
+  iport = NetscriptPorts.get(port);
+  if (iport == null || !(iport instanceof Object)) {
+    throw helpers.makeRuntimeErrorMsg(ctx, `Could not find port: ${port}. This is a bug. Report to dev.`);
+  }
+
   return iport;
 }
 
@@ -607,7 +613,7 @@ function getRunningScriptByArgs(
     throw helpers.makeRuntimeRejectMsg(
       ctx.workerScript,
       `Invalid scriptArgs argument passed into getRunningScript() from ${ctx.function}(). ` +
-        `This is probably a bug. Please report to game developer`,
+      `This is probably a bug. Please report to game developer`,
     );
   }
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -54,7 +54,7 @@ import { NetscriptCorporation } from "./NetscriptFunctions/Corporation";
 import { NetscriptFormulas } from "./NetscriptFunctions/Formulas";
 import { NetscriptStockMarket } from "./NetscriptFunctions/StockMarket";
 import { NetscriptGrafting } from "./NetscriptFunctions/Grafting";
-import { IPort } from "./NetscriptPort";
+import { NetscriptPort, IPort } from "./NetscriptPort";
 import {
   NS,
   Player as INetscriptPlayer,
@@ -1533,7 +1533,12 @@ const base: InternalAPI<NS> = {
             `Invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
           );
         }
-        const iport = NetscriptPorts[port - 1];
+        let iport = NetscriptPorts.get(port);
+        if (iport == null || !(iport instanceof Object)) {
+          NetscriptPorts.set(port, NetscriptPort());
+        }
+        // Try again.
+        iport = NetscriptPorts.get(port);
         if (iport == null || !(iport instanceof Object)) {
           throw helpers.makeRuntimeErrorMsg(ctx, `Could not find port: ${port}. This is a bug. Report to dev.`);
         }

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1518,34 +1518,15 @@ const base: InternalAPI<NS> = {
   tryWritePort:
     (ctx: NetscriptContext) =>
     (_port: unknown, data: unknown = ""): Promise<any> => {
-      let port = helpers.number(ctx, "port", _port);
+      const port = helpers.number(ctx, "port", _port);
       if (typeof data !== "string" && typeof data !== "number") {
         throw helpers.makeRuntimeErrorMsg(
           ctx,
           `Trying to write invalid data to a port: only strings and numbers are valid.`,
         );
       }
-      if (!isNaN(port)) {
-        port = Math.round(port);
-        if (port < 1 || port > CONSTANTS.NumNetscriptPorts) {
-          throw helpers.makeRuntimeErrorMsg(
-            ctx,
-            `Invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
-          );
-        }
-        let iport = NetscriptPorts.get(port);
-        if (iport == null || !(iport instanceof Object)) {
-          NetscriptPorts.set(port, NetscriptPort());
-        }
-        // Try again.
-        iport = NetscriptPorts.get(port);
-        if (iport == null || !(iport instanceof Object)) {
-          throw helpers.makeRuntimeErrorMsg(ctx, `Could not find port: ${port}. This is a bug. Report to dev.`);
-        }
-        return Promise.resolve(iport.tryWrite(data));
-      } else {
-        throw helpers.makeRuntimeErrorMsg(ctx, `Invalid argument: ${port}`);
-      }
+      const iport = helpers.getValidPort(ctx, port);
+      return Promise.resolve(iport.tryWrite(data));
     },
   readPort:
     (ctx: NetscriptContext) =>

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -31,7 +31,7 @@ import { Server } from "./Server/Server";
 import { influenceStockThroughServerGrow } from "./StockMarket/PlayerInfluencing";
 import { isValidFilePath, removeLeadingSlash } from "./Terminal/DirectoryHelpers";
 import { TextFile, getTextFile, createTextFile } from "./TextFile";
-import { NetscriptPorts, runScriptFromScript } from "./NetscriptWorker";
+import { runScriptFromScript } from "./NetscriptWorker";
 import { killWorkerScript } from "./Netscript/killWorkerScript";
 import { workerScripts } from "./Netscript/WorkerScripts";
 import { WorkerScript } from "./Netscript/WorkerScript";
@@ -54,7 +54,7 @@ import { NetscriptCorporation } from "./NetscriptFunctions/Corporation";
 import { NetscriptFormulas } from "./NetscriptFunctions/Formulas";
 import { NetscriptStockMarket } from "./NetscriptFunctions/StockMarket";
 import { NetscriptGrafting } from "./NetscriptFunctions/Grafting";
-import { NetscriptPort, IPort } from "./NetscriptPort";
+import { IPort } from "./NetscriptPort";
 import {
   NS,
   Player as INetscriptPlayer,

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -37,7 +37,6 @@ import { Terminal } from "./Terminal";
 import { ScriptArg } from "./Netscript/ScriptArg";
 import { helpers } from "./Netscript/NetscriptHelpers";
 
-// Netscript Ports are instantiated here
 export const NetscriptPorts: Map<number, IPort> = new Map();
 
 export function prestigeWorkerScripts(): void {

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -13,7 +13,7 @@ import { CONSTANTS } from "./Constants";
 import { Interpreter } from "./ThirdParty/JSInterpreter";
 import { NetscriptFunctions } from "./NetscriptFunctions";
 import { executeJSScript, Node } from "./NetscriptJSEvaluator";
-import { NetscriptPort, IPort } from "./NetscriptPort";
+import { IPort } from "./NetscriptPort";
 import { RunningScript } from "./Script/RunningScript";
 import { getRamUsageFromRunningScript } from "./Script/RunningScriptHelpers";
 import { scriptCalculateOfflineProduction } from "./Script/ScriptHelpers";
@@ -38,17 +38,15 @@ import { ScriptArg } from "./Netscript/ScriptArg";
 import { helpers } from "./Netscript/NetscriptHelpers";
 
 // Netscript Ports are instantiated here
-export const NetscriptPorts: IPort[] = [];
-for (let i = 0; i < CONSTANTS.NumNetscriptPorts; ++i) {
-  NetscriptPorts.push(NetscriptPort());
-}
+export const NetscriptPorts: Map<number, IPort> = new Map();
 
 export function prestigeWorkerScripts(): void {
   for (const ws of workerScripts.values()) {
     ws.env.stopFlag = true;
     killWorkerScript(ws);
   }
-  for (const port of NetscriptPorts) {
+    
+  for (const [__, port] of NetscriptPorts.entries()) {
     port.clear();
   }
 

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -45,7 +45,7 @@ export function prestigeWorkerScripts(): void {
     ws.env.stopFlag = true;
     killWorkerScript(ws);
   }
-    
+
   for (const [__, port] of NetscriptPorts.entries()) {
     port.clear();
   }


### PR DESCRIPTION
# API: More ports (previously max 20, now practically unlimited)

Lets ports be created on-demand instead of always initializing all ports.
Also bump the maximum number up to the safe maximum.

- Formatted
- Linted
- Tested with:

```js
/** @param {NS} ns */
export async function main(ns) {
//works
	await ns.writePort(1.5, "Hello!");
	ns.tprint(ns.readPort(1.5));
//error, over the max limit
	await ns.writePort(Infinity, "Hello again!");
	ns.tprint(ns.getPortHandle(Infinity).peek())
//works
	await ns.writePort(1e103, "Big number");
	ns.tprint(ns.readPort(1e103));
//error, under limit
	await ns.writePort(0, "Hello again!");
	ns.tprint(ns.getPortHandle(0).peek())
}
```

