### PR TITLE
Fix for #2442, allowing going forward in tutorial

### DIFF
--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -624,7 +624,7 @@ export function InteractiveTutorialRoot(): React.ReactElement {
                 <ArrowBackIos />
               </IconButton>
             )}
-            {content.canNext && (
+            {(content.canNext || ITutorial.stepIsDone[step]) && (
               <IconButton onClick={iTutorialNextStep} aria-label="next">
                 <ArrowForwardIos />
               </IconButton>


### PR DESCRIPTION
Fixes #2442.
The code now shows the forward arrow inside the interactive tutorial, if the step was completed before. This prevents being hard stuck inside the tutorial, if the tutorial prevents any terminal input.