### PR TITLE
NETSCRIPT: growthAnalyzeSecurity no longer fails if the optional cores parameter was omitted

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -311,7 +311,7 @@ const base: InternalAPI<NS> = {
     (_threads: unknown, _hostname?: unknown, _cores?: unknown): number => {
       let threads = helpers.number(ctx, "threads", _threads);
       if (_hostname) {
-        const cores = helpers.number(ctx, "cores", _cores) || 1;
+        const cores = _cores ? helpers.number(ctx, "cores", _cores) : 1;
         const hostname = helpers.string(ctx, "hostname", _hostname);
         const server = helpers.getServer(ctx, hostname);
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -308,10 +308,10 @@ const base: InternalAPI<NS> = {
     },
   growthAnalyzeSecurity:
     (ctx: NetscriptContext) =>
-    (_threads: unknown, _hostname?: unknown, _cores?: unknown): number => {
+    (_threads: unknown, _hostname?: unknown, _cores: unknown = 1): number => {
       let threads = helpers.number(ctx, "threads", _threads);
       if (_hostname) {
-        const cores = _cores ? helpers.number(ctx, "cores", _cores) : 1;
+        const cores = helpers.number(ctx, "cores", _cores);
         const hostname = helpers.string(ctx, "hostname", _hostname);
         const server = helpers.getServer(ctx, hostname);
 


### PR DESCRIPTION
When providing a hostname but not providing cores, helpers.number was throwing an error if cores was undefined. Fixed by giving cores a default value of 1.