### PR TITLE
BLADEBURNER: Make Datamancer apply to Tracking

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1229,7 +1229,7 @@ export class Bladeburner {
       switch (actionIdent.name) {
         case "Tracking":
           // Increase estimate accuracy by a relatively small amount
-          city.improvePopulationEstimateByCount(getRandomInt(100, 1e3));
+          city.improvePopulationEstimateByCount(getRandomInt(100, 1e3) * this.skillMultipliers.successChanceEstimate);
           break;
         case "Bounty Hunter":
           city.changePopulationByCount(-1, { estChange: -1, estOffset: 0 });


### PR DESCRIPTION
Makes the Datamancer skill for Bladeburner apply to the Population Estimate change of the Tracking contract. If this was not desired, then the description of Datamancer needs to be made more accurate :D