### PR TITLE
NETSCRIPT: NS1 wrapper no longer fails to properly wrap some functions

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -118,7 +118,7 @@ function startNetscript1Script(workerScript: WorkerScript): Promise<void> {
           // See JSInterpreter.js:3209
           try {
             const callback = args.pop() as (value: unknown) => void;
-            const result = await entry(...args.map(int.pseudoToNative));
+            const result = await entry(...args.map((arg) => int.pseudoToNative(arg)));
             return callback(int.nativeToPseudo(result));
           } catch (e: unknown) {
             // TODO: Unify error handling, this was stolen from previous async handler


### PR DESCRIPTION
Fix #4164
The cause of the issue is that the ts definition for Interpreter.prototype.pseudoToNative only takes in one argument: 
https://github.com/danielyxie/bitburner/blob/69eda4340e4fc63716fd1f8c7b039a32a7fcbf2f/src/ThirdParty/JSInterpreter.d.ts#L6
But the actual function has an optional second argument:
https://github.com/danielyxie/bitburner/blob/69eda4340e4fc63716fd1f8c7b039a32a7fcbf2f/src/ThirdParty/JSInterpreter.js#L2113
In a previous PR, the ts definition made me feel safe using the function directly in a .map, since I thought the 2nd and 3rd automatic arguments from .map would be ignored by the function since it only took in one argument. But since there actually is a second argument, .map sends bad data for this second argument and that breaks certain ns functions that use objects.

Converting the direct use in .map to an anonymous one-arg wrapper function fixes the issue.