### PR TITLE
NETSCRIPT: scp no longer keeps old ram cost when overwriting file

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -924,7 +924,7 @@ const base: InternalAPI<NS> = {
             continue;
           }
           destScript.code = sourceScript.code;
-          destScript.ramUsage = destScript.ramUsage;
+          destScript.ramUsage = sourceScript.ramUsage;
           destScript.markUpdated();
           helpers.log(ctx, () => `WARNING: File '${file}' overwritten on '${destServer?.hostname}'`);
           continue;


### PR DESCRIPTION
FIX #4138 
There was a typo in ns.scp (thanks to yours truly) where overwritten script files were not having their ram updated to the new cost after overwriting.