### PR TITLE
MISC: multiple hasAugmentation checks didn't check if the augment was installed

### DIFF
--- a/src/Message/MessageHelpers.ts
+++ b/src/Message/MessageHelpers.ts
@@ -69,7 +69,7 @@ function checkForMessagesToSend(): void {
   const truthGazer = Messages[MessageFilenames.TruthGazer];
   const redpill = Messages[MessageFilenames.RedPill];
 
-  if (Player.hasAugmentation(AugmentationNames.TheRedPill)) {
+  if (Player.hasAugmentation(AugmentationNames.TheRedPill, true)) {
     //Get the world daemon required hacking level
     const worldDaemon = GetServer(SpecialServers.WorldDaemon);
     if (!(worldDaemon instanceof Server)) {

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -142,7 +142,7 @@ export function NetscriptStanek(): InternalAPI<IStanek> {
         //Return true iff the player is in CotMG and has the first Stanek aug installed
         return (
           Factions[FactionNames.ChurchOfTheMachineGod].isMember &&
-          player.hasAugmentation(AugmentationNames.StaneksGift1)
+          player.hasAugmentation(AugmentationNames.StaneksGift1, true)
         );
       },
   };

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -1462,7 +1462,7 @@ export function sourceFileLvl(this: IPlayer, n: number): number {
 
 export function focusPenalty(this: IPlayer): number {
   let focus = 1;
-  if (!this.hasAugmentation(AugmentationNames["NeuroreceptorManager"])) {
+  if (!this.hasAugmentation(AugmentationNames.NeuroreceptorManager, true)) {
     focus = this.focus ? 1 : CONSTANTS.BaseFocusBonus;
   }
   return focus;

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -55,15 +55,15 @@ export function prestigeAugmentation(): void {
   AddToAllServers(homeComp);
   prestigeHomeComputer(Player, homeComp);
 
-  if (augmentationExists(AugmentationNames.Neurolink) && Player.hasAugmentation(AugmentationNames.Neurolink)) {
+  if (augmentationExists(AugmentationNames.Neurolink) && Player.hasAugmentation(AugmentationNames.Neurolink, true)) {
     homeComp.programs.push(Programs.FTPCrackProgram.name);
     homeComp.programs.push(Programs.RelaySMTPProgram.name);
   }
-  if (augmentationExists(AugmentationNames.CashRoot) && Player.hasAugmentation(AugmentationNames.CashRoot)) {
+  if (augmentationExists(AugmentationNames.CashRoot) && Player.hasAugmentation(AugmentationNames.CashRoot, true)) {
     Player.setMoney(1e6);
     homeComp.programs.push(Programs.BruteSSHProgram.name);
   }
-  if (augmentationExists(AugmentationNames.PCMatrix) && Player.hasAugmentation(AugmentationNames.PCMatrix)) {
+  if (augmentationExists(AugmentationNames.PCMatrix) && Player.hasAugmentation(AugmentationNames.PCMatrix, true)) {
     homeComp.programs.push(Programs.DeepscanV1.name);
     homeComp.programs.push(Programs.AutoLink.name);
   }
@@ -151,7 +151,7 @@ export function prestigeAugmentation(): void {
   }
 
   // Red Pill
-  if (augmentationExists(AugmentationNames.TheRedPill) && Player.hasAugmentation(AugmentationNames.TheRedPill)) {
+  if (augmentationExists(AugmentationNames.TheRedPill) && Player.hasAugmentation(AugmentationNames.TheRedPill, true)) {
     const WorldDaemon = GetServer(SpecialServers.WorldDaemon);
     const DaedalusServer = GetServer(SpecialServers.DaedalusServer);
     if (WorldDaemon && DaedalusServer) {
@@ -160,7 +160,10 @@ export function prestigeAugmentation(): void {
     }
   }
 
-  if (augmentationExists(AugmentationNames.StaneksGift1) && Player.hasAugmentation(AugmentationNames.StaneksGift1)) {
+  if (
+    augmentationExists(AugmentationNames.StaneksGift1) &&
+    Player.hasAugmentation(AugmentationNames.StaneksGift1, true)
+  ) {
     joinFaction(Factions[FactionNames.ChurchOfTheMachineGod]);
   }
 

--- a/src/Work/CompanyWork.tsx
+++ b/src/Work/CompanyWork.tsx
@@ -35,7 +35,7 @@ export class CompanyWork extends Work {
 
   getGainRates(player: IPlayer): WorkStats {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager)) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager, true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
     return scaleWorkStats(calculateCompanyWorkStats(player, player, this.getCompany()), focusBonus);

--- a/src/Work/CreateProgramWork.ts
+++ b/src/Work/CreateProgramWork.ts
@@ -58,7 +58,7 @@ export class CreateProgramWork extends Work {
 
   process(player: IPlayer, cycles: number): boolean {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames["NeuroreceptorManager"])) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager, true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
     //Higher hacking skill will allow you to create programs faster

--- a/src/Work/FactionWork.tsx
+++ b/src/Work/FactionWork.tsx
@@ -39,7 +39,7 @@ export class FactionWork extends Work {
 
   getReputationRate(player: IPlayer): number {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager,true)) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager, true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
     return calculateFactionRep(player, this.factionWorkType, this.getFaction().favor) * focusBonus;
@@ -47,7 +47,7 @@ export class FactionWork extends Work {
 
   getExpRates(player: IPlayer): WorkStats {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager,true)) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager, true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
     const rate = calculateFactionExp(player, this.factionWorkType);

--- a/src/Work/FactionWork.tsx
+++ b/src/Work/FactionWork.tsx
@@ -39,7 +39,7 @@ export class FactionWork extends Work {
 
   getReputationRate(player: IPlayer): number {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager)) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager,true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
     return calculateFactionRep(player, this.factionWorkType, this.getFaction().favor) * focusBonus;
@@ -47,7 +47,7 @@ export class FactionWork extends Work {
 
   getExpRates(player: IPlayer): WorkStats {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager)) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager,true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
     const rate = calculateFactionExp(player, this.factionWorkType);

--- a/src/Work/GraftingWork.tsx
+++ b/src/Work/GraftingWork.tsx
@@ -37,7 +37,7 @@ export class GraftingWork extends Work {
 
   process(player: IPlayer, cycles: number): boolean {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager,true)) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager, true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
 
@@ -52,7 +52,7 @@ export class GraftingWork extends Work {
     if (!cancelled) {
       applyAugmentation({ name: augName, level: 1 });
 
-      if (!player.hasAugmentation(AugmentationNames.CongruityImplant)) {
+      if (!player.hasAugmentation(AugmentationNames.CongruityImplant, true)) {
         player.entropy += 1;
         player.applyEntropy(player.entropy);
       }
@@ -62,7 +62,7 @@ export class GraftingWork extends Work {
           <>
             You've finished grafting {augName}.<br />
             The augmentation has been applied to your body{" "}
-            {player.hasAugmentation(AugmentationNames.CongruityImplant) ? "." : ", but you feel a bit off."}
+            {player.hasAugmentation(AugmentationNames.CongruityImplant, true) ? "." : ", but you feel a bit off."}
           </>,
         );
       }

--- a/src/Work/GraftingWork.tsx
+++ b/src/Work/GraftingWork.tsx
@@ -37,7 +37,7 @@ export class GraftingWork extends Work {
 
   process(player: IPlayer, cycles: number): boolean {
     let focusBonus = 1;
-    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager)) {
+    if (!player.hasAugmentation(AugmentationNames.NeuroreceptorManager,true)) {
       focusBonus = player.focus ? 1 : CONSTANTS.BaseFocusBonus;
     }
 


### PR DESCRIPTION
TRP's message to find the cave was being sent if you had high enough hacking level and had bought the red pill, even if you hadn't installed it yet. Made it so that the `hasAugmentation()` checks whether or not it's installed, not just owned.