### PR TITLE
API BACKUP: add singularity function for exporting game save back

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -205,6 +205,8 @@ const singularity = {
   installAugmentations: SF4Cost(RamCostConstants.ScriptSingularityFn3RamCost),
   isFocused: SF4Cost(0.1),
   setFocus: SF4Cost(0.1),
+  exportGame: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost / 2),
+  exportGameBonus: SF4Cost(RamCostConstants.ScriptSingularityFn1RamCost / 4),
   b1tflum3: SF4Cost(16),
   destroyW0r1dD43m0n: SF4Cost(32),
   getCurrentWork: SF4Cost(0.5),

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -53,6 +53,8 @@ import { CreateProgramWork, isCreateProgramWork } from "../Work/CreateProgramWor
 import { FactionWork } from "../Work/FactionWork";
 import { FactionWorkType } from "../Work/data/FactionWorkType";
 import { CompanyWork } from "../Work/CompanyWork";
+import { canGetBonus, onExport } from "../ExportBonus";
+import { saveObject } from "../SaveObject";
 
 export function NetscriptSingularity(): InternalAPI<ISingularity> {
   const getAugmentation = function (ctx: NetscriptContext, name: string): Augmentation {
@@ -1303,6 +1305,15 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     getCurrentWork: () => (): any | null => {
       if (!player.currentWork) return null;
       return player.currentWork.APICopy();
+    },
+    exportGame: (ctx: NetscriptContext) => (): void => {
+      helpers.checkSingularityAccess(ctx);
+      onExport(player);
+      return saveObject.exportGame();
+    },
+    exportGameBonus: (ctx: NetscriptContext) => (): boolean => {
+      helpers.checkSingularityAccess(ctx);
+      return canGetBonus();
     },
   };
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1497,6 +1497,28 @@ export interface TIX {
  */
 export interface Singularity {
   /**
+   * Backup game save.
+   * @remarks
+   * RAM cost: 1 GB * 16/4/1
+   *
+   *
+   * This function will automatically opens the backup save prompt and claim the free faction favour if available.
+   *
+   */
+  exportGame(): void;
+
+  /**
+   * Returns Backup save bonus availability.
+   * @remarks
+   * RAM cost: 0.5 GB * 16/4/1
+   *
+   *
+   * This function will check if there is a bonus for backing up your save.
+   *
+   */
+  exportGameBonus(): boolean;
+
+  /**
    * Take university class.
    *
    * @remarks


### PR DESCRIPTION
At some point the functionality was removed (https://github.com/danielyxie/bitburner/pull/2845)

This pr just adds these two api functions back assuming they were lost on a conflict or refactor
