### PR TITLE
NETSCRIPT: format fixes

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -75,7 +75,7 @@ interface Player {
 /**
  * @public
  */
- export interface Multipliers {
+export interface Multipliers {
   /** Multiplier to hacking skill */
   hacking?: number;
   /** Multiplier to strength skill */

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -803,7 +803,9 @@ export function Root(props: IProps): React.ReactElement {
                     ...colorProps,
                   };
 
-                  const scriptTabText = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(index)}`;
+                  const scriptTabText = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(
+                    index,
+                  )}`;
                   return (
                     <Draggable
                       key={fileName + hostname}


### PR DESCRIPTION
The command `npm run format` reports some formatting issues under `src/ScriptEditor`.  Fix the reported formatting issues.