### PR TITLE
CORPORATION: Gave investors some economics classes

### DIFF
--- a/src/Corporation/ICorporation.ts
+++ b/src/Corporation/ICorporation.ts
@@ -25,6 +25,7 @@ export interface ICorporation {
   issuedShares: number;
   sharePrice: number;
   storedCycles: number;
+  valuation: number;
 
   unlockUpgrades: number[];
   upgrades: number[];
@@ -36,7 +37,8 @@ export interface ICorporation {
   getState(): string;
   storeCycles(numCycles: number): void;
   process(player: IPlayer): void;
-  determineValuation(): number;
+  determineValuation(): void;
+  determineCycleValuation(): number;
   getTargetSharePrice(): number;
   updateSharePrice(): void;
   immediatelyUpdateSharePrice(): void;

--- a/src/Corporation/data/Constants.ts
+++ b/src/Corporation/data/Constants.ts
@@ -32,7 +32,7 @@ export const CorporationConstants: {
   AllResearch: string[];
   FundingRoundShares: number[];
   FundingRoundMultiplier: number[];
-  AvgProfitLength: number;
+  ValuationLength: number;
 } = {
   INITIALSHARES: 1e9, //Total number of shares you have at your company
   SHARESPERPRICEUPDATE: 1e6, //When selling large number of shares, price is dynamically updated for every batch of this amount
@@ -153,5 +153,5 @@ export const CorporationConstants: {
   FundingRoundShares: [0.1, 0.35, 0.25, 0.2],
   FundingRoundMultiplier: [4, 3, 3, 2.5],
 
-  AvgProfitLength: 1,
+  ValuationLength: 5,
 };

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -244,7 +244,7 @@ function BribeButton(): React.ReactElement {
   const corp = useCorporation();
   const [open, setOpen] = useState(false);
   const canBribe =
-    corp.determineValuation() >= CorporationConstants.BribeThreshold &&
+    corp.valuation >= CorporationConstants.BribeThreshold &&
     player.factions.filter((f) => Factions[f].getInfo().offersWork()).length > 0;
 
   function openBribe(): void {

--- a/src/Corporation/ui/modals/FindInvestorsModal.tsx
+++ b/src/Corporation/ui/modals/FindInvestorsModal.tsx
@@ -16,7 +16,7 @@ interface IProps {
 // Create a popup that lets the player manage exports
 export function FindInvestorsModal(props: IProps): React.ReactElement {
   const corporation = useCorporation();
-  const val = corporation.determineValuation();
+  const val = corporation.valuation;
   if (
     corporation.fundingRound >= CorporationConstants.FundingRoundShares.length ||
     corporation.fundingRound >= CorporationConstants.FundingRoundMultiplier.length

--- a/src/Corporation/ui/modals/GoPublicModal.tsx
+++ b/src/Corporation/ui/modals/GoPublicModal.tsx
@@ -19,10 +19,10 @@ interface IProps {
 export function GoPublicModal(props: IProps): React.ReactElement {
   const corp = useCorporation();
   const [shares, setShares] = useState<number>(NaN);
-  const initialSharePrice = corp.determineValuation() / corp.totalShares;
+  const initialSharePrice = corp.valuation / corp.totalShares;
 
   function goPublic(): void {
-    const initialSharePrice = corp.determineValuation() / corp.totalShares;
+    const initialSharePrice = corp.valuation / corp.totalShares;
     if (isNaN(shares)) {
       dialogBoxCreate("Invalid value for number of issued shares");
       return;

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -146,7 +146,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
         shares: 0,
         round: corporation.fundingRound + 1, // Make more readable
       }; // Don't throw an error here, no reason to have a second function to check if you can get investment.
-    const val = corporation.determineValuation();
+    const val = corporation.valuation;
     const percShares = CorporationConstants.FundingRoundShares[corporation.fundingRound];
     const roundMultiplier = CorporationConstants.FundingRoundMultiplier[corporation.fundingRound];
     const funding = val * percShares * roundMultiplier;
@@ -166,7 +166,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       corporation.public
     )
       return false;
-    const val = corporation.determineValuation();
+    const val = corporation.valuation;
     const percShares = CorporationConstants.FundingRoundShares[corporation.fundingRound];
     const roundMultiplier = CorporationConstants.FundingRoundMultiplier[corporation.fundingRound];
     const funding = val * percShares * roundMultiplier;
@@ -179,7 +179,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
 
   function goPublic(numShares: number): boolean {
     const corporation = getCorporation();
-    const initialSharePrice = corporation.determineValuation() / corporation.totalShares;
+    const initialSharePrice = corporation.valuation / corporation.totalShares;
     if (isNaN(numShares)) throw new Error("Invalid value for number of issued shares");
     if (numShares < 0) throw new Error("Invalid value for number of issued shares");
     if (numShares > corporation.numShares) throw new Error("You don't have that many shares to issue!");


### PR DESCRIPTION
# PLAYER DESCRIPTION 
Previously corporation valuation used a Cumulative Average (CA) for calculating the current valuation:
`V_n = (CV+ V_(n-1) * (L-1)) / L`
where `V_n` is current corporation valuation
`CV` is this cycle's valuation
`V_(n-1)` is previous corporation valuation
`L` is length of valuation affecting cycles
!Note: current cycle's valuation is calculated from current funds and profits, current  corporation valuation is calculated from previous corporation valuation and current cycle's valuation.

L was set to 1 due to complaints, but previously it was set to 20 or 50, which are in my opinion way too large. With L=1 valuation was completely recalculated each cycle without the previous valuation having any effect, and thus any spikes in profit caused huge differences in valuation. CA With L>1 will cause that any changes to the value will have essentially infinite tails, until larger changes or rounding errors remove them. Small L invites players to do investor frauding, while large L causes unnecessary waiting to get a decent valuation after spending large amounts of funds.

This PR changes the calculation to use Simple Moving Average (SMA) for the calculation:

`ValuationsList = [V_(L-1), V_(L-2), ... V_0]`, where `V_n = cycle valuation n cycles ago` and `L` is the length of affecting cycles
`Valuation = SUM(ValuationsList)/L`

With this all cycles within the L limit are used for calculations equally, without any lingering effects from the previous cycles. L=1 has the same effects as L=1 on CA. L>1 doesn't have the issue of infinite tails, and assuming (somewhat) stable profits, after L cycles corporation valuation equals cycle valuation.

In addition to changing how corporation valuation is calculated, this PR changes L from 1 to 5, which is a decent balance between sudden changes affecting valuation and how soon those changes are "forgotten".
 
# Testing

I ran multiple tests (i.e. corp runs from creation to 1e100/s profits) with these changes (I also had to modify the code slightly to wait L cycles before accepting investor offers at the start to get the expected offer) and without them (using the code with the L cycle waits), and the offer amounts were within expected values (there is variability due to RNG) at the start and slightly lower near the end (my script uses newton's method to find perfect prices for products, which causes some slight spikes in profit, with SMA those spikes were noticeably less pronounced). The finishing times for CA L=1 and SMA L=1 were between 1h50min and 1h58min and SMA L=5 1h55 min and 2h10min.