### PR TITLE
CCT: Generate IPs contract type accepts properly formatted js array

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -490,8 +490,8 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         "Note that an octet cannot begin with a '0' unless the number",
         "itself is actually 0. For example, '192.168.010.1' is not a valid IP.\n\n",
         "Examples:\n\n",
-        "25525511135 -> [\"255.255.11.135\", \"255.255.111.35\"]\n",
-        "1938718066 -> [\"193.87.180.66\"]",
+        '25525511135 -> ["255.255.11.135", "255.255.111.35"]\n',
+        '1938718066 -> ["193.87.180.66"]',
       ].join(" ");
     },
     difficulty: 3,

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -532,7 +532,7 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
       }
 
       const sanitizedAns: string = removeBracketsFromArrayString(ans).replace(/\s/g, "");
-      const ansArr: string[] = sanitizedAns.split(",");
+      const ansArr: string[] = sanitizedAns.split(",").map((ip) => ip.replace(/^"|"$/g, ""));
       if (ansArr.length !== ret.length) {
         return false;
       }

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -490,8 +490,8 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         "Note that an octet cannot begin with a '0' unless the number",
         "itself is actually 0. For example, '192.168.010.1' is not a valid IP.\n\n",
         "Examples:\n\n",
-        "25525511135 -> [255.255.11.135, 255.255.111.35]\n",
-        "1938718066 -> [193.87.180.66]",
+        "25525511135 -> [\"255.255.11.135\", \"255.255.111.35\"]\n",
+        "1938718066 -> [\"193.87.180.66\"]",
       ].join(" ");
     },
     difficulty: 3,


### PR DESCRIPTION
fix #4171
fix #4197 

Probably should do a larger rewrite that doesn't compare all contract solutions internally as strings, but this . .

Prior to this, generate IPs was only accepting IPs that were not contained in quotation marks, e.g. something like 
`[192.168.0.1, 192.16.80.1, 19.216.80.1]`. 
This will still be accepted (it probably shouldn't be) but the more correct 
`["192.168.0.1", "192.16.80.1", "19.216.80.1"]`
which is how an array of strings is denoted in js, should also be accepted after this PR.