### PR TITLE
CONTRIBUTIONS: Modify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -5,16 +5,20 @@
 # PR title
 
 Formatted as such:
-SECTION: FIX #xzyw PLAYER DESCRIPTION
+SECTION: PLAYER DESCRIPTION
 
 SECTION is something like "API", "UI", "MISC", "STANEK", "CORPORATION"
-FIX #xyzw is the issue number, if any
 PLAYER DESCRIPTION is what you'd tell a non-contributor to convey what is changed.
 
 # Linked issues
 
 If your pull request is related to a git issue, please link it in the description using #xyz.
-If your PR should close the issue when it is merged in, use `fixes #xyz` or `closes #xyz`. It'll automate the process.
+If your PR should close the issue when it is merged in, use `fixes #xyz` or `closes #xyz` like this:
+
+closes #xxxx
+closes #yyyy
+
+It'll automate the process.
 
 # Documentation
 


### PR DESCRIPTION
Change to PR template, based on discussion in Discord (development channel) today.
Discussed with @HeinousTugboat and @Snarling.

Remove the need to mention issue numbers in PR title,
specify the way issues should be closed.
