### PR TITLE
API: Remove incorrectly placed 's' in ns.tFormat()

### DIFF
--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -38,15 +38,15 @@ function convertTimeMsToTimeElapsedString(time: number, showMilli = false): stri
 
   let res = "";
   if (days > 0) {
-    res += `${days} days `;
+    res += `${days} day${days === 1 ? "" : "s"} `;
   }
   if (hours > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
-    res += `${hours} hours `;
+    res += `${hours} hour${hours === 1 ? "" : "s"} `;
   }
   if (minutes > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
-    res += `${minutes} minutes `;
+    res += `${minutes} minute${minutes === 1 ? "" : "s"} `;
   }
-  res += `${seconds} seconds`;
+  res += `${seconds} second${!showMilli && secTruncMinutes === 1 ? "" : "s"}`;
 
   return res;
 }


### PR DESCRIPTION
As the title states, this PR corrects results like "1 minutes" to "1 minute".