### PR TITLE
UI: FIX #2962 Add a setting to display middle time unit in Time Elapsed String

### DIFF
--- a/src/GameOptions/ui/InterfacePage.tsx
+++ b/src/GameOptions/ui/InterfacePage.tsx
@@ -50,6 +50,12 @@ export const InterfacePage = (): React.ReactElement => {
           <>If this is set all references to memory will use GiB instead of GB, in accordance with IEC 60027-2.</>
         }
       />
+      <OptionSwitch
+        checked={Settings.ShowMiddleNullTimeUnit}
+        onChange={(newValue) => (Settings.ShowMiddleNullTimeUnit = newValue)}
+        text="Show all intermediary times unit, even when null."
+        tooltip={<>ex : 1 hours 13 seconds becomes 1 hours 0 minutes 13 seconds.</>}
+      />
       <Tooltip
         title={
           <Typography>

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -155,6 +155,11 @@ interface IDefaultSettings {
   UseIEC60027_2: boolean;
 
   /*
+   * Display intermediary time unit when their value is null
+   */
+  ShowMiddleNullTimeUnit: boolean;
+
+  /*
    * Character overview settings
    */
   overview: OverviewSettings;
@@ -222,6 +227,7 @@ export const defaultSettings: IDefaultSettings = {
   SuppressSavedGameToast: false,
   SuppressAutosaveDisabledWarnings: false,
   UseIEC60027_2: false,
+  ShowMiddleNullTimeUnit: false,
   ExcludeRunningScriptsFromSave: false,
   IsSidebarOpened: true,
 
@@ -265,6 +271,7 @@ export const Settings: ISettings & ISelfInitializer & ISelfLoading = {
   SuppressSavedGameToast: defaultSettings.SuppressSavedGameToast,
   SuppressAutosaveDisabledWarnings: defaultSettings.SuppressAutosaveDisabledWarnings,
   UseIEC60027_2: defaultSettings.UseIEC60027_2,
+  ShowMiddleNullTimeUnit: defaultSettings.ShowMiddleNullTimeUnit,
   ExcludeRunningScriptsFromSave: defaultSettings.ExcludeRunningScriptsFromSave,
   IsSidebarOpened: defaultSettings.IsSidebarOpened,
 

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -1,3 +1,4 @@
+import { Settings } from "../Settings/Settings";
 import { EqualityFunc } from "../types";
 import { isString } from "./helpers/isString";
 
@@ -39,10 +40,10 @@ function convertTimeMsToTimeElapsedString(time: number, showMilli = false): stri
   if (days > 0) {
     res += `${days} days `;
   }
-  if (hours > 0) {
+  if (hours > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
     res += `${hours} hours `;
   }
-  if (minutes > 0) {
+  if (minutes > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
     res += `${minutes} minutes `;
   }
   res += `${seconds} seconds`;


### PR DESCRIPTION
Copy of https://github.com/danielyxie/bitburner/pull/3695 because git wouldn't let me fix MC in github. All credit to borisflagell

Fix https://github.com/danielyxie/bitburner/issues/2962