### PR TITLE
ns.getBitNodeMultipliers will now optionally accept 2 args

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1091,6 +1091,10 @@ const base: InternalAPI<NS> = {
       }
 
       if (bitNode != 12) {
+        if (Player.bitNodeN == 12) {
+          const copy = Object.assign({}, BitNodeMultipliers);
+          return copy;
+        }
         const copy = Object.assign({}, specificBNMultipliers(bitNode, 0));
         return copy;
       } else if (bitNode == 12) {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import { vsprintf, sprintf } from "sprintf-js";
 import { WorkerScriptStartStopEventEmitter } from "./Netscript/WorkerScriptStartStopEventEmitter";
 import { BitNodeMultipliers } from "./BitNode/BitNodeMultipliers";
+import { getBitNodeMultipliers as specificBNMultipliers } from "./BitNode/BitNode";
 import { CONSTANTS } from "./Constants";
 import {
   calculateHackingChance,
@@ -1072,13 +1073,36 @@ const base: InternalAPI<NS> = {
       levelCost: Player.mults.hacknet_node_level_cost,
     };
   },
-  getBitNodeMultipliers: (ctx: NetscriptContext) => (): IBNMults => {
-    if (Player.sourceFileLvl(5) <= 0 && Player.bitNodeN !== 5) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "Requires Source-File 5 to run.");
-    }
-    const copy = Object.assign({}, BitNodeMultipliers);
-    return copy;
-  },
+  getBitNodeMultipliers: 
+    (ctx: NetscriptContext) => 
+    (_bitNode: number, _lvl: number): IBNMults => {
+      let bitNode = _bitNode;
+      const lvl = _lvl;
+      if (Player.sourceFileLvl(5) <= 0 && Player.bitNodeN !== 5) {
+        throw helpers.makeRuntimeErrorMsg(ctx, "Requires Source-File 5 to run.");
+      }
+
+      if (bitNode == undefined) {
+        bitNode = Player.bitNodeN;
+      }
+
+      if (bitNode > 13 || bitNode < 1 ) {
+        throw helpers.makeRuntimeErrorMsg(ctx, "Invalid BitNode, can only be an integer 1-13");
+      }
+
+      if (lvl < 0 && lvl != undefined) {
+        throw helpers.makeRuntimeErrorMsg(ctx, "Invalid level, must be an integer above 0.");
+      }
+
+      if (bitNode != 12) {
+        const copy = Object.assign({}, specificBNMultipliers(bitNode, 0));
+        return copy;
+      } else if (bitNode == 12) {
+        const copy = Object.assign({}, specificBNMultipliers(bitNode, lvl));
+        return copy;
+      }
+      return Object.assign({}, BitNodeMultipliers);
+    },
   getServer:
     (ctx: NetscriptContext) =>
     (_hostname: unknown = ctx.workerScript.hostname): IServerDef => {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1075,15 +1075,11 @@ const base: InternalAPI<NS> = {
   },
   getBitNodeMultipliers:
     (ctx: NetscriptContext) =>
-    (_bitNode: number, _lvl: number): IBNMults => {
-      let bitNode = _bitNode;
-      const lvl = _lvl;
+    (_bitNode: unknown = Player.bitNodeN, _lvl: unknown = 1): IBNMults => {
+      const bitNode = helpers.number(ctx, "bitNode", _bitNode);
+      const lvl = helpers.number(ctx, "lvl", _lvl);
       if (Player.sourceFileLvl(5) <= 0 && Player.bitNodeN !== 5) {
         throw helpers.makeRuntimeErrorMsg(ctx, "Requires Source-File 5 to run.");
-      }
-
-      if (bitNode == undefined) {
-        bitNode = Player.bitNodeN;
       }
 
       if (bitNode > 13 || bitNode < 1) {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1097,7 +1097,7 @@ const base: InternalAPI<NS> = {
         if (Player.bitNodeN == 12) {
           const copy = Object.assign({}, BitNodeMultipliers);
           return copy;
-        } 
+        }
         const copy = Object.assign({}, specificBNMultipliers(bitNode, lvl));
         return copy;
       }

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1091,13 +1091,13 @@ const base: InternalAPI<NS> = {
       }
 
       if (bitNode != 12) {
-        if (Player.bitNodeN == 12) {
-          const copy = Object.assign({}, BitNodeMultipliers);
-          return copy;
-        }
         const copy = Object.assign({}, specificBNMultipliers(bitNode, 0));
         return copy;
       } else if (bitNode == 12) {
+        if (Player.bitNodeN == 12) {
+          const copy = Object.assign({}, BitNodeMultipliers);
+          return copy;
+        } 
         const copy = Object.assign({}, specificBNMultipliers(bitNode, lvl));
         return copy;
       }

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1073,8 +1073,8 @@ const base: InternalAPI<NS> = {
       levelCost: Player.mults.hacknet_node_level_cost,
     };
   },
-  getBitNodeMultipliers: 
-    (ctx: NetscriptContext) => 
+  getBitNodeMultipliers:
+    (ctx: NetscriptContext) =>
     (_bitNode: number, _lvl: number): IBNMults => {
       let bitNode = _bitNode;
       const lvl = _lvl;
@@ -1086,7 +1086,7 @@ const base: InternalAPI<NS> = {
         bitNode = Player.bitNodeN;
       }
 
-      if (bitNode > 13 || bitNode < 1 ) {
+      if (bitNode > 13 || bitNode < 1) {
         throw helpers.makeRuntimeErrorMsg(ctx, "Invalid BitNode, can only be an integer 1-13");
       }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6603,11 +6603,11 @@ export interface NS {
    * print(ServerMaxMoney);
    * print(HackExpGain);
    * ```
-   * @param BitNode - BitNode you want the multipliers for.
-   * @param lvl - The level of the BitNode (for BN12)
+   * @param bitNode - BitNode you want the multipliers for. Optional.
+   * @param lvl - The level of the BitNode. Optional. For BN12.
    * @returns Object containing the current (or supplied) BitNode multipliers.
    */
-  getBitNodeMultipliers(BitNode, lvl): BitNodeMultipliers;
+  getBitNodeMultipliers(bitNode?: number, lvl?: number): BitNodeMultipliers;
 
   /**
    * Get information about the player.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6579,7 +6579,7 @@ export interface NS {
    * @remarks
    * RAM cost: 4 GB
    *
-   * Returns an object containing the current BitNode multipliers.
+   * Returns an object containing the current (or supplied) BitNode multipliers.
    * This function requires you to be in Bitnode 5 or have Source-File 5 in order to run.
    * The multipliers are returned in decimal forms (e.g. 1.5 instead of 150%).
    * The multipliers represent the difference between the current BitNode and
@@ -6603,9 +6603,11 @@ export interface NS {
    * print(ServerMaxMoney);
    * print(HackExpGain);
    * ```
-   * @returns Object containing the current BitNode multipliers.
+   * @param BitNode - BitNode you want the multipliers for.
+   * @param lvl - The level of the BitNode (for BN12)
+   * @returns Object containing the current (or supplied) BitNode multipliers.
    */
-  getBitNodeMultipliers(): BitNodeMultipliers;
+  getBitNodeMultipliers(BitNode, lvl): BitNodeMultipliers;
 
   /**
    * Get information about the player.


### PR DESCRIPTION
# ns.getBitNodeMultipliers will now optionally accept 2 args

MISC: `ns.getBitNodeMultipliers()` can now optionally accept 2 args, so that the player can get the multipliers of a bitnode that they are not currently in.

made per this request: https://discord.com/channels/415207508303544321/415207923506216971/1028774572436230244