### PR TITLE
DOC: gang task: typo fix

### DIFF
--- a/src/Gang/data/tasks.ts
+++ b/src/Gang/data/tasks.ts
@@ -282,7 +282,7 @@ export const gangMemberTasksMetadata: IGangMemberTaskMetadata[] = [
     },
   },
   {
-    desc: "Assign this gang member to threaten and black mail high-profile targets<br><br>Earns money - Slightly increases respect - Slightly increases wanted level",
+    desc: "Assign this gang member to threaten and blackmail high-profile targets<br><br>Earns money - Slightly increases respect - Slightly increases wanted level",
     isCombat: true,
     isHacking: false,
     name: "Threaten & Blackmail",


### PR DESCRIPTION
In the list of gang tasks, change `black mail` to `blackmail` because the description is referring to the crime of blackmail.