### PR TITLE
CCT: no special characters in file names of Coding Contracts

### DIFF
--- a/src/CodingContractGenerator.ts
+++ b/src/CodingContractGenerator.ts
@@ -191,7 +191,8 @@ function getRandomFilename(server: BaseServer, reward: ICodingContractReward): s
   }
 
   if (reward.name) {
-    contractFn += `-${reward.name.replace(/\s/g, "")}`;
+    // Only alphanumeric characters in the reward name.
+    contractFn += `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}`;
   }
 
   return contractFn;


### PR DESCRIPTION
Fixes #4067.  The file name of a Coding Contract follows the format `contract-xxx-rewardName.cct`.  The part `xxx` means a sequence of random decimal digits.  The part `rewardName` can be an empty string if the player is not part of any faction nor is working for a company.  However, if the player is working for a company or faction whose name has a special character, then the special character would also appear in the generated file name.  We only want alphanumeric characters throughout the whole file name.

To make sure the issue is fixed, at the root directory of the source tree, run this from the command line:

```sh
$ npm install
$ npm run start:dev
```

Open a web browser and go to `localhost:8000`.  Load the save file provided at #4067, open the dev menu, and generate a bunch of random Coding Contracts on the home server.  The contracts for Joe's Guns no longer have special characters in their name.