### PR TITLE
MISC: Fix bug in person.hasAugmentation

### DIFF
--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -199,5 +199,11 @@ export function updateSkillLevels(this: Person): void {
 }
 
 export function hasAugmentation(this: Person, augName: string, ignoreQueued = false) {
-  return this.augmentations.some((a) => a.name === augName && (ignoreQueued || !this.queuedAugmentations.includes(a)));
+  if (this.augmentations.some((a) => a.name === augName)) {
+    return true;
+  }
+  if (!ignoreQueued && this.queuedAugmentations.some((a) => a.name === augName)) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
#4122 introduced a bug where `person.hasAugmentation` did not correctly return if a player had a queued augmentation.

Screenshot of the bug in question: I should be able to purchase CSP Gen III since I own CSP Gen II (it is queued, but not installed)
![image](https://user-images.githubusercontent.com/15802150/193939910-3bd98488-ed79-40ad-833a-9dd1f7afce76.png)

For reference, the commit showing the regression: https://github.com/danielyxie/bitburner/commit/b364cdf7343c365f4edd3e39e2cca8fe41011cb8?diff=split#diff-1a340806bb6720dd5be22ba71979a6b26940f77dcc4b72d029360b6d2e85b3fdL10