### PR TITLE
UI: Bitnode stats now show if BB/Corporation are disabled

### DIFF
--- a/src/Augmentation/ui/PlayerMultipliers.tsx
+++ b/src/Augmentation/ui/PlayerMultipliers.tsx
@@ -252,7 +252,7 @@ export function PlayerMultipliers(): React.ReactElement {
     },
   ];
 
-  if (Player.canAccessBladeburner()) {
+  if (Player.canAccessBladeburner() && BitNodeMultipliers.BladeburnerRank > 0) {
     rightColData.push(
       {
         mult: "Bladeburner Success Chance",

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -655,6 +655,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
     }
     case 8: {
       return Object.assign(mults, {
+        BladeburnerRank: 0,
         ScriptHackMoney: 0.3,
         ScriptHackMoneyGain: 0,
         ManualHackMoney: 0,

--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -280,6 +280,14 @@ function BladeburnerMults({ mults }: IMultsProps): React.ReactElement {
   const player = use.Player();
   if (!player.canAccessBladeburner()) return <></>;
 
+  if (mults.BladeburnerRank == 0) {
+    const rows: IBNMultRows = {
+      BladeburnerRank: { name: "Disabled", content: "" },
+    };
+
+    return <BNMultTable sectionName="Bladeburner" rowData={rows} mults={mults} />;
+  }
+
   const rows: IBNMultRows = {
     BladeburnerRank: { name: "Rank Gain" },
     BladeburnerSkillCost: { name: "Skill Cost" },
@@ -322,6 +330,17 @@ function GangMults({ mults }: IMultsProps): React.ReactElement {
 function CorporationMults({ mults }: IMultsProps): React.ReactElement {
   const player = use.Player();
   if (!player.canAccessCorporation()) return <></>;
+
+  if (mults.CorporationSoftcap < 0.15) {
+    const rows: IBNMultRows = {
+      CorporationSoftcap: {
+        name: "Disabled",
+        content: "",
+      },
+    };
+
+    return <BNMultTable sectionName="Corporation" rowData={rows} mults={mults} />;
+  }
 
   const rows: IBNMultRows = {
     CorporationSoftcap: {

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -83,7 +83,7 @@ export function SpecialLocation(props: IProps): React.ReactElement {
   }
 
   function renderBladeburner(): React.ReactElement {
-    if (!player.canAccessBladeburner()) {
+    if (!player.canAccessBladeburner() || BitNodeMultipliers.BladeburnerRank == 0) {
       return <></>;
     }
     const text = inBladeburner ? "Enter Bladeburner Headquarters" : "Apply to Bladeburner Division";

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -397,8 +397,8 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     },
     joinBladeburnerDivision: (ctx: NetscriptContext) => (): boolean => {
       if (player.bitNodeN === 7 || player.sourceFileLvl(7) > 0) {
-        if (player.bitNodeN === 8) {
-          return false;
+        if (BitNodeMultipliers.BladeburnerRank == 0) {
+          return false; // Disabled in this bitnode
         }
         if (player.bladeburner instanceof Bladeburner) {
           return true; // Already member

--- a/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
@@ -2,10 +2,6 @@ import { Bladeburner } from "../../Bladeburner/Bladeburner";
 import { IPlayer } from "../IPlayer";
 
 export function canAccessBladeburner(this: IPlayer): boolean {
-  if (this.bitNodeN === 8) {
-    return false;
-  }
-
   return this.bitNodeN === 6 || this.bitNodeN === 7 || this.sourceFileLvl(6) > 0 || this.sourceFileLvl(7) > 0;
 }
 

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -532,7 +532,7 @@ export function CharacterStats(): React.ReactElement {
               ]}
               color={Settings.theme.combat}
             />
-            {player.canAccessBladeburner() && (
+            {player.canAccessBladeburner() && BitNodeMultipliers.BladeburnerRank > 0 && (
               <MultiplierTable
                 rows={[
                   {


### PR DESCRIPTION
BN8 used to be hardcoded to disable bladeburner; this is now tied to `BitNodeMultipliers.BladeburnerRank` being set to 0. No other bitnode uses it at the moment.

If a bitnode has bladeburner disabled (because of the check above), it will be shown in the stats as such. Similarly, if corporations are disabled (which happens when CorporationSoftcap is less than 0.15), it will also be shown.

BN8 stats:

![изображение](https://user-images.githubusercontent.com/6681708/189686107-af31cbc1-13fe-418d-baaf-266ed6b7e1f7.png)
