### PR TITLE
SCRIPTS: FIX #4081 Rerunning a script from tail window recalculates ram usage

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -393,10 +393,9 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
   const ramAvailable = server.maxRam - server.ramUsed;
   if (ramUsage > ramAvailable + 0.001) {
     dialogBoxCreate(
-      `Not enough RAM to run script ${runningScriptObj.filename} with args ` +
-        `${arrayToString(runningScriptObj.args)}. This likely occurred because you re-loaded ` +
-        `the game and the script's RAM usage increased (either because of an update to the game or ` +
-        `your changes to the script.)`,
+      `Not enough RAM to run script ${runningScriptObj.filename} with args ${arrayToString(runningScriptObj.args)}.\n` +
+        `This can occur when you reload the game and the script's RAM usage has increased (either because of an update to the game or ` +
+        `your changes to the script).\nThis can also occur if you have attempted to launched a script from a tail window with insufficient RAM. `,
     );
     return false;
   }

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -395,7 +395,7 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
     dialogBoxCreate(
       `Not enough RAM to run script ${runningScriptObj.filename} with args ${arrayToString(runningScriptObj.args)}.\n` +
         `This can occur when you reload the game and the script's RAM usage has increased (either because of an update to the game or ` +
-        `your changes to the script).\nThis can also occur if you have attempted to launched a script from a tail window with insufficient RAM. `,
+        `your changes to the script).\nThis can also occur if you have attempted to launch a script from a tail window with insufficient RAM. `,
     );
     return false;
   }

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -213,6 +213,7 @@ function LogWindow(props: IProps): React.ReactElement {
     if (server === null) return;
     const s = findRunningScript(script.filename, script.args, server);
     if (s === null) {
+      script.ramUsage = 0;
       startWorkerScript(script, server);
     } else {
       setScript(s);


### PR DESCRIPTION
Fixes #4081 

Previously the run button on a tail window was always using the cached ram calculation for the script from the first time the log box was spawned, due to the runningScript being the same object and this line from RunningScriptHelpers.ts:

https://github.com/danielyxie/bitburner/blob/2592c6ccd89d5559c9cc3cdf99416eb1c57edca2/src/Script/RunningScriptHelpers.ts#L4-L7

Now rerunning a script using the run button will force a cost recalculation by resetting the ramUsage to 0 before relaunching, which disables this caching behavior.

Here is a test on current dev branch:

![BrokenAttemptToRunScriptFromTail](https://user-images.githubusercontent.com/84951833/188449077-b848b1bd-d848-427f-b940-39902b3ea120.png)

And here is the fixed result from this PR:

![FixedAttemptToRunScriptFromTail](https://user-images.githubusercontent.com/84951833/188449213-47945eda-7ce0-4f4c-9829-f6edf89e07e9.png)
