### PR TITLE
Fix for #2442 and #2795.

### DIFF
--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -125,7 +125,7 @@ export function TerminalRoot({ terminal, router, player }: IProps): React.ReactE
                     paragraph={false}
                     onClick={() => terminal.connectToServer(player, item.hostname)}
                   >
-                    <Typography>{item.hostname}</Typography>
+                    <Typography sx={{ textDecoration: 'underline' }}>{item.hostname}</Typography>
                   </MuiLink>
                 </>
               )}

--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -125,7 +125,7 @@ export function TerminalRoot({ terminal, router, player }: IProps): React.ReactE
                     paragraph={false}
                     onClick={() => terminal.connectToServer(player, item.hostname)}
                   >
-                    <Typography sx={{ textDecoration: 'underline' }}>{item.hostname}</Typography>
+                    <Typography sx={{ textDecoration: 'underline', "&:hover": { textDecoration: 'none'} }}>{item.hostname}</Typography>
                   </MuiLink>
                 </>
               )}

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -624,7 +624,7 @@ export function InteractiveTutorialRoot(): React.ReactElement {
                 <ArrowBackIos />
               </IconButton>
             )}
-            {content.canNext && (
+            {(content.canNext || ITutorial.stepIsDone[step]) && (
               <IconButton onClick={iTutorialNextStep} aria-label="next">
                 <ArrowForwardIos />
               </IconButton>


### PR DESCRIPTION
#2442:
The code now shows the forward arrow, if the current segment has already been finished before.

#2795:
The code now simply adds the tag underline to the text, making a visually better underline. The change only affects link objects from the terminal.