### PR TITLE
DOC: `stock.getPrice()`: typo fixes and update examples

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1089,11 +1089,12 @@ export interface TIX {
   getSymbols(): string[];
 
   /**
-   * Returns the price of a stock
+   * Returns the price of a stock.
    *
    * @remarks
    * RAM cost: 2 GB
-   * The stock’s price is the average of its bid and ask price.
+   *
+   * The stock’s price is the average of its bid and ask prices.
    *
    * @example
    * ```ts

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1104,6 +1104,10 @@ export interface TIX {
    * @example
    * ```ts
    * // NS1
+   * stock.getPrice("FSIG");
+   * 
+   * // Choose the first stock symbol from the array of stock symbols.  Get the price
+   * // of the corresponding stock.
    * var sym = stock.getSymbols()[0];
    * tprint("Stock symbol: " + sym);
    * tprint("Stock price: " + stock.getPrice(sym));
@@ -1111,6 +1115,10 @@ export interface TIX {
    * @example
    * ```ts
    * // NS2
+   * ns.stock.getPrice("FSIG");
+   * 
+   * // Choose the first stock symbol from the array of stock symbols.  Get the price
+   * // of the corresponding stock.
    * const sym = ns.stock.getSymbols()[0];
    * ns.tprint("Stock symbol: " + sym);
    * ns.tprint("Stock price: " + ns.stock.getPrice(sym));

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1094,17 +1094,26 @@ export interface TIX {
    * @remarks
    * RAM cost: 2 GB
    *
-   * The stock’s price is the average of its bid and ask prices.
+   * The stock’s price is the average of its bid and ask prices. This function requires
+   * that you have the following:
+   *
+   * 1. WSE Account
+   *
+   * 1. TIX API Access
    *
    * @example
    * ```ts
    * // NS1
-   * stock.getPrice("FISG");
+   * var sym = stock.getSymbols()[0];
+   * tprint("Stock symbol: " + sym);
+   * tprint("Stock price: " + stock.getPrice(sym));
    * ```
    * @example
    * ```ts
    * // NS2
-   * ns.stock.getPrice("FISG");
+   * const sym = ns.stock.getSymbols()[0];
+   * ns.tprint("Stock symbol: " + sym);
+   * ns.tprint("Stock price: " + ns.stock.getPrice(sym));
    * ```
    * @param sym - Stock symbol.
    * @returns The price of a stock.


### PR DESCRIPTION
Fixes #4184.  Here's a description of the commits in this PR.  Refer to the commit messages for longer descriptions.

1. Commit 5e14d07d9a648071dce101173bdce681c22de8af.  Some typo and presentation fixes.
2. Commit 4cf270138d2c1b73a0333abf8b43d46a250d814c.  Fix the hard-coded, but erroneous, stock symbol in the examples.  Update the examples and documentation of the function `stock.getPrice()`.