### PR TITLE
CORPORATION API: FIX #3655 Expose exports from Material

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -360,6 +360,9 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
         const materialName = helpers.string(ctx, "materialName", _materialName);
         const material = getMaterial(divisionName, cityName, materialName);
         const corporation = getCorporation();
+        const exports = material.exp.map((e) => {
+          return { div: e.ind, loc: e.city, amt: e.amt };
+        });
         return {
           cost: material.bCost,
           sCost: material.sCost,
@@ -370,6 +373,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
           cmp: corporation.unlockUpgrades[3] ? material.cmp : undefined,
           prod: material.prd,
           sell: material.sll,
+          exp: exports,
         };
       },
     getProduct:

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7211,10 +7211,25 @@ interface Material {
   prod: number;
   /** Amount of material sold */
   sell: number;
-  /** cost to buy material */
+  /** Cost to buy material */
   cost: number;
   /** Sell cost, can be "MP+5" */
   sCost: string | number;
+  /** Export orders */
+  exp: Export[];
+}
+
+/**
+ * Export order for a material
+ * @public
+ */
+interface Export {
+  /** Division the material is being exported to */
+  div: string;
+  /** City the material is being exported to */
+  loc: string;
+  /** Amount of material exported */
+  amt: string;
 }
 
 /**


### PR DESCRIPTION
fixes #3655

This adds a new field to Material, which is the list of export orders for that material. With this change it is now plausible to delete existing exports that scripts don't know about or have forgotten, among other things. The export array is appropriately copied so that modifying it will not update exports in the game.

Test script (does require an existing corporation with an export order somewhere):

``` js
/** @param {NS} ns */
export async function main(ns) {
    // Update with your own corporation's info
    var sourceDiv = "Del Rasmoh";
    var sourceCity = "Sector-12";
    var material = "Food";

    var originalMaterial = ns.corporation.getMaterial(sourceDiv, sourceCity, material);
    var originalExports = originalMaterial.exp.length;
    if (originalExports === 0) {
        ns.tprint("WARN: Please configure test to point to a division/city/material with one or more exports.");
        return;
    }

    var newMaterial = ns.corporation.getMaterial(sourceDiv, sourceCity, material);
    newMaterial.exp[0].amt = 1234567890;

    if (newMaterial.exp[0].amt === originalMaterial.exp[0].amt) {
        ns.tprint("ERROR: Original export state changed!");
        return;
    }

    ns.corporation.cancelExportMaterial(sourceDiv, sourceCity, originalMaterial.exp[0].div, originalMaterial.exp[0].loc, material, originalMaterial.exp[0].amt);
    newMaterial = ns.corporation.getMaterial(sourceDiv, sourceCity, material);

    if (newMaterial.exp.length !== originalExports - 1) {
        ns.tprint("ERROR: Did not successfully delete export");
        return;
    }

    ns.tprint("SUCCESS!");
}
```