### PR TITLE
UI: Removed three empty lines from BB status screen

### DIFF
--- a/src/Bladeburner/ui/Stats.tsx
+++ b/src/Bladeburner/ui/Stats.tsx
@@ -94,7 +94,6 @@ export function Stats(props: IProps): React.ReactElement {
             </Typography>
           </Tooltip>
         </Box>
-        <br />
         <Typography>
           Stamina Penalty: {formatNumber((1 - props.bladeburner.calculateStaminaPenalty()) * 100, 1)}%
         </Typography>
@@ -122,7 +121,6 @@ export function Stats(props: IProps): React.ReactElement {
             </Typography>
           </Tooltip>
         </Box>
-        <br />
         <Box display="flex">
           <Tooltip
             title={
@@ -134,7 +132,6 @@ export function Stats(props: IProps): React.ReactElement {
             <Typography>Synthoid Communities: {formatNumber(props.bladeburner.getCurrentCity().comms, 0)}</Typography>
           </Tooltip>
         </Box>
-        <br />
         <Box display="flex">
           <Tooltip
             title={


### PR DESCRIPTION
A very minor thing! But some browsers (steam version included) render them as huge gaps, and it makes the status screen uncomfortably long. This change removes the lines between stamina and stamina penalty; between synthoid population and synthoid communities; and between synthoid communities and city chaos. The first removal creates a block with stamina information, and the second and the third create a block with city information, so the lines go together in a way that makes sense.

![image](https://user-images.githubusercontent.com/6681708/188855826-e2456452-f02d-47a9-8c5b-23c7ef21be5e.png)
