### PR TITLE
UI: Split money earned into income and expenses

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -635,10 +635,7 @@ export const achievements: IMap<Achievement> = {
     ...achievementData["CHALLENGE_BN9"],
     Icon: "BN9+",
     Visible: () => hasAccessToSF(Player, 9),
-    Condition: () =>
-      Player.bitNodeN === 9 &&
-      bitNodeFinishedState() &&
-      !Player.moneySourceB.hasAnythingFrom("hacknet"),
+    Condition: () => Player.bitNodeN === 9 && bitNodeFinishedState() && !Player.moneySourceB.hasAnythingFrom("hacknet"),
   },
   CHALLENGE_BN10: {
     ...achievementData["CHALLENGE_BN10"],

--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -328,7 +328,7 @@ export const achievements: IMap<Achievement> = {
   STOCK_1q: {
     ...achievementData["STOCK_1q"],
     Icon: "$1Q",
-    Condition: () => Player.moneySourceB.stock >= 1e15,
+    Condition: () => Player.moneySourceB.getTotal("stock") >= 1e15,
   },
   DISCOUNT: {
     ...achievementData["DISCOUNT"],
@@ -374,7 +374,7 @@ export const achievements: IMap<Achievement> = {
   HACKNET_NODE_10M: {
     ...achievementData["HACKNET_NODE_10M"],
     Icon: "hacknet-10m",
-    Condition: () => !hasHacknetServers(Player) && Player.moneySourceB.hacknet >= 10e6,
+    Condition: () => !hasHacknetServers(Player) && Player.moneySourceB.getIncome("hacknet") >= 10e6,
   },
   REPUTATION_10M: {
     ...achievementData["REPUTATION_10M"],
@@ -407,7 +407,7 @@ export const achievements: IMap<Achievement> = {
   HOSPITALIZED: {
     ...achievementData["HOSPITALIZED"],
     Icon: "OUCH",
-    Condition: () => Player.moneySourceB.hospitalization !== 0,
+    Condition: () => Player.moneySourceB.getExpenses("hospitalization") !== 0,
   },
   GANG: {
     ...achievementData["GANG"],
@@ -551,7 +551,7 @@ export const achievements: IMap<Achievement> = {
     ...achievementData["HACKNET_SERVER_1B"],
     Icon: "HASHNETMONEY",
     Visible: () => hasAccessToSF(Player, 9),
-    Condition: () => hasHacknetServers(Player) && Player.moneySourceB.hacknet >= 1e9,
+    Condition: () => hasHacknetServers(Player) && Player.moneySourceB.getIncome("hacknet") >= 1e9,
     AdditionalUnlock: [achievementData.HACKNET_NODE_10M.ID],
   },
   MAX_CACHE: {
@@ -638,8 +638,7 @@ export const achievements: IMap<Achievement> = {
     Condition: () =>
       Player.bitNodeN === 9 &&
       bitNodeFinishedState() &&
-      Player.moneySourceB.hacknet === 0 &&
-      Player.moneySourceB.hacknet_expenses === 0,
+      !Player.moneySourceB.hasAnythingFrom("hacknet"),
   },
   CHALLENGE_BN10: {
     ...achievementData["CHALLENGE_BN10"],

--- a/src/Hacknet/HacknetHelpers.tsx
+++ b/src/Hacknet/HacknetHelpers.tsx
@@ -49,7 +49,7 @@ export function purchaseHacknet(player: IPlayer): number {
     if (!player.canAfford(cost) || numOwned >= HacknetServerConstants.MaxServers) {
       return -1;
     }
-    player.loseMoney(cost, "hacknet_expenses");
+    player.loseMoney(cost, "hacknet");
     player.createHacknetServer();
     updateHashManagerCapacity(player);
 
@@ -68,7 +68,7 @@ export function purchaseHacknet(player: IPlayer): number {
     const name = "hacknet-node-" + numOwned;
     const node = new HacknetNode(name, player.mults.hacknet_node_money);
 
-    player.loseMoney(cost, "hacknet_expenses");
+    player.loseMoney(cost, "hacknet");
     player.hacknetNodes.push(node);
 
     return numOwned;
@@ -265,7 +265,7 @@ export function purchaseLevelUpgrade(player: IPlayer, node: HacknetNode | Hackne
     return false;
   }
 
-  player.loseMoney(cost, "hacknet_expenses");
+  player.loseMoney(cost, "hacknet");
   node.upgradeLevel(sanitizedLevels, player.mults.hacknet_node_money);
 
   return true;
@@ -304,7 +304,7 @@ export function purchaseRamUpgrade(player: IPlayer, node: HacknetNode | HacknetS
     return false;
   }
 
-  player.loseMoney(cost, "hacknet_expenses");
+  player.loseMoney(cost, "hacknet");
   node.upgradeRam(sanitizedLevels, player.mults.hacknet_node_money);
 
   return true;
@@ -335,7 +335,7 @@ export function purchaseCoreUpgrade(player: IPlayer, node: HacknetNode | Hacknet
     return false;
   }
 
-  player.loseMoney(cost, "hacknet_expenses");
+  player.loseMoney(cost, "hacknet");
   node.upgradeCore(sanitizedLevels, player.mults.hacknet_node_money);
 
   return true;
@@ -363,7 +363,7 @@ export function purchaseCacheUpgrade(player: IPlayer, node: HacknetServer, level
     return false;
   }
 
-  player.loseMoney(cost, "hacknet_expenses");
+  player.loseMoney(cost, "hacknet");
   node.upgradeCache(sanitizedLevels);
 
   return true;

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -1447,7 +1447,7 @@ export function getIntelligenceBonus(this: IPlayer, weight: number): number {
 }
 
 export function getCasinoWinnings(this: IPlayer): number {
-  return this.moneySourceA.casino;
+  return this.moneySourceA.getTotal("casino");
 }
 
 export function canAccessCotMG(this: IPlayer): boolean {

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -166,6 +166,9 @@ export function prestigeAugmentation(): void {
 
   staneksGift.prestigeAugmentation();
 
+  Player.moneySourceA.record(Player.money, "starting");
+  Player.moneySourceB.record(Player.money, "starting");
+
   resetPidCounter();
   ProgramsSeen.splice(0, ProgramsSeen.length);
   InvitationsSeen.splice(0, InvitationsSeen.length);
@@ -306,6 +309,9 @@ export function prestigeSourceFile(flume: boolean): void {
     Player.money = CONSTANTS.TravelCost;
   }
   staneksGift.prestigeSourceFile();
+
+  Player.moneySourceA.record(Player.money, "starting");
+  Player.moneySourceB.record(Player.money, "starting");
 
   // Gain int exp
   if (Player.sourceFileLvl(5) !== 0 && !flume) Player.gainIntelligenceExp(300);

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -274,7 +274,7 @@ const Engine: {
       }
 
       let offlineReputation = 0;
-      const offlineHackingIncome = (Player.moneySourceA.hacking / Player.playtimeSinceLastAug) * timeOffline * 0.75;
+      const offlineHackingIncome = (Player.moneySourceA.getIncome("hacking") / Player.playtimeSinceLastAug) * timeOffline * 0.75;
       Player.gainMoney(offlineHackingIncome, "hacking");
       // Process offline progress
 

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -274,7 +274,8 @@ const Engine: {
       }
 
       let offlineReputation = 0;
-      const offlineHackingIncome = (Player.moneySourceA.getIncome("hacking") / Player.playtimeSinceLastAug) * timeOffline * 0.75;
+      const offlineHackingIncome =
+        (Player.moneySourceA.getIncome("hacking") / Player.playtimeSinceLastAug) * timeOffline * 0.75;
       Player.gainMoney(offlineHackingIncome, "hacking");
       // Process offline progress
 

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -115,61 +115,156 @@ function MoneyModal({ open, onClose }: IMoneyModalProps): React.ReactElement {
   function convertMoneySourceTrackerToString(src: MoneySourceTracker): React.ReactElement {
     const parts: [string, JSX.Element, JSX.Element, JSX.Element][] = [
       [``, <span>Income</span>, <span>Expenses</span>, <span>Total</span>],
-      [`Total:`, <Money money={src.getIncome("total") || ""} />, <Money money={-src.getExpenses("total") || ""} />, <Money money={src.getTotal("total") || ""} />]
+      [
+        `Total:`,
+        <Money money={src.getIncome("total") || ""} />,
+        <Money money={-src.getExpenses("total") || ""} />,
+        <Money money={src.getTotal("total") || ""} />,
+      ],
     ];
     if (src.hasAnythingFrom("augmentations")) {
-      parts.push([`Augmentations:`, <Money money={src.getIncome("augmentations") || ""} />, <Money money={-src.getExpenses("augmentations") || ""} />, <Money money={src.getTotal("augmentations") || ""} />]);
+      parts.push([
+        `Augmentations:`,
+        <Money money={src.getIncome("augmentations") || ""} />,
+        <Money money={-src.getExpenses("augmentations") || ""} />,
+        <Money money={src.getTotal("augmentations") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("bladeburner")) {
-      parts.push([`Bladeburner:`, <Money money={src.getIncome("bladeburner") || ""} />, <Money money={-src.getExpenses("bladeburner") || ""} />, <Money money={src.getTotal("bladeburner") || ""} />]);
+      parts.push([
+        `Bladeburner:`,
+        <Money money={src.getIncome("bladeburner") || ""} />,
+        <Money money={-src.getExpenses("bladeburner") || ""} />,
+        <Money money={src.getTotal("bladeburner") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("casino")) {
-      parts.push([`Casino:`, <Money money={src.getIncome("casino") || ""} />, <Money money={-src.getExpenses("casino") || ""} />, <Money money={src.getTotal("casino") || ""} />]);
+      parts.push([
+        `Casino:`,
+        <Money money={src.getIncome("casino") || ""} />,
+        <Money money={-src.getExpenses("casino") || ""} />,
+        <Money money={src.getTotal("casino") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("codingcontract")) {
-      parts.push([`Coding Contracts:`, <Money money={src.getIncome("codingcontract") || ""} />, <Money money={-src.getExpenses("codingcontract") || ""} />, <Money money={src.getTotal("codingcontract") || ""} />]);
+      parts.push([
+        `Coding Contracts:`,
+        <Money money={src.getIncome("codingcontract") || ""} />,
+        <Money money={-src.getExpenses("codingcontract") || ""} />,
+        <Money money={src.getTotal("codingcontract") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("work")) {
-      parts.push([`Company Work:`, <Money money={src.getIncome("work") || ""} />, <Money money={-src.getExpenses("work") || ""} />, <Money money={src.getTotal("work") || ""} />]);
+      parts.push([
+        `Company Work:`,
+        <Money money={src.getIncome("work") || ""} />,
+        <Money money={-src.getExpenses("work") || ""} />,
+        <Money money={src.getTotal("work") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("class")) {
-      parts.push([`Class:`, <Money money={src.getIncome("class") || ""} />, <Money money={-src.getExpenses("class") || ""} />, <Money money={src.getTotal("class") || ""} />]);
+      parts.push([
+        `Class:`,
+        <Money money={src.getIncome("class") || ""} />,
+        <Money money={-src.getExpenses("class") || ""} />,
+        <Money money={src.getTotal("class") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("corporation")) {
-      parts.push([`Corporation:`, <Money money={src.getIncome("corporation") || ""} />, <Money money={-src.getExpenses("corporation") || ""} />, <Money money={src.getTotal("corporation") || ""} />]);
+      parts.push([
+        `Corporation:`,
+        <Money money={src.getIncome("corporation") || ""} />,
+        <Money money={-src.getExpenses("corporation") || ""} />,
+        <Money money={src.getTotal("corporation") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("crime")) {
-      parts.push([`Crimes:`, <Money money={src.getIncome("crime") || ""} />, <Money money={-src.getExpenses("crime") || ""} />, <Money money={src.getTotal("crime") || ""} />]);
+      parts.push([
+        `Crimes:`,
+        <Money money={src.getIncome("crime") || ""} />,
+        <Money money={-src.getExpenses("crime") || ""} />,
+        <Money money={src.getTotal("crime") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("gang")) {
-      parts.push([`Gang:`, <Money money={src.getIncome("gang") || ""} />, <Money money={-src.getExpenses("gang") || ""} />, <Money money={src.getTotal("gang") || ""} />]);
+      parts.push([
+        `Gang:`,
+        <Money money={src.getIncome("gang") || ""} />,
+        <Money money={-src.getExpenses("gang") || ""} />,
+        <Money money={src.getTotal("gang") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("hacking")) {
-      parts.push([`Hacking:`, <Money money={src.getIncome("hacking") || ""} />, <Money money={-src.getExpenses("hacking") || ""} />, <Money money={src.getTotal("hacking") || ""} />]);
+      parts.push([
+        `Hacking:`,
+        <Money money={src.getIncome("hacking") || ""} />,
+        <Money money={-src.getExpenses("hacking") || ""} />,
+        <Money money={src.getTotal("hacking") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("hacknet")) {
-      parts.push([`Hacknet Nodes:`, <Money money={src.getIncome("hacknet") || ""} />, <Money money={-src.getExpenses("hacknet") || ""} />, <Money money={src.getTotal("hacknet") || ""} />]);
+      parts.push([
+        `Hacknet Nodes:`,
+        <Money money={src.getIncome("hacknet") || ""} />,
+        <Money money={-src.getExpenses("hacknet") || ""} />,
+        <Money money={src.getTotal("hacknet") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("hospitalization")) {
-      parts.push([`Hospitalization:`, <Money money={src.getIncome("hospitalization") || ""} />, <Money money={-src.getExpenses("hospitalization") || ""} />, <Money money={src.getTotal("hospitalization") || ""} />]);
+      parts.push([
+        `Hospitalization:`,
+        <Money money={src.getIncome("hospitalization") || ""} />,
+        <Money money={-src.getExpenses("hospitalization") || ""} />,
+        <Money money={src.getTotal("hospitalization") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("infiltration")) {
-      parts.push([`Infiltration:`, <Money money={src.getIncome("infiltration") || ""} />, <Money money={-src.getExpenses("infiltration") || ""} />, <Money money={src.getTotal("infiltration") || ""} />]);
+      parts.push([
+        `Infiltration:`,
+        <Money money={src.getIncome("infiltration") || ""} />,
+        <Money money={-src.getExpenses("infiltration") || ""} />,
+        <Money money={src.getTotal("infiltration") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("servers")) {
-      parts.push([`Servers:`, <Money money={src.getIncome("servers") || ""} />, <Money money={-src.getExpenses("servers") || ""} />, <Money money={src.getTotal("servers") || ""} />]);
+      parts.push([
+        `Servers:`,
+        <Money money={src.getIncome("servers") || ""} />,
+        <Money money={-src.getExpenses("servers") || ""} />,
+        <Money money={src.getTotal("servers") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("starting")) {
-      parts.push([`Starting Money:`, <Money money={src.getIncome("starting") || ""} />, <Money money={-src.getExpenses("starting") || ""} />, <Money money={src.getTotal("starting") || ""} />]);
+      parts.push([
+        `Starting Money:`,
+        <Money money={src.getIncome("starting") || ""} />,
+        <Money money={-src.getExpenses("starting") || ""} />,
+        <Money money={src.getTotal("starting") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("stock")) {
-      parts.push([`Stock Market:`, <Money money={src.getIncome("stock") || ""} />, <Money money={-src.getExpenses("stock") || ""} />, <Money money={src.getTotal("stock") || ""} />]);
+      parts.push([
+        `Stock Market:`,
+        <Money money={src.getIncome("stock") || ""} />,
+        <Money money={-src.getExpenses("stock") || ""} />,
+        <Money money={src.getTotal("stock") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("sleeves")) {
-      parts.push([`Sleeves:`, <Money money={src.getIncome("sleeves") || ""} />, <Money money={-src.getExpenses("sleeves") || ""} />, <Money money={src.getTotal("sleeves") || ""} />]);
+      parts.push([
+        `Sleeves:`,
+        <Money money={src.getIncome("sleeves") || ""} />,
+        <Money money={-src.getExpenses("sleeves") || ""} />,
+        <Money money={src.getTotal("sleeves") || ""} />,
+      ]);
     }
     if (src.hasAnythingFrom("other")) {
-      parts.push([`Other:`, <Money money={src.getIncome("other") || ""} />, <Money money={-src.getExpenses("other") || ""} />, <Money money={src.getTotal("other") || ""} />]);
+      parts.push([
+        `Other:`,
+        <Money money={src.getIncome("other") || ""} />,
+        <Money money={-src.getExpenses("other") || ""} />,
+        <Money money={src.getTotal("other") || ""} />,
+      ]);
     }
     return <StatsTable rows={parts} wide />;
   }

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -113,62 +113,64 @@ interface IMoneyModalProps {
 function MoneyModal({ open, onClose }: IMoneyModalProps): React.ReactElement {
   const player = use.Player();
   function convertMoneySourceTrackerToString(src: MoneySourceTracker): React.ReactElement {
-    const parts: [string, JSX.Element][] = [[`Total:`, <Money money={src.total} />]];
-    if (src.augmentations) {
-      parts.push([`Augmentations:`, <Money money={src.augmentations} />]);
+    const parts: [string, JSX.Element, JSX.Element, JSX.Element][] = [
+      [``, <span>Income</span>, <span>Expenses</span>, <span>Total</span>],
+      [`Total:`, <Money money={src.getIncome("total") || ""} />, <Money money={-src.getExpenses("total") || ""} />, <Money money={src.getTotal("total") || ""} />]
+    ];
+    if (src.hasAnythingFrom("augmentations")) {
+      parts.push([`Augmentations:`, <Money money={src.getIncome("augmentations") || ""} />, <Money money={-src.getExpenses("augmentations") || ""} />, <Money money={src.getTotal("augmentations") || ""} />]);
     }
-    if (src.bladeburner) {
-      parts.push([`Bladeburner:`, <Money money={src.bladeburner} />]);
+    if (src.hasAnythingFrom("bladeburner")) {
+      parts.push([`Bladeburner:`, <Money money={src.getIncome("bladeburner") || ""} />, <Money money={-src.getExpenses("bladeburner") || ""} />, <Money money={src.getTotal("bladeburner") || ""} />]);
     }
-    if (src.casino) {
-      parts.push([`Casino:`, <Money money={src.casino} />]);
+    if (src.hasAnythingFrom("casino")) {
+      parts.push([`Casino:`, <Money money={src.getIncome("casino") || ""} />, <Money money={-src.getExpenses("casino") || ""} />, <Money money={src.getTotal("casino") || ""} />]);
     }
-    if (src.codingcontract) {
-      parts.push([`Coding Contracts:`, <Money money={src.codingcontract} />]);
+    if (src.hasAnythingFrom("codingcontract")) {
+      parts.push([`Coding Contracts:`, <Money money={src.getIncome("codingcontract") || ""} />, <Money money={-src.getExpenses("codingcontract") || ""} />, <Money money={src.getTotal("codingcontract") || ""} />]);
     }
-    if (src.work) {
-      parts.push([`Company Work:`, <Money money={src.work} />]);
+    if (src.hasAnythingFrom("work")) {
+      parts.push([`Company Work:`, <Money money={src.getIncome("work") || ""} />, <Money money={-src.getExpenses("work") || ""} />, <Money money={src.getTotal("work") || ""} />]);
     }
-    if (src.class) {
-      parts.push([`Class:`, <Money money={src.class} />]);
+    if (src.hasAnythingFrom("class")) {
+      parts.push([`Class:`, <Money money={src.getIncome("class") || ""} />, <Money money={-src.getExpenses("class") || ""} />, <Money money={src.getTotal("class") || ""} />]);
     }
-    if (src.corporation) {
-      parts.push([`Corporation:`, <Money money={src.corporation} />]);
+    if (src.hasAnythingFrom("corporation")) {
+      parts.push([`Corporation:`, <Money money={src.getIncome("corporation") || ""} />, <Money money={-src.getExpenses("corporation") || ""} />, <Money money={src.getTotal("corporation") || ""} />]);
     }
-    if (src.crime) {
-      parts.push([`Crimes:`, <Money money={src.crime} />]);
+    if (src.hasAnythingFrom("crime")) {
+      parts.push([`Crimes:`, <Money money={src.getIncome("crime") || ""} />, <Money money={-src.getExpenses("crime") || ""} />, <Money money={src.getTotal("crime") || ""} />]);
     }
-    if (src.gang) {
-      parts.push([`Gang:`, <Money money={src.gang} />]);
+    if (src.hasAnythingFrom("gang")) {
+      parts.push([`Gang:`, <Money money={src.getIncome("gang") || ""} />, <Money money={-src.getExpenses("gang") || ""} />, <Money money={src.getTotal("gang") || ""} />]);
     }
-    if (src.hacking) {
-      parts.push([`Hacking:`, <Money money={src.hacking} />]);
+    if (src.hasAnythingFrom("hacking")) {
+      parts.push([`Hacking:`, <Money money={src.getIncome("hacking") || ""} />, <Money money={-src.getExpenses("hacking") || ""} />, <Money money={src.getTotal("hacking") || ""} />]);
     }
-    if (src.hacknet) {
-      parts.push([`Hacknet Nodes:`, <Money money={src.hacknet} />]);
+    if (src.hasAnythingFrom("hacknet")) {
+      parts.push([`Hacknet Nodes:`, <Money money={src.getIncome("hacknet") || ""} />, <Money money={-src.getExpenses("hacknet") || ""} />, <Money money={src.getTotal("hacknet") || ""} />]);
     }
-    if (src.hacknet_expenses) {
-      parts.push([`Hacknet Nodes Expenses:`, <Money money={src.hacknet_expenses} />]);
+    if (src.hasAnythingFrom("hospitalization")) {
+      parts.push([`Hospitalization:`, <Money money={src.getIncome("hospitalization") || ""} />, <Money money={-src.getExpenses("hospitalization") || ""} />, <Money money={src.getTotal("hospitalization") || ""} />]);
     }
-    if (src.hospitalization) {
-      parts.push([`Hospitalization:`, <Money money={src.hospitalization} />]);
+    if (src.hasAnythingFrom("infiltration")) {
+      parts.push([`Infiltration:`, <Money money={src.getIncome("infiltration") || ""} />, <Money money={-src.getExpenses("infiltration") || ""} />, <Money money={src.getTotal("infiltration") || ""} />]);
     }
-    if (src.infiltration) {
-      parts.push([`Infiltration:`, <Money money={src.infiltration} />]);
+    if (src.hasAnythingFrom("servers")) {
+      parts.push([`Servers:`, <Money money={src.getIncome("servers") || ""} />, <Money money={-src.getExpenses("servers") || ""} />, <Money money={src.getTotal("servers") || ""} />]);
     }
-    if (src.servers) {
-      parts.push([`Servers:`, <Money money={src.servers} />]);
+    if (src.hasAnythingFrom("starting")) {
+      parts.push([`Starting Money:`, <Money money={src.getIncome("starting") || ""} />, <Money money={-src.getExpenses("starting") || ""} />, <Money money={src.getTotal("starting") || ""} />]);
     }
-    if (src.stock) {
-      parts.push([`Stock Market:`, <Money money={src.stock} />]);
+    if (src.hasAnythingFrom("stock")) {
+      parts.push([`Stock Market:`, <Money money={src.getIncome("stock") || ""} />, <Money money={-src.getExpenses("stock") || ""} />, <Money money={src.getTotal("stock") || ""} />]);
     }
-    if (src.sleeves) {
-      parts.push([`Sleeves:`, <Money money={src.sleeves} />]);
+    if (src.hasAnythingFrom("sleeves")) {
+      parts.push([`Sleeves:`, <Money money={src.getIncome("sleeves") || ""} />, <Money money={-src.getExpenses("sleeves") || ""} />, <Money money={src.getTotal("sleeves") || ""} />]);
     }
-    if (src.other) {
-      parts.push([`Other:`, <Money money={src.other} />]);
+    if (src.hasAnythingFrom("other")) {
+      parts.push([`Other:`, <Money money={src.getIncome("other") || ""} />, <Money money={-src.getExpenses("other") || ""} />, <Money money={src.getTotal("other") || ""} />]);
     }
-
     return <StatsTable rows={parts} wide />;
   }
 

--- a/src/utils/MoneySourceTracker.ts
+++ b/src/utils/MoneySourceTracker.ts
@@ -19,8 +19,7 @@ export class MoneySourceTracker {
     if (amt > 0) {
       this.income[sanitizedSource] += amt;
       this.income.total += amt;
-    }
-    else {
+    } else {
       this.expenses[sanitizedSource] -= amt;
       this.expenses.total -= amt;
     }
@@ -39,7 +38,7 @@ export class MoneySourceTracker {
   hasAnythingFrom(source: string): boolean {
     const sanitizedSource = this.trySanitizeSource(source);
     if (sanitizedSource === "") return false;
-    return (this.income[sanitizedSource] > 0 || this.expenses[sanitizedSource] > 0);
+    return this.income[sanitizedSource] > 0 || this.expenses[sanitizedSource] > 0;
   }
 
   // Returns income for the source
@@ -55,7 +54,7 @@ export class MoneySourceTracker {
     if (sanitizedSource === "") return 0;
     return this.expenses[sanitizedSource];
   }
-  
+
   // Returns [income - expenses] for the source
   getTotal(source: string): number {
     const sanitizedSource = this.trySanitizeSource(source);
@@ -82,11 +81,9 @@ export class MoneySourceTracker {
       for (const name in value.data) {
         if (name == "hacknet_expenses") {
           ret.expenses["hacknet"] = -value.data[name];
-        }
-        else if (value.data[name] > 0) {
+        } else if (value.data[name] > 0) {
           ret.income[name] = value.data[name];
-        }
-        else if (value.data[name] < 0) {
+        } else if (value.data[name] < 0) {
           ret.expenses[name] = -value.data[name];
         }
       }
@@ -97,7 +94,7 @@ export class MoneySourceTracker {
 }
 
 class MoneySourceTrackerRecord {
-  [key: string]: number
+  [key: string]: number;
   starting = 0;
   bladeburner = 0;
   casino = 0;


### PR DESCRIPTION
Additionally: money the player starts with is also listed in that window; this should make the total always equal player's current money. "Hacknet expenses" category has been removed and merged into "hacknet nodes".

![изображение](https://user-images.githubusercontent.com/6681708/188509237-f2025843-1e16-479a-841c-39d98e1469b5.png)

Any stats gathered before this change will be converted; any positive number will be treated as income and any negative number will be treated as expenses. It's not going to be completely accurate until augment install/next bitnode, but won't cause any errors.