### PR TITLE
Fix Jest CI Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Netburner.txt
 
 # editor files
 .vscode
+
+.idea/

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,5 +9,6 @@ module.exports = {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/test/__mocks__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/test/__mocks__/styleMock.js",
+    "\\!!raw-loader!.*$": "<rootDir>/test/__mocks__/rawLoader.js",
   },
 };

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -13,7 +13,7 @@ import {
   isFileData,
 } from "./MessageDefinitions";
 
-import libSource from "!!raw-loader!../ScriptEditor/NetscriptDefinitions.d.ts";
+import libSource from "../ScriptEditor/NetscriptDefinitions.d.ts";
 
 function error(errorMsg: string, { id }: RFAMessage): RFAMessage {
   return new RFAMessage({ error: errorMsg, id: id });

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -13,7 +13,7 @@ import {
   isFileData,
 } from "./MessageDefinitions";
 
-import libSource from "../ScriptEditor/NetscriptDefinitions.d.ts";
+import libSource from "!!raw-loader!../ScriptEditor/NetscriptDefinitions.d.ts";
 
 function error(errorMsg: string, { id }: RFAMessage): RFAMessage {
   return new RFAMessage({ error: errorMsg, id: id });


### PR DESCRIPTION
Fixes the import statement that has been causing the CI suite to fail.

Also adds jetbrains IDE exclusions to the list.
