### PR TITLE
MISC: FIX #3649 Preventing server starting security level from going above 100

### DIFF
--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -76,7 +76,9 @@ export class Server extends BaseServer {
 
     //Hack Difficulty is synonymous with server security. Base Difficulty = Starting difficulty
     this.hackDifficulty =
-      params.hackDifficulty != null ? Math.min(params.hackDifficulty * BitNodeMultipliers.ServerStartingSecurity, 100) : 1;
+      params.hackDifficulty != null
+        ? Math.min(params.hackDifficulty * BitNodeMultipliers.ServerStartingSecurity, 100)
+        : 1;
     this.baseDifficulty = this.hackDifficulty;
     this.minDifficulty = Math.max(1, Math.round(this.hackDifficulty / 3));
     this.serverGrowth = params.serverGrowth != null ? params.serverGrowth : 1; //Integer from 0 to 100. Affects money increase from grow()

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -75,12 +75,11 @@ export class Server extends BaseServer {
     this.moneyMax = 25 * this.moneyAvailable * BitNodeMultipliers.ServerMaxMoney;
 
     //Hack Difficulty is synonymous with server security. Base Difficulty = Starting difficulty
-    this.hackDifficulty =
-      params.hackDifficulty != null
-        ? Math.min(params.hackDifficulty * BitNodeMultipliers.ServerStartingSecurity, 100)
-        : 1;
+    const realDifficulty =
+      params.hackDifficulty != null ? params.hackDifficulty * BitNodeMultipliers.ServerStartingSecurity : 1;
+    this.hackDifficulty = Math.min(realDifficulty, 100);
     this.baseDifficulty = this.hackDifficulty;
-    this.minDifficulty = Math.max(1, Math.round(this.hackDifficulty / 3));
+    this.minDifficulty = Math.min(Math.max(1, Math.round(realDifficulty / 3)), 100);
     this.serverGrowth = params.serverGrowth != null ? params.serverGrowth : 1; //Integer from 0 to 100. Affects money increase from grow()
 
     //Port information, required for porthacking servers to get admin rights

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -76,7 +76,7 @@ export class Server extends BaseServer {
 
     //Hack Difficulty is synonymous with server security. Base Difficulty = Starting difficulty
     this.hackDifficulty =
-      params.hackDifficulty != null ? params.hackDifficulty * BitNodeMultipliers.ServerStartingSecurity : 1;
+      params.hackDifficulty != null ? Math.min(params.hackDifficulty * BitNodeMultipliers.ServerStartingSecurity, 100) : 1;
     this.baseDifficulty = this.hackDifficulty;
     this.minDifficulty = Math.max(1, Math.round(this.hackDifficulty / 3));
     this.serverGrowth = params.serverGrowth != null ? params.serverGrowth : 1; //Integer from 0 to 100. Affects money increase from grow()


### PR DESCRIPTION
fixes #3649 

Testing:
Minimum starting security level on server creation seems to have been fixes since this issue was made as it properly shows as 1 on both branches. The changes appear to have fixed the new starting security of each server on creation, though that also affects the minimum security calculations, which I am not sure myself whether the new or old values are intended, and if they were I can revise the pr as so. **Will note that in the screenshots "Maximum" was a typo on my script as the value after the word is actually the minimum security and github also did not allow me to upload screenshots so I have left links.**

Current (BN13):
https://prnt.sc/4gpx7Am1zaCq
PR( BN13):
https://prnt.sc/1EYiHWcqOeyu