### PR TITLE
DOC: Add link to official server in Remote API documentation

### DIFF
--- a/doc/source/remoteapi.rst
+++ b/doc/source/remoteapi.rst
@@ -7,6 +7,9 @@ That server can then perform a number of actions.
 Most commonly this is used in conjunction with an external text editor or API
 in order to make writing scripts easier, or even use typescript.
 
+To make use of this Remote API through the official server, look here: https://github.com/bitburner-official/typescript-template.
+If you want to make your own server, see below for API details.
+
 This API uses the JSON RCP 2.0 protocol. Inputs are in the following form:
 
     .. code-block:: javascript


### PR DESCRIPTION
Reason for this is since some people end up at this file first, without being aware of an existing solution already being available.