### PR TITLE
CCT: inconsistent probability for generation between online and offline

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -262,7 +262,7 @@ const Engine: {
         if (numCyclesOffline < 3000 * 100) {
           // if we have less than 100 rolls, just roll them exactly.
           for (let i = 0; i < numCyclesOffline / 3000; i++) {
-            if (Math.random() < 0.25) numContracts++;
+            if (Math.random() <= 0.25) numContracts++;
           }
         } else {
           // just average it.


### PR DESCRIPTION
Fixes #4110.  While online, there is 25% chance for a Coding Contract to appear.  The same should apply when a player loads the game after being offline for a period of time.  Currently, loading the game after being offline would give a generation probability of less than 25%.  The mismatch between offline and online gives an unfair advantage to having the game running for an extended period of time.  Early in the game, Coding Contracts are a good source of money.  Leaving the game offline should not be penalized with a possibly lesser chance of generating another Coding Contract.