### PR TITLE
SLEEVE: Fixes 2 issues in Sleeve's implementation of crime work 

### DIFF
--- a/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
@@ -25,16 +25,16 @@ export class SleeveCrimeWork extends Work {
     return crime;
   }
 
-  getExp(): WorkStats {
+  getExp(sleeve: Sleeve): WorkStats {
     const crime = this.getCrime();
     return newWorkStats({
-      money: crime.money * BitNodeMultipliers.CrimeMoney,
-      hackExp: crime.hacking_exp * BitNodeMultipliers.CrimeExpGain,
-      strExp: crime.strength_exp * BitNodeMultipliers.CrimeExpGain,
-      defExp: crime.defense_exp * BitNodeMultipliers.CrimeExpGain,
-      dexExp: crime.dexterity_exp * BitNodeMultipliers.CrimeExpGain,
-      agiExp: crime.agility_exp * BitNodeMultipliers.CrimeExpGain,
-      chaExp: crime.charisma_exp * BitNodeMultipliers.CrimeExpGain,
+      money: crime.money * BitNodeMultipliers.CrimeMoney * sleeve.mults.crime_money,
+      hackExp: crime.hacking_exp * BitNodeMultipliers.CrimeExpGain * sleeve.mults.hacking_exp,
+      strExp: crime.strength_exp * BitNodeMultipliers.CrimeExpGain * sleeve.mults.strength_exp,
+      defExp: crime.defense_exp * BitNodeMultipliers.CrimeExpGain * sleeve.mults.defense_exp,
+      dexExp: crime.dexterity_exp * BitNodeMultipliers.CrimeExpGain * sleeve.mults.dexterity_exp,
+      agiExp: crime.agility_exp * BitNodeMultipliers.CrimeExpGain * sleeve.mults.agility_exp,
+      chaExp: crime.charisma_exp * BitNodeMultipliers.CrimeExpGain * sleeve.mults.charisma_exp,
       intExp: crime.intelligence_exp * BitNodeMultipliers.CrimeExpGain,
     });
   }
@@ -47,7 +47,7 @@ export class SleeveCrimeWork extends Work {
     this.cyclesWorked += cycles;
 
     const crime = this.getCrime();
-    let gains = this.getExp();
+    let gains = this.getExp(sleeve);
     if (this.cyclesWorked >= this.cyclesNeeded()) {
       if (Math.random() < crime.successRate(sleeve)) {
         Player.karma -= crime.karma * sleeve.syncBonus();

--- a/src/PersonObjects/Sleeve/ui/StatsElement.tsx
+++ b/src/PersonObjects/Sleeve/ui/StatsElement.tsx
@@ -97,15 +97,15 @@ export function EarningsElement(props: IProps): React.ReactElement {
 
   let data: (string | JSX.Element)[][] = [];
   if (isSleeveCrimeWork(props.sleeve.currentWork)) {
-    const gains = props.sleeve.currentWork.getExp();
+    const gains = props.sleeve.currentWork.getExp(props.sleeve);
     data = [
       [`Money:`, <Money money={5 * gains.money} />],
-      [`Hacking Exp:`, `${numeralWrapper.formatExp(5 * gains.hackExp * BitNodeMultipliers.CrimeExpGain)}`],
-      [`Strength Exp:`, `${numeralWrapper.formatExp(5 * gains.strExp * BitNodeMultipliers.CrimeExpGain)}`],
-      [`Defense Exp:`, `${numeralWrapper.formatExp(5 * gains.defExp * BitNodeMultipliers.CrimeExpGain)}`],
-      [`Dexterity Exp:`, `${numeralWrapper.formatExp(5 * gains.dexExp * BitNodeMultipliers.CrimeExpGain)}`],
-      [`Agility Exp:`, `${numeralWrapper.formatExp(5 * gains.agiExp * BitNodeMultipliers.CrimeExpGain)}`],
-      [`Charisma Exp:`, `${numeralWrapper.formatExp(5 * gains.chaExp * BitNodeMultipliers.CrimeExpGain)}`],
+      [`Hacking Exp:`, `${numeralWrapper.formatExp(5 * gains.hackExp)}`],
+      [`Strength Exp:`, `${numeralWrapper.formatExp(5 * gains.strExp)}`],
+      [`Defense Exp:`, `${numeralWrapper.formatExp(5 * gains.defExp)}`],
+      [`Dexterity Exp:`, `${numeralWrapper.formatExp(5 * gains.dexExp)}`],
+      [`Agility Exp:`, `${numeralWrapper.formatExp(5 * gains.agiExp)}`],
+      [`Charisma Exp:`, `${numeralWrapper.formatExp(5 * gains.chaExp)}`],
     ];
   }
   if (isSleeveClassWork(props.sleeve.currentWork)) {


### PR DESCRIPTION
Fixes :
Bitnode multiplier being applied twice in the Sleeve UI. (So a x0.5 would appear to be x0.25)
Sleeve's multipliers not being applied at all (neither in UI, nor engine).

