### PR TITLE
TESTS: Fixed tests for PRs and converted tests to TS.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "d.ts"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   transform: {
     "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "d.ts"],
   transform: {
     "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitburner",
-  "version": "1.7.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitburner",
-      "version": "1.7.0",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {
@@ -6074,9 +6074,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001328",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001328.tgz",
-      "integrity": "sha512-Ue55jHkR/s4r00FLNiX+hGMMuwml/QGqqzVeMQ5thUewznU2EdULFvI3JR7JJid6OrjJNfFvHY2G2dIjmRaDDQ==",
+      "version": "1.0.30001414",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
+      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==",
       "funding": [
         {
           "type": "opencollective",
@@ -26801,9 +26801,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001328",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001328.tgz",
-      "integrity": "sha512-Ue55jHkR/s4r00FLNiX+hGMMuwml/QGqqzVeMQ5thUewznU2EdULFvI3JR7JJid6OrjJNfFvHY2G2dIjmRaDDQ=="
+      "version": "1.0.30001414",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
+      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg=="
     },
     "caseless": {
       "version": "0.12.0",

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { BitNodeMultipliers, IBitNodeMultipliers } from "./BitNodeMultipliers";
 import { Player } from "../Player";
+import { BitNodeMultipliers, IBitNodeMultipliers } from "./BitNodeMultipliers";
 import { IMap } from "../types";
 import { FactionNames } from "../Faction/data/FactionNames";
 import { CityName } from "../Locations/data/CityNames";
@@ -30,422 +30,425 @@ class BitNode {
 }
 
 export const BitNodes: IMap<BitNode> = {};
-
-BitNodes["BitNode1"] = new BitNode(
-  1,
-  0,
-  "Source Genesis",
-  "The original BitNode",
-  (
-    <>
-      The first BitNode created by the Enders to imprison the minds of humans. It became the prototype and
-      testing-grounds for all of the BitNodes that followed.
-      <br />
-      <br />
-      This is the first BitNode that you play through. It has no special modifications or mechanics.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 1, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File lets the player start with 32GB of RAM on his/her home computer when
-      entering a new BitNode, and also increases all of the player's multipliers by:
-      <br />
-      <br />
-      Level 1: 16%
-      <br />
-      Level 2: 24%
-      <br />
-      Level 3: 28%
-    </>
-  ),
-);
-BitNodes["BitNode2"] = new BitNode(
-  2,
-  0,
-  "Rise of the Underworld",
-  "From the shadows, they rose", //Gangs
-  (
-    <>
-      From the shadows, they rose.
-      <br />
-      <br />
-      Organized crime groups quickly filled the void of power left behind from the collapse of Western government in the
-      2050s. As society and civilization broke down, people quickly succumbed to the innate human impulse of evil and
-      savagery. The organized crime factions quickly rose to the top of the modern world.
-      <br />
-      <br />
-      Certain Factions ({FactionNames.SlumSnakes}, {FactionNames.Tetrads}, {FactionNames.TheSyndicate},{" "}
-      {FactionNames.TheDarkArmy}, {FactionNames.SpeakersForTheDead}, {FactionNames.NiteSec}, {FactionNames.TheBlackHand}
-      ) give the player the ability to form and manage their own gangs. These gangs will earn the player money and
-      reputation with the corresponding Faction
-      <br />
-      Every Augmentation in the game will be available through the Factions listed above
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 2, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File allows you to form gangs in other BitNodes once your karma decreases
-      to a certain value. It also increases the player's crime success rate, crime money, and charisma multipliers by:
-      <br />
-      <br />
-      Level 1: 24%
-      <br />
-      Level 2: 36%
-      <br />
-      Level 3: 42%
-    </>
-  ),
-);
-BitNodes["BitNode3"] = new BitNode(
-  3,
-  0,
-  "Corporatocracy",
-  "The Price of Civilization",
-  (
-    <>
-      Our greatest illusion is that a healthy society can revolve around a single-minded pursuit of wealth.
-      <br />
-      <br />
-      Sometime in the early 21st century economic and political globalization turned the world into a corporatocracy,
-      and it never looked back. Now, the privileged elite will happily bankrupt their own countrymen, decimate their own
-      community, and evict their neighbors from houses in their desperate bid to increase their wealth.
-      <br />
-      <br />
-      In this BitNode you can create and manage your own corporation. Running a successful corporation has the potential
-      of generating massive profits.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 3, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File lets you create corporations on other BitNodes (although some
-      BitNodes will disable this mechanic) and level 3 permanently unlocks the full API. This Source-File also increases
-      your charisma and company salary multipliers by:
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-BitNodes["BitNode4"] = new BitNode(
-  4,
-  1,
-  "The Singularity",
-  "The Man and the Machine",
-  (
-    <>
-      The Singularity has arrived. The human race is gone, replaced by artificially superintelligent beings that are
-      more machine than man. <br />
-      <br />
-      <br />
-      In this BitNode you will gain access to a new set of Netscript Functions known as Singularity Functions. These
-      functions allow you to control most aspects of the game through scripts, including working for factions/companies,
-      purchasing/installing Augmentations, and creating programs.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 4, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File lets you access and use the Singularity Functions in other BitNodes.
-      Each level of this Source-File reduces the RAM cost of singularity functions:
-      <br />
-      Level 1: 16x
-      <br />
-      Level 2: 4x
-      <br />
-      Level 3: 1x
-    </>
-  ),
-);
-BitNodes["BitNode5"] = new BitNode(
-  5,
-  1,
-  "Artificial Intelligence",
-  "Posthuman",
-  (
-    <>
-      They said it couldn't be done. They said the human brain, along with its consciousness and intelligence, couldn't
-      be replicated. They said the complexity of the brain results from unpredictable, nonlinear interactions that
-      couldn't be modeled by 1's and 0's. They were wrong.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 5, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File grants you a special new stat called Intelligence. Intelligence is
-      unique because it is permanent and persistent (it never gets reset back to 1). However gaining Intelligence
-      experience is much slower than other stats. Higher Intelligence levels will boost your production for many actions
-      in the game. <br />
-      <br />
-      In addition, this Source-File will unlock the getBitNodeMultipliers() Netscript function and let you start with
-      Formulas.exe, and will also raise all of your hacking-related multipliers by:
-      <br />
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-BitNodes["BitNode6"] = new BitNode(
-  6,
-  1,
-  FactionNames.Bladeburners,
-  "Like Tears in Rain",
-  (
-    <>
-      In the middle of the 21st century, {FactionNames.OmniTekIncorporated} began designing and manufacturing advanced
-      synthetic androids, or Synthoids for short. They achieved a major technological breakthrough in the sixth
-      generation of their Synthoid design, called MK-VI, by developing a hyperintelligent AI. Many argue that this was
-      the first sentient AI ever created. This resulted in Synthoid models that were stronger, faster, and more
-      intelligent than the humans that had created them.
-      <br />
-      <br />
-      In this BitNode you will be able to access the {FactionNames.Bladeburners} Division at the NSA, which provides a
-      new mechanic for progression.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 6, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File allows you to access the NSA's {FactionNames.Bladeburners} Division
-      in other BitNodes. In addition, this Source-File will raise both the level and experience gain rate of all your
-      combat stats by:
-      <br />
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-BitNodes["BitNode7"] = new BitNode(
-  7,
-  2,
-  `${FactionNames.Bladeburners} 2079`,
-  "More human than humans",
-  (
-    <>
-      In the middle of the 21st century, you were doing cutting-edge work at {FactionNames.OmniTekIncorporated} as part
-      of the AI design team for advanced synthetic androids, or Synthoids for short. You helped achieve a major
-      technological breakthrough in the sixth generation of the company's Synthoid design, called MK-VI, by developing a
-      hyperintelligent AI. Many argue that this was the first sentient AI ever created. This resulted in Synthoid models
-      that were stronger, faster, and more intelligent than the humans that had created them.
-      <br />
-      <br />
-      In this BitNode you will be able to access the {FactionNames.Bladeburners} API, which allows you to access{" "}
-      {FactionNames.Bladeburners} functionality through Netscript.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 7, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File allows you to access the {FactionNames.Bladeburners} Netscript API in
-      other BitNodes. In addition, this Source-File will increase all of your {FactionNames.Bladeburners} multipliers
-      by:
-      <br />
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-BitNodes["BitNode8"] = new BitNode(
-  8,
-  2,
-  "Ghost of Wall Street",
-  "Money never sleeps",
-  (
-    <>
-      You are trying to make a name for yourself as an up-and-coming hedge fund manager on Wall Street.
-      <br />
-      <br />
-      In this BitNode:
-      <br />
-      <br />
-      You start with $250 million
-      <br />
-      You start with a WSE membership and access to the TIX API
-      <br />
-      You are able to short stocks and place different types of orders (limit/stop)
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 8, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File grants the following benefits:
-      <br />
-      <br />
-      Level 1: Permanent access to WSE and TIX API
-      <br />
-      Level 2: Ability to short stocks in other BitNodes
-      <br />
-      Level 3: Ability to use limit/stop orders in other BitNodes
-      <br />
-      <br />
-      This Source-File also increases your hacking growth multipliers by:
-      <br />
-      Level 1: 12%
-      <br />
-      Level 2: 18%
-      <br />
-      Level 3: 21%
-    </>
-  ),
-);
-BitNodes["BitNode9"] = new BitNode(
-  9,
-  2,
-  "Hacktocracy",
-  "Hacknet Unleashed",
-  (
-    <>
-      When {FactionNames.FulcrumSecretTechnologies} released their open-source Linux distro Chapeau, it quickly became
-      the OS of choice for the underground hacking community. Chapeau became especially notorious for powering the
-      Hacknet, a global, decentralized network used for nefarious purposes. {FactionNames.FulcrumSecretTechnologies}{" "}
-      quickly abandoned the project and dissociated themselves from it.
-      <br />
-      <br />
-      This BitNode unlocks the Hacknet Server, an upgraded version of the Hacknet Node. Hacknet Servers generate hashes,
-      which can be spent on a variety of different upgrades.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 9, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File grants the following benefits:
-      <br />
-      <br />
-      Level 1: Permanently unlocks the Hacknet Server in other BitNodes
-      <br />
-      Level 2: You start with 128GB of RAM on your home computer when entering a new BitNode
-      <br />
-      Level 3: Grants a highly-upgraded Hacknet Server when entering a new BitNode
-      <br />
-      <br />
-      (Note that the Level 3 effect of this Source-File only applies when entering a new BitNode, NOT when installing
-      Augmentations)
-      <br />
-      <br />
-      This Source-File also increases your hacknet multipliers by:
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-BitNodes["BitNode10"] = new BitNode(
-  10,
-  2,
-  "Digital Carbon",
-  "Your body is not who you are",
-  (
-    <>
-      In 2084, VitaLife unveiled to the world the Persona Core, a technology that allowed people to digitize their
-      consciousness. Their consciousness could then be transferred into Synthoids or other bodies by trasmitting the
-      digitized data. Human bodies became nothing more than 'sleeves' for the human consciousness. Mankind had finally
-      achieved immortality - at least for those that could afford it.
-      <br />
-      <br />
-      This BitNode unlocks Sleeve and grafting technologies. Sleeve technology allows you to:
-      <br />
-      <br />
-      1. Grafting: Visit VitaLife in New Tokyo to be able to obtain Augmentations without needing to install
-      <br />
-      2. Duplicate Sleeves: Duplicate your consciousness into Synthoids, allowing you to perform different tasks
-      synchronously.
-      <br />
-      <br />
-      Grafting technology allows you to graft Augmentations, which is an alternative way of installing Augmentations.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 10, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File unlocks Sleeve technology, and the Grafting API in other BitNodes.
-      Each level of this Source-File also grants you a Duplicate Sleeve
-    </>
-  ),
-);
-BitNodes["BitNode11"] = new BitNode(
-  11,
-  1,
-  "The Big Crash",
-  "Okay. Sell it all.",
-  (
-    <>
-      The 2050s was defined by the massive amounts of violent civil unrest and anarchic rebellion that rose all around
-      the world. It was this period of disorder that eventually lead to the governmental reformation of many global
-      superpowers, most notably the USA and China. But just as the world was slowly beginning to recover from these dark
-      times, financial catastrophe hit.
-      <br />
-      <br />
-      In many countries, the high cost of trying to deal with the civil disorder bankrupted the governments. In all of
-      this chaos and confusion, hackers were able to steal billions of dollars from the world's largest electronic
-      banks, prompting an international banking crisis as governments were unable to bail out insolvent banks. Now, the
-      world is slowly crumbling in the middle of the biggest economic crisis of all time.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 11, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File makes it so that company favor increases BOTH the player's salary and
-      reputation gain rate at that company by 1% per favor (rather than just the reputation gain). This Source-File also
-      increases the player's company salary and reputation gain multipliers by:
-      <br />
-      <br />
-      Level 1: 32%
-      <br />
-      Level 2: 48%
-      <br />
-      Level 3: 56%
-      <br />
-      <br />
-      It also reduces the price increase for every aug bought by:
-      <br />
-      <br />
-      Level 1: 4%
-      <br />
-      Level 2: 6%
-      <br />
-      Level 3: 7%
-    </>
-  ),
-);
-BitNodes["BitNode12"] = new BitNode(
-  12,
-  0,
-  "The Recursion",
-  "Repeat.",
-  (
-    <>
-      To iterate is human, to recurse divine.
-      <br />
-      <br />
-      Every time this BitNode is destroyed, it becomes slightly harder. Destroying this BitNode will give you
-      Source-File 12, or if you already have this Source-File it will upgrade its level. There is no maximum level for
-      Source-File 12. Each level of Source-File 12 lets you start any BitNodes with NeuroFlux Governor equal to the
-      level of this source file.
-    </>
-  ),
-);
-BitNodes["BitNode13"] = new BitNode(
-  13,
-  2,
-  "They're lunatics",
-  "1 step back, 2 steps forward",
-  (
-    <>
-      With the invention of Augmentations in the 2040s a religious group known as the{" "}
-      {FactionNames.ChurchOfTheMachineGod} has rallied far more support than anyone would have hoped.
-      <br />
-      <br />
-      Their leader, Allison "Mother" Stanek is said to have created her own Augmentation whose power goes beyond any
-      other. Find her in {CityName.Chongqing} and gain her trust.
-      <br />
-      <br />
-      Destroying this BitNode will give you Source-File 13, or if you already have this Source-File it will upgrade its
-      level up to a maximum of 3. This Source-File lets the {FactionNames.ChurchOfTheMachineGod} appear in other
-      BitNodes.
-      <br />
-      <br />
-      Each level of this Source-File increases the size of Stanek's Gift.
-    </>
-  ),
-);
+export function initBitNodes() {
+  BitNodes["BitNode1"] = new BitNode(
+    1,
+    0,
+    "Source Genesis",
+    "The original BitNode",
+    (
+      <>
+        The first BitNode created by the Enders to imprison the minds of humans. It became the prototype and
+        testing-grounds for all of the BitNodes that followed.
+        <br />
+        <br />
+        This is the first BitNode that you play through. It has no special modifications or mechanics.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 1, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File lets the player start with 32GB of RAM on his/her home computer
+        when entering a new BitNode, and also increases all of the player's multipliers by:
+        <br />
+        <br />
+        Level 1: 16%
+        <br />
+        Level 2: 24%
+        <br />
+        Level 3: 28%
+      </>
+    ),
+  );
+  BitNodes["BitNode2"] = new BitNode(
+    2,
+    0,
+    "Rise of the Underworld",
+    "From the shadows, they rose", //Gangs
+    (
+      <>
+        From the shadows, they rose.
+        <br />
+        <br />
+        Organized crime groups quickly filled the void of power left behind from the collapse of Western government in
+        the 2050s. As society and civilization broke down, people quickly succumbed to the innate human impulse of evil
+        and savagery. The organized crime factions quickly rose to the top of the modern world.
+        <br />
+        <br />
+        Certain Factions ({FactionNames.SlumSnakes}, {FactionNames.Tetrads}, {FactionNames.TheSyndicate},{" "}
+        {FactionNames.TheDarkArmy}, {FactionNames.SpeakersForTheDead}, {FactionNames.NiteSec},{" "}
+        {FactionNames.TheBlackHand}
+        ) give the player the ability to form and manage their own gangs. These gangs will earn the player money and
+        reputation with the corresponding Faction
+        <br />
+        Every Augmentation in the game will be available through the Factions listed above
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 2, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File allows you to form gangs in other BitNodes once your karma
+        decreases to a certain value. It also increases the player's crime success rate, crime money, and charisma
+        multipliers by:
+        <br />
+        <br />
+        Level 1: 24%
+        <br />
+        Level 2: 36%
+        <br />
+        Level 3: 42%
+      </>
+    ),
+  );
+  BitNodes["BitNode3"] = new BitNode(
+    3,
+    0,
+    "Corporatocracy",
+    "The Price of Civilization",
+    (
+      <>
+        Our greatest illusion is that a healthy society can revolve around a single-minded pursuit of wealth.
+        <br />
+        <br />
+        Sometime in the early 21st century economic and political globalization turned the world into a corporatocracy,
+        and it never looked back. Now, the privileged elite will happily bankrupt their own countrymen, decimate their
+        own community, and evict their neighbors from houses in their desperate bid to increase their wealth.
+        <br />
+        <br />
+        In this BitNode you can create and manage your own corporation. Running a successful corporation has the
+        potential of generating massive profits.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 3, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File lets you create corporations on other BitNodes (although some
+        BitNodes will disable this mechanic) and level 3 permanently unlocks the full API. This Source-File also
+        increases your charisma and company salary multipliers by:
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  BitNodes["BitNode4"] = new BitNode(
+    4,
+    1,
+    "The Singularity",
+    "The Man and the Machine",
+    (
+      <>
+        The Singularity has arrived. The human race is gone, replaced by artificially superintelligent beings that are
+        more machine than man. <br />
+        <br />
+        <br />
+        In this BitNode you will gain access to a new set of Netscript Functions known as Singularity Functions. These
+        functions allow you to control most aspects of the game through scripts, including working for
+        factions/companies, purchasing/installing Augmentations, and creating programs.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 4, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File lets you access and use the Singularity Functions in other
+        BitNodes. Each level of this Source-File reduces the RAM cost of singularity functions:
+        <br />
+        Level 1: 16x
+        <br />
+        Level 2: 4x
+        <br />
+        Level 3: 1x
+      </>
+    ),
+  );
+  BitNodes["BitNode5"] = new BitNode(
+    5,
+    1,
+    "Artificial Intelligence",
+    "Posthuman",
+    (
+      <>
+        They said it couldn't be done. They said the human brain, along with its consciousness and intelligence,
+        couldn't be replicated. They said the complexity of the brain results from unpredictable, nonlinear interactions
+        that couldn't be modeled by 1's and 0's. They were wrong.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 5, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File grants you a special new stat called Intelligence. Intelligence is
+        unique because it is permanent and persistent (it never gets reset back to 1). However gaining Intelligence
+        experience is much slower than other stats. Higher Intelligence levels will boost your production for many
+        actions in the game. <br />
+        <br />
+        In addition, this Source-File will unlock the getBitNodeMultipliers() Netscript function and let you start with
+        Formulas.exe, and will also raise all of your hacking-related multipliers by:
+        <br />
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  BitNodes["BitNode6"] = new BitNode(
+    6,
+    1,
+    FactionNames.Bladeburners,
+    "Like Tears in Rain",
+    (
+      <>
+        In the middle of the 21st century, {FactionNames.OmniTekIncorporated} began designing and manufacturing advanced
+        synthetic androids, or Synthoids for short. They achieved a major technological breakthrough in the sixth
+        generation of their Synthoid design, called MK-VI, by developing a hyperintelligent AI. Many argue that this was
+        the first sentient AI ever created. This resulted in Synthoid models that were stronger, faster, and more
+        intelligent than the humans that had created them.
+        <br />
+        <br />
+        In this BitNode you will be able to access the {FactionNames.Bladeburners} Division at the NSA, which provides a
+        new mechanic for progression.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 6, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File allows you to access the NSA's {FactionNames.Bladeburners} Division
+        in other BitNodes. In addition, this Source-File will raise both the level and experience gain rate of all your
+        combat stats by:
+        <br />
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  BitNodes["BitNode7"] = new BitNode(
+    7,
+    2,
+    `${FactionNames.Bladeburners} 2079`,
+    "More human than humans",
+    (
+      <>
+        In the middle of the 21st century, you were doing cutting-edge work at {FactionNames.OmniTekIncorporated} as
+        part of the AI design team for advanced synthetic androids, or Synthoids for short. You helped achieve a major
+        technological breakthrough in the sixth generation of the company's Synthoid design, called MK-VI, by developing
+        a hyperintelligent AI. Many argue that this was the first sentient AI ever created. This resulted in Synthoid
+        models that were stronger, faster, and more intelligent than the humans that had created them.
+        <br />
+        <br />
+        In this BitNode you will be able to access the {FactionNames.Bladeburners} API, which allows you to access{" "}
+        {FactionNames.Bladeburners} functionality through Netscript.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 7, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File allows you to access the {FactionNames.Bladeburners} Netscript API
+        in other BitNodes. In addition, this Source-File will increase all of your {FactionNames.Bladeburners}{" "}
+        multipliers by:
+        <br />
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  BitNodes["BitNode8"] = new BitNode(
+    8,
+    2,
+    "Ghost of Wall Street",
+    "Money never sleeps",
+    (
+      <>
+        You are trying to make a name for yourself as an up-and-coming hedge fund manager on Wall Street.
+        <br />
+        <br />
+        In this BitNode:
+        <br />
+        <br />
+        You start with $250 million
+        <br />
+        You start with a WSE membership and access to the TIX API
+        <br />
+        You are able to short stocks and place different types of orders (limit/stop)
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 8, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File grants the following benefits:
+        <br />
+        <br />
+        Level 1: Permanent access to WSE and TIX API
+        <br />
+        Level 2: Ability to short stocks in other BitNodes
+        <br />
+        Level 3: Ability to use limit/stop orders in other BitNodes
+        <br />
+        <br />
+        This Source-File also increases your hacking growth multipliers by:
+        <br />
+        Level 1: 12%
+        <br />
+        Level 2: 18%
+        <br />
+        Level 3: 21%
+      </>
+    ),
+  );
+  BitNodes["BitNode9"] = new BitNode(
+    9,
+    2,
+    "Hacktocracy",
+    "Hacknet Unleashed",
+    (
+      <>
+        When {FactionNames.FulcrumSecretTechnologies} released their open-source Linux distro Chapeau, it quickly became
+        the OS of choice for the underground hacking community. Chapeau became especially notorious for powering the
+        Hacknet, a global, decentralized network used for nefarious purposes. {FactionNames.FulcrumSecretTechnologies}{" "}
+        quickly abandoned the project and dissociated themselves from it.
+        <br />
+        <br />
+        This BitNode unlocks the Hacknet Server, an upgraded version of the Hacknet Node. Hacknet Servers generate
+        hashes, which can be spent on a variety of different upgrades.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 9, or if you already have this Source-File it will upgrade its
+        level up to a maximum of 3. This Source-File grants the following benefits:
+        <br />
+        <br />
+        Level 1: Permanently unlocks the Hacknet Server in other BitNodes
+        <br />
+        Level 2: You start with 128GB of RAM on your home computer when entering a new BitNode
+        <br />
+        Level 3: Grants a highly-upgraded Hacknet Server when entering a new BitNode
+        <br />
+        <br />
+        (Note that the Level 3 effect of this Source-File only applies when entering a new BitNode, NOT when installing
+        Augmentations)
+        <br />
+        <br />
+        This Source-File also increases your hacknet multipliers by:
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  BitNodes["BitNode10"] = new BitNode(
+    10,
+    2,
+    "Digital Carbon",
+    "Your body is not who you are",
+    (
+      <>
+        In 2084, VitaLife unveiled to the world the Persona Core, a technology that allowed people to digitize their
+        consciousness. Their consciousness could then be transferred into Synthoids or other bodies by transmitting the
+        digitized data. Human bodies became nothing more than 'sleeves' for the human consciousness. Mankind had finally
+        achieved immortality - at least for those that could afford it.
+        <br />
+        <br />
+        This BitNode unlocks Sleeve and grafting technologies. Sleeve technology allows you to:
+        <br />
+        <br />
+        1. Grafting: Visit VitaLife in New Tokyo to be able to obtain Augmentations without needing to install
+        <br />
+        2. Duplicate Sleeves: Duplicate your consciousness into Synthoids, allowing you to perform different tasks
+        synchronously.
+        <br />
+        <br />
+        Grafting technology allows you to graft Augmentations, which is an alternative way of installing Augmentations.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 10, or if you already have this Source-File it will upgrade
+        its level up to a maximum of 3. This Source-File unlocks Sleeve technology, and the Grafting API in other
+        BitNodes. Each level of this Source-File also grants you a Duplicate Sleeve
+      </>
+    ),
+  );
+  BitNodes["BitNode11"] = new BitNode(
+    11,
+    1,
+    "The Big Crash",
+    "Okay. Sell it all.",
+    (
+      <>
+        The 2050s was defined by the massive amounts of violent civil unrest and anarchic rebellion that rose all around
+        the world. It was this period of disorder that eventually lead to the governmental reformation of many global
+        superpowers, most notably the USA and China. But just as the world was slowly beginning to recover from these
+        dark times, financial catastrophe hit.
+        <br />
+        <br />
+        In many countries, the high cost of trying to deal with the civil disorder bankrupted the governments. In all of
+        this chaos and confusion, hackers were able to steal billions of dollars from the world's largest electronic
+        banks, prompting an international banking crisis as governments were unable to bail out insolvent banks. Now,
+        the world is slowly crumbling in the middle of the biggest economic crisis of all time.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 11, or if you already have this Source-File it will upgrade
+        its level up to a maximum of 3. This Source-File makes it so that company favor increases BOTH the player's
+        salary and reputation gain rate at that company by 1% per favor (rather than just the reputation gain). This
+        Source-File also increases the player's company salary and reputation gain multipliers by:
+        <br />
+        <br />
+        Level 1: 32%
+        <br />
+        Level 2: 48%
+        <br />
+        Level 3: 56%
+        <br />
+        <br />
+        It also reduces the price increase for every aug bought by:
+        <br />
+        <br />
+        Level 1: 4%
+        <br />
+        Level 2: 6%
+        <br />
+        Level 3: 7%
+      </>
+    ),
+  );
+  BitNodes["BitNode12"] = new BitNode(
+    12,
+    0,
+    "The Recursion",
+    "Repeat.",
+    (
+      <>
+        To iterate is human, to recurse divine.
+        <br />
+        <br />
+        Every time this BitNode is destroyed, it becomes slightly harder. Destroying this BitNode will give you
+        Source-File 12, or if you already have this Source-File it will upgrade its level. There is no maximum level for
+        Source-File 12. Each level of Source-File 12 lets you start any BitNodes with NeuroFlux Governor equal to the
+        level of this source file.
+      </>
+    ),
+  );
+  BitNodes["BitNode13"] = new BitNode(
+    13,
+    2,
+    "They're lunatics",
+    "1 step back, 2 steps forward",
+    (
+      <>
+        With the invention of Augmentations in the 2040s a religious group known as the{" "}
+        {FactionNames.ChurchOfTheMachineGod} has rallied far more support than anyone would have hoped.
+        <br />
+        <br />
+        Their leader, Allison "Mother" Stanek is said to have created her own Augmentation whose power goes beyond any
+        other. Find her in {CityName.Chongqing} and gain her trust.
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File 13, or if you already have this Source-File it will upgrade
+        its level up to a maximum of 3. This Source-File lets the {FactionNames.ChurchOfTheMachineGod} appear in other
+        BitNodes.
+        <br />
+        <br />
+        Each level of this Source-File increases the size of Stanek's Gift.
+      </>
+    ),
+  );
+}
 
 export const defaultMultipliers: IBitNodeMultipliers = {
   HackingLevelMultiplier: 1,

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -75,7 +75,7 @@ interface Player {
 /**
  * @public
  */
- export interface Multipliers {
+export interface Multipliers {
   /** Multiplier to hacking skill */
   hacking?: number;
   /** Multiplier to strength skill */

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -803,7 +803,9 @@ export function Root(props: IProps): React.ReactElement {
                     ...colorProps,
                   };
 
-                  const scriptTabText = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(index)}`;
+                  const scriptTabText = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(
+                    index,
+                  )}`;
                   return (
                     <Draggable
                       key={fileName + hostname}

--- a/src/SourceFile/SourceFiles.tsx
+++ b/src/SourceFile/SourceFiles.tsx
@@ -1,226 +1,229 @@
 import React from "react";
 import { SourceFile } from "./SourceFile";
 import { IMap } from "../types";
+import { initBitNodes } from "../BitNode/BitNode";
 
 export const SourceFiles: IMap<SourceFile> = {};
-
-SourceFiles["SourceFile1"] = new SourceFile(
-  1,
-  (
-    <>
-      This Source-File lets the player start with 32GB of RAM on his/her home computer. It also increases all of the
-      player's multipliers by:
-      <br />
-      <br />
-      Level 1: 16%
-      <br />
-      Level 2: 24%
-      <br />
-      Level 3: 28%
-    </>
-  ),
-);
-SourceFiles["SourceFile2"] = new SourceFile(
-  2,
-  (
-    <>
-      This Source-File allows you to form gangs in other BitNodes once your karma decreases to a certain value. It also
-      increases the player's crime success rate, crime money, and charisma multipliers by:
-      <br />
-      <br />
-      Level 1: 24%
-      <br />
-      Level 2: 36%
-      <br />
-      Level 3: 42%
-    </>
-  ),
-);
-SourceFiles["SourceFile3"] = new SourceFile(
-  3,
-  (
-    <>
-      This Source-File lets you create corporations on other BitNodes (although some BitNodes will disable this
-      mechanic) and level 3 permanently unlocks the full API. This Source-File also increases your charisma and company
-      salary multipliers by:
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-SourceFiles["SourceFile4"] = new SourceFile(
-  4,
-  (
-    <>
-      This Source-File lets you access and use the Singularity Functions in every BitNode. Every level of this
-      Source-File reduces the RAM cost of Singularity functions:
-      <br />
-      Level 1: 16x
-      <br />
-      Level 2: 4x
-      <br />
-      Level 3: 1x
-    </>
-  ),
-);
-SourceFiles["SourceFile5"] = new SourceFile(
-  5,
-  (
-    <>
-      This Source-File grants a special new stat called Intelligence. Intelligence is unique because it is permanent and
-      persistent (it never gets reset back to 1). However, gaining Intelligence experience is much slower than other
-      stats. Higher Intelligence levels will boost your production for many actions in the game. In addition, this
-      Source-File will unlock:
-      <br />
-      <ul>
-        <li>
-          The <code>getBitNodeMultipliers()</code> Netscript function
-        </li>
-        <li>Permanent access to Formulas.exe</li>
-        <li>
-          Access to BitNode multiplier information on the <b>Stats</b> page
-        </li>
-      </ul>
-      It will also raise all of your hacking-related multipliers by:
-      <br />
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-SourceFiles["SourceFile6"] = new SourceFile(
-  6,
-  (
-    <>
-      This Source-File allows you to access the NSA's Bladeburner Division in other BitNodes. In addition, this
-      Source-File will raise both the level and experience gain rate of all your combat stats by:
-      <br />
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-SourceFiles["SourceFile7"] = new SourceFile(
-  7,
-  (
-    <>
-      This Source-File allows you to access the Bladeburner Netscript API in other BitNodes. In addition, this
-      Source-File will increase all of your Bladeburner multipliers by:
-      <br />
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-SourceFiles["SourceFile8"] = new SourceFile(
-  8,
-  (
-    <>
-      This Source-File grants the following benefits:
-      <br />
-      <br />
-      Level 1: Permanent access to WSE and TIX API
-      <br />
-      Level 2: Ability to short stocks in other BitNodes
-      <br />
-      Level 3: Ability to use limit/stop orders in other BitNodes
-      <br />
-      <br />
-      This Source-File also increases your hacking growth multipliers by:
-      <br />
-      Level 1: 12%
-      <br />
-      Level 2: 18%
-      <br />
-      Level 3: 21%
-    </>
-  ),
-);
-SourceFiles["SourceFile9"] = new SourceFile(
-  9,
-  (
-    <>
-      This Source-File grants the following benefits:
-      <br />
-      <br />
-      Level 1: Permanently unlocks the Hacknet Server in other BitNodes
-      <br />
-      Level 2: You start with 128GB of RAM on your home computer when entering a new BitNode
-      <br />
-      Level 3: Grants a highly-upgraded Hacknet Server when entering a new BitNode
-      <br />
-      <br />
-      (Note that the Level 3 effect of this Source-File only applies when entering a new BitNode, NOT when installing
-      Augmentations)
-      <br />
-      <br />
-      This Source-File also increases your hacknet multipliers by:
-      <br />
-      Level 1: 8%
-      <br />
-      Level 2: 12%
-      <br />
-      Level 3: 14%
-    </>
-  ),
-);
-SourceFiles["SourceFile10"] = new SourceFile(
-  10,
-  (
-    <>
-      This Source-File unlocks Sleeve technology, and the Grafting API in other BitNodes. Each level of this Source-File
-      also grants you a Duplicate Sleeve
-    </>
-  ),
-);
-SourceFiles["SourceFile11"] = new SourceFile(
-  11,
-  (
-    <>
-      This Source-File makes it so that company favor increases BOTH the player's salary and reputation gain rate at
-      that company by 1% per favor (rather than just the reputation gain). This Source-File also increases the player's
-      company salary and reputation gain multipliers by:
-      <br />
-      <br />
-      Level 1: 32%
-      <br />
-      Level 2: 48%
-      <br />
-      Level 3: 56%
-      <br />
-      <br />
-      It also reduces the price increase for every aug bought by:
-      <br />
-      <br />
-      Level 1: 4%
-      <br />
-      Level 2: 6%
-      <br />
-      Level 3: 7%
-    </>
-  ),
-);
-SourceFiles["SourceFile12"] = new SourceFile(
-  12,
-  <>This Source-File lets the player start with Neuroflux Governor equal to the level of this Source-File.</>,
-);
-SourceFiles["SourceFile13"] = new SourceFile(
-  13,
-  <>Each level of this Source-File increases the size of Stanek's Gift.</>,
-);
+export function initSourceFiles() {
+  initBitNodes();
+  SourceFiles["SourceFile1"] = new SourceFile(
+    1,
+    (
+      <>
+        This Source-File lets the player start with 32GB of RAM on his/her home computer. It also increases all of the
+        player's multipliers by:
+        <br />
+        <br />
+        Level 1: 16%
+        <br />
+        Level 2: 24%
+        <br />
+        Level 3: 28%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile2"] = new SourceFile(
+    2,
+    (
+      <>
+        This Source-File allows you to form gangs in other BitNodes once your karma decreases to a certain value. It
+        also increases the player's crime success rate, crime money, and charisma multipliers by:
+        <br />
+        <br />
+        Level 1: 24%
+        <br />
+        Level 2: 36%
+        <br />
+        Level 3: 42%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile3"] = new SourceFile(
+    3,
+    (
+      <>
+        This Source-File lets you create corporations on other BitNodes (although some BitNodes will disable this
+        mechanic) and level 3 permanently unlocks the full API. This Source-File also increases your charisma and
+        company salary multipliers by:
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile4"] = new SourceFile(
+    4,
+    (
+      <>
+        This Source-File lets you access and use the Singularity Functions in every BitNode. Every level of this
+        Source-File reduces the RAM cost of Singularity functions:
+        <br />
+        Level 1: 16x
+        <br />
+        Level 2: 4x
+        <br />
+        Level 3: 1x
+      </>
+    ),
+  );
+  SourceFiles["SourceFile5"] = new SourceFile(
+    5,
+    (
+      <>
+        This Source-File grants a special new stat called Intelligence. Intelligence is unique because it is permanent
+        and persistent (it never gets reset back to 1). However, gaining Intelligence experience is much slower than
+        other stats. Higher Intelligence levels will boost your production for many actions in the game. In addition,
+        this Source-File will unlock:
+        <br />
+        <ul>
+          <li>
+            The <code>getBitNodeMultipliers()</code> Netscript function
+          </li>
+          <li>Permanent access to Formulas.exe</li>
+          <li>
+            Access to BitNode multiplier information on the <b>Stats</b> page
+          </li>
+        </ul>
+        It will also raise all of your hacking-related multipliers by:
+        <br />
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile6"] = new SourceFile(
+    6,
+    (
+      <>
+        This Source-File allows you to access the NSA's Bladeburner Division in other BitNodes. In addition, this
+        Source-File will raise both the level and experience gain rate of all your combat stats by:
+        <br />
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile7"] = new SourceFile(
+    7,
+    (
+      <>
+        This Source-File allows you to access the Bladeburner Netscript API in other BitNodes. In addition, this
+        Source-File will increase all of your Bladeburner multipliers by:
+        <br />
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile8"] = new SourceFile(
+    8,
+    (
+      <>
+        This Source-File grants the following benefits:
+        <br />
+        <br />
+        Level 1: Permanent access to WSE and TIX API
+        <br />
+        Level 2: Ability to short stocks in other BitNodes
+        <br />
+        Level 3: Ability to use limit/stop orders in other BitNodes
+        <br />
+        <br />
+        This Source-File also increases your hacking growth multipliers by:
+        <br />
+        Level 1: 12%
+        <br />
+        Level 2: 18%
+        <br />
+        Level 3: 21%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile9"] = new SourceFile(
+    9,
+    (
+      <>
+        This Source-File grants the following benefits:
+        <br />
+        <br />
+        Level 1: Permanently unlocks the Hacknet Server in other BitNodes
+        <br />
+        Level 2: You start with 128GB of RAM on your home computer when entering a new BitNode
+        <br />
+        Level 3: Grants a highly-upgraded Hacknet Server when entering a new BitNode
+        <br />
+        <br />
+        (Note that the Level 3 effect of this Source-File only applies when entering a new BitNode, NOT when installing
+        Augmentations)
+        <br />
+        <br />
+        This Source-File also increases your hacknet multipliers by:
+        <br />
+        Level 1: 8%
+        <br />
+        Level 2: 12%
+        <br />
+        Level 3: 14%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile10"] = new SourceFile(
+    10,
+    (
+      <>
+        This Source-File unlocks Sleeve technology, and the Grafting API in other BitNodes. Each level of this
+        Source-File also grants you a Duplicate Sleeve
+      </>
+    ),
+  );
+  SourceFiles["SourceFile11"] = new SourceFile(
+    11,
+    (
+      <>
+        This Source-File makes it so that company favor increases BOTH the player's salary and reputation gain rate at
+        that company by 1% per favor (rather than just the reputation gain). This Source-File also increases the
+        player's company salary and reputation gain multipliers by:
+        <br />
+        <br />
+        Level 1: 32%
+        <br />
+        Level 2: 48%
+        <br />
+        Level 3: 56%
+        <br />
+        <br />
+        It also reduces the price increase for every aug bought by:
+        <br />
+        <br />
+        Level 1: 4%
+        <br />
+        Level 2: 6%
+        <br />
+        Level 3: 7%
+      </>
+    ),
+  );
+  SourceFiles["SourceFile12"] = new SourceFile(
+    12,
+    <>This Source-File lets the player start with Neuroflux Governor equal to the level of this Source-File.</>,
+  );
+  SourceFiles["SourceFile13"] = new SourceFile(
+    13,
+    <>Each level of this Source-File increases the size of Stanek's Gift.</>,
+  );
+}

--- a/src/SourceFile/SourceFiles.tsx
+++ b/src/SourceFile/SourceFiles.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { SourceFile } from "./SourceFile";
 import { IMap } from "../types";
-import { initBitNodes } from "../BitNode/BitNode";
+import { initBitNodes, initBitNodeMultipliers } from "../BitNode/BitNode";
 
 export const SourceFiles: IMap<SourceFile> = {};
+/** Engine initializer for SourceFiles, BitNodes, and BitNodeMultipliers. Run once at engine load. */
 export function initSourceFiles() {
   initBitNodes();
+  initBitNodeMultipliers();
   SourceFiles["SourceFile1"] = new SourceFile(
     1,
     (

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -4,7 +4,6 @@
 import { convertTimeMsToTimeElapsedString } from "./utils/StringHelperFunctions";
 import { initAugmentations } from "./Augmentation/AugmentationHelpers";
 import { AugmentationNames } from "./Augmentation/data/AugmentationNames";
-import { initBitNodeMultipliers } from "./BitNode/BitNode";
 import { initSourceFiles } from "./SourceFile/SourceFiles";
 import { initDarkWebItems } from "./DarkWeb/DarkWebItems";
 import { generateRandomContract } from "./CodingContractGenerator";
@@ -232,7 +231,6 @@ const Engine: {
     if (loadGame(saveString)) {
       ThemeEvents.emit();
       initSourceFiles();
-      initBitNodeMultipliers();
       initDarkWebItems();
       initAugmentations(); // Also calls Player.reapplyAllAugmentations()
       Player.reapplyAllSourceFiles();
@@ -372,7 +370,6 @@ const Engine: {
     } else {
       // No save found, start new game
       initSourceFiles();
-      initBitNodeMultipliers();
       initDarkWebItems();
       Engine.start(); // Run main game loop and Scripts loop
       Player.init();

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -5,6 +5,7 @@ import { convertTimeMsToTimeElapsedString } from "./utils/StringHelperFunctions"
 import { initAugmentations } from "./Augmentation/AugmentationHelpers";
 import { AugmentationNames } from "./Augmentation/data/AugmentationNames";
 import { initBitNodeMultipliers } from "./BitNode/BitNode";
+import { initSourceFiles } from "./SourceFile/SourceFiles";
 import { initDarkWebItems } from "./DarkWeb/DarkWebItems";
 import { generateRandomContract } from "./CodingContractGenerator";
 import { initCompanies } from "./Company/Companies";
@@ -230,7 +231,7 @@ const Engine: {
 
     if (loadGame(saveString)) {
       ThemeEvents.emit();
-
+      initSourceFiles();
       initBitNodeMultipliers();
       initDarkWebItems();
       initAugmentations(); // Also calls Player.reapplyAllAugmentations()
@@ -370,6 +371,7 @@ const Engine: {
       );
     } else {
       // No save found, start new game
+      initSourceFiles();
       initBitNodeMultipliers();
       initDarkWebItems();
       Engine.start(); // Run main game loop and Scripts loop

--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -62,7 +62,7 @@ class NumeralFormatter {
     if (n === Infinity) return "∞";
     for (let i = 0; i < extraFormats.length; i++) {
       if (extraFormats[i] < nAbs && nAbs <= extraFormats[i] * 1000) {
-        return this.format(n as number / extraFormats[i], "0." + "0".repeat(decimalPlaces)) + extraNotations[i];
+        return this.format((n as number) / extraFormats[i], "0." + "0".repeat(decimalPlaces)) + extraNotations[i];
       }
     }
     if (nAbs < 1000) {

--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -38,9 +38,9 @@ class NumeralFormatter {
     return true;
   }
 
-  format(n: number, format: string): string {
-    // numeraljs doesnt properly format numbers that are too big or too small
-    if (Math.abs(n) < 1e-6) {
+  format(n: number | string, format?: string): string {
+    // numeral.js doesn't properly format numbers that are too big or too small
+    if (Math.abs(n as number) < 1e-6) {
       n = 0;
     }
     const answer = numeral(n).format(format);
@@ -50,19 +50,19 @@ class NumeralFormatter {
     return answer;
   }
 
-  formatBigNumber(n: number): string {
+  formatBigNumber(n: number | string): string {
     return this.format(n, "0.000a");
   }
 
   // TODO: leverage numeral.js to do it. This function also implies you can
   // use this format in some text field but you can't. ( "1t" will parse but
   // "1s" will not)
-  formatReallyBigNumber(n: number, decimalPlaces = 3): string {
-    const nAbs = Math.abs(n);
+  formatReallyBigNumber(n: number | string, decimalPlaces = 3): string {
+    const nAbs = Math.abs(n as number);
     if (n === Infinity) return "∞";
     for (let i = 0; i < extraFormats.length; i++) {
       if (extraFormats[i] < nAbs && nAbs <= extraFormats[i] * 1000) {
-        return this.format(n / extraFormats[i], "0." + "0".repeat(decimalPlaces)) + extraNotations[i];
+        return this.format(n as number / extraFormats[i], "0." + "0".repeat(decimalPlaces)) + extraNotations[i];
       }
     }
     if (nAbs < 1000) {
@@ -118,7 +118,7 @@ class NumeralFormatter {
     return this.format(n * gigaMultiplier.standard, "0.00b");
   }
 
-  formatPercentage(n: number, decimalPlaces = 2): string {
+  formatPercentage(n: number | string, decimalPlaces = 2): string {
     const formatter: string = "0." + "0".repeat(decimalPlaces) + "%";
     return this.format(n, formatter);
   }

--- a/test/jest/Netscript/DynamicRamCalculation.test.ts
+++ b/test/jest/Netscript/DynamicRamCalculation.test.ts
@@ -5,8 +5,6 @@ import { RunningScript } from "../../../src/Script/RunningScript";
 import { Script } from "../../../src/Script/Script";
 import { WorkerScript } from "../../../src/Netscript/WorkerScript";
 
-
-
 describe("Netscript Dynamic RAM Calculation/Generation Tests", function () {
   const ScriptBaseCost = RamCostConstants.ScriptBaseRamCost;
   // Creates a mock RunningScript object
@@ -85,10 +83,9 @@ describe("Netscript Dynamic RAM Calculation/Generation Tests", function () {
     // Run the function through the workerscript's args
     const scope = workerScript.env.vars;
     let curr = fnDesc.reduce((prev, curr) => {
-      try{
+      try {
         return prev[curr];
-      }
-      catch{
+      } catch {
         throw new Error(`Invalid function: [${fnDesc}]`);
       }
     }, scope as any);
@@ -143,14 +140,13 @@ describe("Netscript Dynamic RAM Calculation/Generation Tests", function () {
       scriptRef: runningScript,
     };
     workerScript.env.vars = NetscriptFunctions(workerScript as unknown as WorkerScript);
-    
+
     // Run the function through the workerscript's args
     const scope = workerScript.env.vars;
     let curr = fnDesc.reduce((prev, curr) => {
-      try{
+      try {
         return prev[curr];
-      }
-      catch{
+      } catch {
         throw new Error(`Invalid function: [${fnDesc}]`);
       }
     }, scope as any);

--- a/test/jest/Netscript/DynamicRamCalculation.test.ts
+++ b/test/jest/Netscript/DynamicRamCalculation.test.ts
@@ -41,7 +41,10 @@ describe("Netscript Dynamic RAM Calculation/Generation Tests", function () {
    * @param {(...args: unknown[]) => unknown} fn
    * @param  {unknown[]} args
    */
-  function runPotentiallyAsyncFunction(fn: Function, ...args: (string | number | boolean)[]) {
+  function runPotentiallyAsyncFunction(
+    fn: (...args: (string | number | boolean)[]) => unknown,
+    ...args: (string | number | boolean)[]
+  ) {
     const res = fn(...args);
     if (res instanceof Promise) {
       res.catch(() => undefined);
@@ -82,7 +85,7 @@ describe("Netscript Dynamic RAM Calculation/Generation Tests", function () {
 
     // Run the function through the workerscript's args
     const scope = workerScript.env.vars;
-    let curr = fnDesc.reduce((prev, curr) => {
+    const curr = fnDesc.reduce((prev, curr) => {
       try {
         return prev[curr];
       } catch {
@@ -143,7 +146,7 @@ describe("Netscript Dynamic RAM Calculation/Generation Tests", function () {
 
     // Run the function through the workerscript's args
     const scope = workerScript.env.vars;
-    let curr = fnDesc.reduce((prev, curr) => {
+    const curr = fnDesc.reduce((prev, curr) => {
       try {
         return prev[curr];
       } catch {

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -1,6 +1,3 @@
-// Player is needed for calculating costs like Singularity functions, that depend on acquired source files
-import { Player } from "../../../src/Player";
-
 import { RamCostConstants } from "../../../src/Netscript/RamCostGenerator";
 import { calculateRamUsage } from "../../../src/Script/RamCalculations";
 import { Script } from "../../../src/Script/Script";

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -5,10 +5,6 @@ import { RamCostConstants } from "../../../src/Netscript/RamCostGenerator";
 import { calculateRamUsage } from "../../../src/Script/RamCalculations";
 import { Script } from "../../../src/Script/Script";
 
-jest.mock(`!!raw-loader!../NetscriptDefinitions.d.ts`, () => "", {
-  virtual: true,
-});
-
 const ScriptBaseCost = RamCostConstants.ScriptBaseRamCost;
 const HackCost = 0.1;
 const GrowCost = 0.15;
@@ -17,13 +13,8 @@ const HacknetCost = 4;
 const CorpCost = 1024 - ScriptBaseCost;
 
 describe("Parsing NetScript code to work out static RAM costs", function () {
-  // Tests numeric equality, allowing for floating point imprecision - and includes script base cost
-  /**
-   *
-   * @param {number} val
-   * @param {number} expected
-   */
-  function expectCost(val, expected) {
+  /** Tests numeric equality, allowing for floating point imprecision - and includes script base cost */
+  function expectCost(val: number, expected: number) {
     const expectedWithBase = expected + ScriptBaseCost;
     expect(val).toBeGreaterThanOrEqual(expectedWithBase - 100 * Number.EPSILON);
     expect(val).toBeLessThanOrEqual(expectedWithBase + 100 * Number.EPSILON);
@@ -34,7 +25,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
       const code = `
         export async function main(ns) { }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, 0);
     });
 
@@ -44,7 +35,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.print("Slum snakes r00l!");
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, 0);
     });
 
@@ -54,7 +45,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.hack("joesguns");
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -64,7 +55,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await X.hack("joesguns");
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -75,7 +66,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.hack("joesguns");
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -86,7 +77,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.grow("joesguns");
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HackCost + GrowCost);
     });
 
@@ -99,7 +90,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.hack("joesguns");
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -114,7 +105,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           async doHacking() { await this.ns.hack("joesguns"); }
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -129,7 +120,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           async doHacking() { await this.#ns.hack("joesguns"); }
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HackCost);
     });
   });
@@ -142,7 +133,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         }
         function get() { return 0; }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, 0);
     });
 
@@ -153,7 +144,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         }
         function purchaseNode() { return 0; }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       // Works at present, because the parser checks the namespace only, not the function name
       expectCost(calculated, 0);
     });
@@ -166,7 +157,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         }
         function getTask() { return 0; }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, 0);
     });
   });
@@ -178,7 +169,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.hacknet.purchaseNode(0);
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, HacknetCost);
     });
 
@@ -188,7 +179,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.corporation.getCorporation();
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, CorpCost);
     });
 
@@ -199,7 +190,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.hacknet.purchaseNode(0);
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, CorpCost + HacknetCost);
     });
 
@@ -209,7 +200,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.sleeve.getTask(3);
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [])).cost;
+      const calculated = calculateRamUsage(code, []).cost;
       expectCost(calculated, SleeveGetTaskCost);
     });
   });
@@ -219,7 +210,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
       const libCode = `
         export function dummy() { return 0; }
       `;
-      const lib = new Script(Player, "libTest.js", libCode, []);
+      const lib = new Script("libTest.js", libCode);
 
       const code = `
         import { dummy } from "libTest";
@@ -227,7 +218,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           dummy();
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [lib])).cost;
+      const calculated = calculateRamUsage(code, [lib]).cost;
       expectCost(calculated, 0);
     });
 
@@ -235,7 +226,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
       const libCode = `
         export async function doHack(ns) { return await ns.hack("joesguns"); }
       `;
-      const lib = new Script(Player, "libTest.js", libCode, []);
+      const lib = new Script("libTest.js", libCode);
 
       const code = `
         import { doHack } from "libTest";
@@ -243,7 +234,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await doHack(ns);
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [lib])).cost;
+      const calculated = calculateRamUsage(code, [lib]).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -252,7 +243,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         export async function doHack(ns) { return await ns.hack("joesguns"); }
         export async function doGrow(ns) { return await ns.grow("joesguns"); }
       `;
-      const lib = new Script(Player, "libTest.js", libCode, []);
+      const lib = new Script("libTest.js", libCode);
 
       const code = `
         import { doHack } from "libTest";
@@ -260,7 +251,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await doHack(ns);
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [lib])).cost;
+      const calculated = calculateRamUsage(code, [lib]).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -269,7 +260,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         export async function doHack(ns) { return await ns.hack("joesguns"); }
         export async function doGrow(ns) { return await ns.grow("joesguns"); }
       `;
-      const lib = new Script(Player, "libTest.js", libCode, []);
+      const lib = new Script("libTest.js", libCode);
 
       const code = `
         import * as test from "libTest";
@@ -277,7 +268,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await test.doHack(ns);
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [lib])).cost;
+      const calculated = calculateRamUsage(code, [lib]).cost;
       expectCost(calculated, HackCost + GrowCost);
     });
 
@@ -291,7 +282,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           async doGrow() { return await this.ns.grow("joesguns"); }
         }
       `;
-      const lib = new Script(Player, "libTest.js", libCode, []);
+      const lib = new Script("libTest.js", libCode);
 
       const code = `
         import * as test from "libTest";
@@ -299,7 +290,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await test.doHack(ns);
         }
       `;
-      const calculated = (await calculateRamUsage(Player, code, [lib])).cost;
+      const calculated = calculateRamUsage(code, [lib]).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -314,7 +305,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
             return Grower;
           }
         `;
-      const lib = new Script(Player, "libTest.js", libCode, []);
+      const lib = new Script("libTest.js", libCode);
 
       const code = `
           import { createClass } from "libTest";
@@ -325,7 +316,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
             await growerInstance.doGrow();
           }
         `;
-      const calculated = (await calculateRamUsage(Player, code, [lib])).cost;
+      const calculated = calculateRamUsage(code, [lib]).cost;
       expectCost(calculated, GrowCost);
     });
   });

--- a/test/jest/Script/Script.test.ts
+++ b/test/jest/Script/Script.test.ts
@@ -1,9 +1,4 @@
 import { Script } from "../../../src/Script/Script";
-import { Player } from "../../../src/Player";
-
-jest.mock(`!!raw-loader!../NetscriptDefinitions.d.ts`, () => "", {
-  virtual: true,
-});
 
 const code = `/** @param {NS} ns */
 export async function main(ns) {
@@ -14,9 +9,8 @@ describe("Validate Save Script Works", function () {
   it("Save", function () {
     const server = "home";
     const filename = "test.js";
-    const player = Player;
     const script = new Script();
-    script.saveScript(player, filename, code, server, []);
+    script.saveScript(filename, code, server, []);
 
     expect(script.filename).toEqual(filename);
     expect(script.code).toEqual(code);

--- a/test/jest/Terminal/Directory.test.ts
+++ b/test/jest/Terminal/Directory.test.ts
@@ -224,10 +224,10 @@ describe("Terminal Directory Tests", function () {
     });
 
     it("should return false for invalid arguments", function () {
-      expect(isValidFilePath(null)).toEqual(false);
-      expect(isValidFilePath()).toEqual(false);
-      expect(isValidFilePath(5)).toEqual(false);
-      expect(isValidFilePath({})).toEqual(false);
+      expect(isValidFilePath(null as unknown as string)).toEqual(false);
+      expect(isValidFilePath(undefined as unknown as string)).toEqual(false);
+      expect(isValidFilePath(5 as unknown as string)).toEqual(false);
+      expect(isValidFilePath({} as unknown as string)).toEqual(false);
     });
   });
 
@@ -283,8 +283,8 @@ describe("Terminal Directory Tests", function () {
     });
 
     it("should return false for invalid inputs (inputs that aren't filepaths)", function () {
-      expect(isInRootDirectory(null)).toEqual(false);
-      expect(isInRootDirectory(undefined)).toEqual(false);
+      expect(isInRootDirectory(null  as unknown as string)).toEqual(false);
+      expect(isInRootDirectory(undefined  as unknown as string)).toEqual(false);
       expect(isInRootDirectory("")).toEqual(false);
       expect(isInRootDirectory(" ")).toEqual(false);
       expect(isInRootDirectory("a")).toEqual(false);

--- a/test/jest/Terminal/Directory.test.ts
+++ b/test/jest/Terminal/Directory.test.ts
@@ -283,8 +283,8 @@ describe("Terminal Directory Tests", function () {
     });
 
     it("should return false for invalid inputs (inputs that aren't filepaths)", function () {
-      expect(isInRootDirectory(null  as unknown as string)).toEqual(false);
-      expect(isInRootDirectory(undefined  as unknown as string)).toEqual(false);
+      expect(isInRootDirectory(null as unknown as string)).toEqual(false);
+      expect(isInRootDirectory(undefined as unknown as string)).toEqual(false);
       expect(isInRootDirectory("")).toEqual(false);
       expect(isInRootDirectory(" ")).toEqual(false);
       expect(isInRootDirectory("a")).toEqual(false);

--- a/test/jest/Terminal/determineAllPossibilitiesForTabCompletion.test.ts
+++ b/test/jest/Terminal/determineAllPossibilitiesForTabCompletion.test.ts
@@ -1,4 +1,3 @@
-import { CityName } from "./../../../src/Locations/data/CityNames";
 /* eslint-disable no-await-in-loop */
 
 import { Player } from "../../../src/Player";
@@ -7,10 +6,7 @@ import { Server } from "../../../src/Server/Server";
 import { AddToAllServers, prestigeAllServers } from "../../../src/Server/AllServers";
 import { LocationName } from "../../../src/Locations/data/LocationNames";
 import { CodingContract } from "../../../src/CodingContracts";
-
-jest.mock(`!!raw-loader!../NetscriptDefinitions.d.ts`, () => "", {
-  virtual: true,
-});
+import { initDarkWebItems } from "../../../src/DarkWeb/DarkWebItems";
 
 describe("determineAllPossibilitiesForTabCompletion", function () {
   let closeServer: Server;
@@ -18,6 +14,7 @@ describe("determineAllPossibilitiesForTabCompletion", function () {
 
   beforeEach(() => {
     prestigeAllServers();
+    initDarkWebItems();
     Player.init();
 
     closeServer = new Server({
@@ -36,7 +33,7 @@ describe("determineAllPossibilitiesForTabCompletion", function () {
       hackDifficulty: 1,
       moneyAvailable: 70000,
       numOpenPortsRequired: 0,
-      organizationName: CityName.Aevum,
+      organizationName: LocationName.Sector12JoesGuns,
       requiredHackingSkill: 1,
       serverGrowth: 3000,
     });
@@ -49,12 +46,12 @@ describe("determineAllPossibilitiesForTabCompletion", function () {
   });
 
   it("completes the connect command", async () => {
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "connect ", 0);
+    const options = await determineAllPossibilitiesForTabCompletion("connect ", 0);
     expect(options).toEqual(["near"]);
   });
 
   it("completes the buy command", async () => {
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "buy ", 0);
+    const options = await determineAllPossibilitiesForTabCompletion("buy ", 0);
     expect(options.sort()).toEqual(
       [
         "BruteSSH.exe",
@@ -74,43 +71,43 @@ describe("determineAllPossibilitiesForTabCompletion", function () {
   it("completes the scp command", async () => {
     Player.getHomeComputer().writeToTextFile("note.txt", "oh hai mark");
     Player.getHomeComputer().messages.push("af.lit");
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
-    const options1 = await determineAllPossibilitiesForTabCompletion(Player, "scp ", 0);
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
+    const options1 = await determineAllPossibilitiesForTabCompletion("scp ", 0);
     expect(options1).toEqual(["/www/script.js", "af.lit", "note.txt", "www/"]);
 
-    const options2 = await determineAllPossibilitiesForTabCompletion(Player, "scp note.txt ", 1);
+    const options2 = await determineAllPossibilitiesForTabCompletion("scp note.txt ", 1);
     expect(options2).toEqual(["home", "near", "far"]);
   });
 
   it("completes the kill, tail, mem, and check commands", async () => {
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
     for (const command of ["kill", "tail", "mem", "check"]) {
-      const options = await determineAllPossibilitiesForTabCompletion(Player, `${command} `, 0);
+      const options = await determineAllPossibilitiesForTabCompletion(`${command} `, 0);
       expect(options).toEqual(["/www/script.js", "www/"]);
     }
   });
 
   it("completes the nano commands", async () => {
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
     Player.getHomeComputer().writeToTextFile("note.txt", "oh hai mark");
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "nano ", 0);
+    const options = await determineAllPossibilitiesForTabCompletion("nano ", 0);
     expect(options).toEqual(["/www/script.js", "note.txt", "www/"]);
   });
 
   it("completes the rm command", async () => {
     Player.getHomeComputer().writeToTextFile("note.txt", "oh hai mark");
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
     Player.getHomeComputer().contracts.push(new CodingContract("linklist.cct"));
     Player.getHomeComputer().messages.push("asl.msg");
     Player.getHomeComputer().messages.push("af.lit");
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "rm ", 0);
+    const options = await determineAllPossibilitiesForTabCompletion("rm ", 0);
     expect(options).toEqual(["/www/script.js", "NUKE.exe", "af.lit", "note.txt", "linklist.cct", "www/"]);
   });
 
   it("completes the run command", async () => {
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
     Player.getHomeComputer().contracts.push(new CodingContract("linklist.cct"));
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "run ", 0);
+    const options = await determineAllPossibilitiesForTabCompletion("run ", 0);
     expect(options).toEqual(["/www/script.js", "NUKE.exe", "linklist.cct", "www/"]);
   });
 
@@ -118,36 +115,36 @@ describe("determineAllPossibilitiesForTabCompletion", function () {
     Player.getHomeComputer().writeToTextFile("/www/note.txt", "oh hai mark");
     Player.getHomeComputer().messages.push("asl.msg");
     Player.getHomeComputer().messages.push("af.lit");
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "cat ", 0);
+    const options = await determineAllPossibilitiesForTabCompletion("cat ", 0);
     expect(options).toEqual(["asl.msg", "af.lit", "/www/note.txt", "www/"]);
   });
 
   it("completes the download and mv commands", async () => {
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
     Player.getHomeComputer().writeToTextFile("note.txt", "oh hai mark");
     for (const command of ["download", "mv"]) {
-      const options = await determineAllPossibilitiesForTabCompletion(Player, `${command} `, 0);
+      const options = await determineAllPossibilitiesForTabCompletion(`${command} `, 0);
       expect(options).toEqual(["/www/script.js", "note.txt", "www/"]);
     }
   });
 
   it("completes the cd command", async () => {
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "cd ", 0);
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
+    const options = await determineAllPossibilitiesForTabCompletion("cd ", 0);
     expect(options).toEqual(["www/"]);
   });
 
   it("completes the ls and cd commands", async () => {
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
     for (const command of ["ls", "cd"]) {
-      const options = await determineAllPossibilitiesForTabCompletion(Player, `${command} `, 0);
+      const options = await determineAllPossibilitiesForTabCompletion(`${command} `, 0);
       expect(options).toEqual(["www/"]);
     }
   });
 
   it("completes commands starting with ./", async () => {
-    Player.getHomeComputer().writeToScriptFile(Player, "/www/script.js", "oh hai mark");
-    const options = await determineAllPossibilitiesForTabCompletion(Player, "run ./", 0);
+    Player.getHomeComputer().writeToScriptFile("/www/script.js", "oh hai mark");
+    const options = await determineAllPossibilitiesForTabCompletion("run ./", 0);
     expect(options).toEqual([".//www/script.js", "NUKE.exe", "./www/"]);
   });
 });

--- a/test/jest/ui/nFormat.test.ts
+++ b/test/jest/ui/nFormat.test.ts
@@ -241,6 +241,6 @@ describe("Finding the number furthest away from 0", () => {
     expect(numeralWrapper.largestAbsoluteNumber(789123, -123456, -456789)).toEqual(789123);
   });
   test("Should return 0 for invalid input", () => {
-    expect(numeralWrapper.largestAbsoluteNumber("abc", undefined, null)).toEqual(0);
+    expect(numeralWrapper.largestAbsoluteNumber("abc" as unknown as number, undefined, null as unknown as number)).toEqual(0);
   });
 });

--- a/test/jest/ui/nFormat.test.ts
+++ b/test/jest/ui/nFormat.test.ts
@@ -1,6 +1,6 @@
 import { numeralWrapper } from "../../../src/ui/numeralFormat";
 
-let decimalFormat = "0.[000000]";
+const decimalFormat = "0.[000000]";
 
 describe("Numeral formatting for positive numbers", () => {
   test("should not format too small numbers", () => {

--- a/test/jest/ui/nFormat.test.ts
+++ b/test/jest/ui/nFormat.test.ts
@@ -241,6 +241,8 @@ describe("Finding the number furthest away from 0", () => {
     expect(numeralWrapper.largestAbsoluteNumber(789123, -123456, -456789)).toEqual(789123);
   });
   test("Should return 0 for invalid input", () => {
-    expect(numeralWrapper.largestAbsoluteNumber("abc" as unknown as number, undefined, null as unknown as number)).toEqual(0);
+    expect(
+      numeralWrapper.largestAbsoluteNumber("abc" as unknown as number, undefined, null as unknown as number),
+    ).toEqual(0);
   });
 });


### PR DESCRIPTION
Here are a description of the changes:
1. All test files changes to .ts instead of .js. Fixed a bunch of function parameter issues to fix test failures.
2. removed jest mock for NetscriptDefinition.d.ts. At first this required adding .d.ts as an extension type for jest config. Later I had to remove the extra .d.ts extension type for a lint failure of the configs not matching. But after converting all tests to .ts, this extra .d.ts extension is no longer needed and the tests do not complain about not being able to find that file despite removing the jest mock.
3. ran `npx browserslist@latest --update-db` because I kept getting yelled at in the console that it was out of date. This modified package-lock.json.
4. Added initializers for SourceFiles and BitNodes because there was a circular import dependency causing the tests to fail without these. initSourceFiles calls initBitNodes and initBitNodeMultipliers. These initializers occur first in the Engine initialization.
5. On numeralWrapper, changed some of the functions to accept number | string instead of just number, and to treat the input `as number` in functions where it is going to be autoconverted (e.g. Math functions). This matches the actual behavior and also doesn't complain about all the tests with strings.
6. Also includes a format+lint which fixed two unrelated files.