### PR TITLE
UI: Remove extra / from open script tab when files are in a folder

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -824,7 +824,7 @@ export function Root(props: IProps): React.ReactElement {
                     ...colorProps,
                   };
 
-                  const scriptTabText = `${hostname}:~/${fileName} ${dirty(index)}`;
+                  const scriptTabText = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(index)}`;
                   return (
                     <Draggable
                       key={fileName + hostname}


### PR DESCRIPTION
### Before:
![image](https://user-images.githubusercontent.com/23249107/192076195-9605fd38-ca26-4a30-8180-f2b6d48b3467.png)

### After
![image](https://user-images.githubusercontent.com/23249107/192076328-9cbe4762-428f-44f6-8fe9-d31bf6493c5a.png)
