### PR TITLE
UI: Fixed `nano` not correctly opening a script in root of a server if `cd`'d into a directory

### DIFF
--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -150,8 +150,12 @@ export function ls(args: (string | number | boolean)[], server: BaseServer): voi
         return Terminal.error(`File is not on this server, connect to ${hostname} and try again`);
       }
       if (filename.startsWith("/")) filename = filename.slice(1);
+      // Terminal.getFilepath needs leading slash to correctly work here
+      if (prefix === "") filename = `/${filename}`;
       const filepath = Terminal.getFilepath(`${prefix}${filename}`);
-      const code = toString(Terminal.getScript(filepath)?.code);
+      // Terminal.getScript also calls Terminal.getFilepath and therefore also
+      // needs the given parameter
+      const code = toString(Terminal.getScript(`${prefix}${filename}`)?.code);
       Router.toScriptEditor({ [filepath]: code });
     }
 


### PR DESCRIPTION
This PR fixes `nano` opening the incorrect file in the root directory if you cd'd into a directory.

## Expected Behavior
The script editor should open the correct file when you click on a file name of the root directory while having a directory currently opened/displayed.

## Steps to reproduce
1. Create a file in root directory.
2. Execute `ls` command.
3. Create a file in a directory.
4. Navigate to directory via `cd`.
5. Click on the file link of the previous `ls`.

Currently this opens a file in the current directory with the name of file in the root directory.

## Checks made this works
I created multiple files in different and differently nested directories. I executed `ls` on all directories and opened all files from every selected directory. For me this seems to work now.
