### PR TITLE
DOC: `ns.exec()`: typo fixes and clean presentation

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5369,10 +5369,10 @@ export interface NS {
    * @remarks
    * RAM cost: 1.3 GB
    *
-   * Run a script as a separate process on a specified server. This is similar to the run function
+   * Run a script as a separate process on a specified server. This is similar to the function {@link NS.run | run}
    * except that it can be used to run a script on any server, instead of just the current server.
    *
-   * If the script was successfully started, then this functions returns the PID of that script.
+   * If the script was successfully started, then this function returns the PID of that script.
    * Otherwise, it returns 0.
    *
    * PID stands for Process ID. The PID is a unique identifier for each script.
@@ -5392,7 +5392,7 @@ export interface NS {
    * //This last example will try to run the script foo.script on the foodnstuff server with 5 threads. It will also pass the number 1 and the string “test” in as arguments to the script:
    * exec("foo.script", "foodnstuff", 5, 1, "test");
    * ```
-   * * @example
+   * @example
    * ```ts
    * // NS2:
    * //The simplest way to use the exec command is to call it with just the script name and the target server. The following example will try to run generic-hack.script on the foodnstuff server:
@@ -5406,7 +5406,7 @@ export interface NS {
    * ```
    * @param script - Filename of script to execute.
    * @param host - Hostname of the `target server` on which to execute the script.
-   * @param numThreads - Optional thread count for new script. Set to 1 by default. Will be rounded to nearest integer.
+   * @param numThreads - Optional thread count for new script. Set to 1 by default. Will be rounded down to the nearest integer.
    * @param args - Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the third argument numThreads must be filled in with a value.
    * @returns Returns the PID of a successfully started script, and 0 otherwise.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5383,25 +5383,35 @@ export interface NS {
    * @example
    * ```ts
    * // NS1:
-   * //The simplest way to use the exec command is to call it with just the script name and the target server. The following example will try to run generic-hack.script on the foodnstuff server:
+   * // The simplest way to use the exec command is to call it with just the script name
+   * // and the target server. The following example will try to run generic-hack.script
+   * // on the foodnstuff server.
    * exec("generic-hack.script", "foodnstuff");
    *
-   * //The following example will try to run the script generic-hack.script on the joesguns server with 10 threads:
+   * // The following example will try to run the script generic-hack.script on the
+   * // joesguns server with 10 threads.
    * exec("generic-hack.script", "joesguns", 10);
    *
-   * //This last example will try to run the script foo.script on the foodnstuff server with 5 threads. It will also pass the number 1 and the string “test” in as arguments to the script:
+   * // This last example will try to run the script foo.script on the foodnstuff server
+   * // with 5 threads. It will also pass the number 1 and the string “test” in as
+   * // arguments to the script.
    * exec("foo.script", "foodnstuff", 5, 1, "test");
    * ```
    * @example
    * ```ts
    * // NS2:
-   * //The simplest way to use the exec command is to call it with just the script name and the target server. The following example will try to run generic-hack.script on the foodnstuff server:
+   * // The simplest way to use the exec command is to call it with just the script name
+   * // and the target server. The following example will try to run generic-hack.script
+   * // on the foodnstuff server.
    * ns.exec("generic-hack.script", "foodnstuff");
    *
-   * //The following example will try to run the script generic-hack.script on the joesguns server with 10 threads:
+   * // The following example will try to run the script generic-hack.script on the
+   * // joesguns server with 10 threads.
    * ns.exec("generic-hack.script", "joesguns", 10);
    *
-   * //This last example will try to run the script foo.script on the foodnstuff server with 5 threads. It will also pass the number 1 and the string “test” in as arguments to the script:
+   * // This last example will try to run the script foo.script on the foodnstuff server
+   * // with 5 threads. It will also pass the number 1 and the string “test” in as
+   * // arguments to the script.
    * ns.exec("foo.script", "foodnstuff", 5, 1, "test");
    * ```
    * @param script - Filename of script to execute.


### PR DESCRIPTION
A bunch of typographical fixes in the documentation of `ns.exec()`.  Also, break very long comments into multiple lines so they can be viewed online via a browser without having to use the horizontal scrollbar.  The commit messages contain more details.