### PR TITLE
SLEEVES: FIX #3819 Allow using the regeneration chamber with sleeves to heal them.

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -440,6 +440,9 @@ export class Sleeve extends Person {
       case "Diplomacy":
         this.startWork(p, new SleeveBladeburnerWork({ type: "General", name: "Diplomacy" }));
         return true;
+      case "Hyperbolic Regeneration Chamber":
+        this.startWork(p, new SleeveBladeburnerWork({ type: "General", name: "Hyperbolic Regeneration Chamber" }));
+        return true;
       case "Infiltrate synthoids":
         this.startWork(p, new SleeveInfiltrateWork());
         return true;

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -159,6 +159,7 @@ export class Sleeve extends Person {
     this.exp.agility = 0;
     this.exp.charisma = 0;
     this.updateStatLevels();
+    this.hp.current = this.hp.max;
 
     // Reset task-related stuff
     this.stopWork(p);

--- a/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
+++ b/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
@@ -35,6 +35,7 @@ const bladeburnerSelectorOptions: string[] = [
   "Field analysis",
   "Recruitment",
   "Diplomacy",
+  "Hyperbolic Regeneration Chamber",
   "Infiltrate synthoids",
   "Support main sleeve",
   "Take on contracts",
@@ -285,6 +286,8 @@ function getABC(sleeve: Sleeve): [string, string, string] {
         return ["Perform Bladeburner Actions", "Diplomacy", "------"];
       case "Recruitment":
         return ["Perform Bladeburner Actions", "Recruitment", "------"];
+      case: "Hyperbolic Regeneration Chamber":
+        return ["Perform Bladeburner Actions", "Hyperbolic Regeneration Chamber", "------"];
     }
   }
 

--- a/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
+++ b/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
@@ -286,7 +286,7 @@ function getABC(sleeve: Sleeve): [string, string, string] {
         return ["Perform Bladeburner Actions", "Diplomacy", "------"];
       case "Recruitment":
         return ["Perform Bladeburner Actions", "Recruitment", "------"];
-      case: "Hyperbolic Regeneration Chamber":
+      case "Hyperbolic Regeneration Chamber":
         return ["Perform Bladeburner Actions", "Hyperbolic Regeneration Chamber", "------"];
     }
   }


### PR DESCRIPTION
This also allows using sleeves to generate stamina faster even if at full HP and resets them to full HP when starting a new bitnode.

Fixes #3819.
