### PR TITLE
FACTION: Include BN multiplier in faction donation

### DIFF
--- a/src/Faction/formulas/donation.ts
+++ b/src/Faction/formulas/donation.ts
@@ -1,6 +1,7 @@
 import { CONSTANTS } from "../../Constants";
+import { BitNodeMultipliers } from "../../BitNode/BitNodeMultipliers";
 import { Person } from "../../PersonObjects/Person";
 
 export function repFromDonation(amt: number, person: Person): number {
-  return (amt / CONSTANTS.DonateMoneyToRepDivisor) * person.mults.faction_rep;
+  return (amt / CONSTANTS.DonateMoneyToRepDivisor) * person.mults.faction_rep * BitNodeMultipliers.FactionWorkRepGain;
 }


### PR DESCRIPTION
# FACTION: Include BN multiplier in faction donation

This got mentioned in the Steam forums, I'm not 100% convinced if it should be changed or not. But currently it is very unclear to the player that there is a difference between working and donating.

They grey number is used for donations, while the white one is used for work.

![grafik](https://user-images.githubusercontent.com/22813377/194639978-adecdd5a-5a1d-49b2-b24c-c98cd2defe21.png)

If this change is accepted, the BN multipliers name should be changed in the future to match.