### PR TITLE
SLEEVE: Can no longer use API to assign sleeves to bladeburner tasks before player is member

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -424,6 +424,7 @@ export class Sleeve extends Person {
    * Begin a bladeburner task
    */
   bladeburner(action: string, contract: string): boolean {
+    if (!Player.bladeburner) return false;
     switch (action) {
       case "Field analysis":
         this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Field Analysis" }));
@@ -448,7 +449,6 @@ export class Sleeve extends Person {
         this.startWork(new SleeveBladeburnerWork({ type: "Contracts", name: contract }));
         return true;
     }
-
     return false;
   }
 


### PR DESCRIPTION
FIX #4089 

Additionally I made changes in Sleeve.ts to remove player as a parameter from main sleeve functions. E.g. Sleeve.stopWork(Player) is now Sleeve.stopWork().

Other changes are just follow-on changes for these parameter changes in Sleeve.ts, and a lint fix from a different merged PR that wasn't lint checked properly (AugmentationCreator.tsx)