### PR TITLE
UI: FIX #4106 Fix incorrect experience display in Crime UI.

### DIFF
--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -119,6 +119,7 @@ function ExpRows(rate: WorkStats): React.ReactElement[] {
   ];
 }
 
+/* Because crime exp is given all at once at the end, we don't care about the cycles per second. */
 function CrimeExpRows(rate: WorkStats): React.ReactElement[] {
   return [
     rate.hackExp > 0 ? (
@@ -126,7 +127,7 @@ function CrimeExpRows(rate: WorkStats): React.ReactElement[] {
         name="Hacking Exp"
         color={Settings.theme.hack}
         data={{
-          content: `${numeralWrapper.formatExp(rate.hackExp * CYCLES_PER_SEC)}`,
+          content: `${numeralWrapper.formatExp(rate.hackExp)}`,
         }}
       />
     ) : (
@@ -137,7 +138,7 @@ function CrimeExpRows(rate: WorkStats): React.ReactElement[] {
         name="Strength Exp"
         color={Settings.theme.combat}
         data={{
-          content: `${numeralWrapper.formatExp(rate.strExp * CYCLES_PER_SEC)}`,
+          content: `${numeralWrapper.formatExp(rate.strExp)}`,
         }}
       />
     ) : (
@@ -148,7 +149,7 @@ function CrimeExpRows(rate: WorkStats): React.ReactElement[] {
         name="Defense Exp"
         color={Settings.theme.combat}
         data={{
-          content: `${numeralWrapper.formatExp(rate.defExp * CYCLES_PER_SEC)}`,
+          content: `${numeralWrapper.formatExp(rate.defExp)}`,
         }}
       />
     ) : (
@@ -159,7 +160,7 @@ function CrimeExpRows(rate: WorkStats): React.ReactElement[] {
         name="Dexterity Exp"
         color={Settings.theme.combat}
         data={{
-          content: `${numeralWrapper.formatExp(rate.dexExp * CYCLES_PER_SEC)}`,
+          content: `${numeralWrapper.formatExp(rate.dexExp)}`,
         }}
       />
     ) : (
@@ -170,7 +171,7 @@ function CrimeExpRows(rate: WorkStats): React.ReactElement[] {
         name="Agility Exp"
         color={Settings.theme.combat}
         data={{
-          content: `${numeralWrapper.formatExp(rate.agiExp * CYCLES_PER_SEC)}`,
+          content: `${numeralWrapper.formatExp(rate.agiExp)}`,
         }}
       />
     ) : (
@@ -181,7 +182,7 @@ function CrimeExpRows(rate: WorkStats): React.ReactElement[] {
         name="Charisma Exp"
         color={Settings.theme.cha}
         data={{
-          content: `${numeralWrapper.formatExp(rate.chaExp * CYCLES_PER_SEC)}`,
+          content: `${numeralWrapper.formatExp(rate.chaExp)}`,
         }}
       />
     ) : (


### PR DESCRIPTION
fixes #4106 

The code for the UI for crimes was incorrectly multiplying the displayed experience rewards by 5. By removing the multiplication by CYCLES_PER_SEC (which is 5 on unmodified builds), the crime UI now correctly displays the amount of experience earned by committing crimes.

Visually, the difference is as follows:
BEFORE:
![fix4106_before](https://user-images.githubusercontent.com/3587118/191142905-0cd36eb5-9a42-42e5-a3dd-6c14ca0e80cc.png)
AFTER:
![fix4106_after](https://user-images.githubusercontent.com/3587118/191142904-3d217dd0-e1a1-4225-a456-d33b56ca34ca.png)