### PR TITLE
DOC: `ns.scan()`: typo fixes and add 2 examples

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5156,8 +5156,8 @@ export interface NS {
    * node way from the specified target server. The hostnames in the returned
    * array are strings.
    *
-   * @param host - Optional, Hostname of the server to scan, default to current server.
-   * @returns Returns an string of hostnames.
+   * @param host - Optional. Hostname of the server to scan, default to current server.
+   * @returns Returns an array of hostnames.
    */
   scan(host?: string): string[];
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5156,6 +5156,41 @@ export interface NS {
    * node way from the specified target server. The hostnames in the returned
    * array are strings.
    *
+   * @example
+   * ```ts
+   * // NS1
+   * // All servers that are one hop from the current server.
+   * tprint("Neighbors of current server.");
+   * var neighbor = scan();
+   * for (var i = 0; i < neighbor.length; i++) {
+   *     tprint(neighbor[i]);
+   * }
+   * // All neighbors of n00dles.
+   * var target = "n00dles";
+   * neighbor = scan(target);
+   * tprintf("Neighbors of %s.", target);
+   * for (var i = 0; i < neighbor.length; i++) {
+   *     tprint(neighbor[i]);
+   * }
+   * ```
+   * @example
+   * ```ts
+   * // NS2
+   * // All servers that are one hop from the current server.
+   * ns.tprint("Neighbors of current server.");
+   * let neighbor = ns.scan();
+   * for (let i = 0; i < neighbor.length; i++) {
+   *     ns.tprint(neighbor[i]);
+   * }
+   * // All neighbors of n00dles.
+   * const target = "n00dles";
+   * neighbor = ns.scan(target);
+   * ns.tprintf("Neighbors of %s.", target);
+   * for (let i = 0; i < neighbor.length; i++) {
+   *     ns.tprint(neighbor[i]);
+   * }
+   * ```
+   *
    * @param host - Optional. Hostname of the server to scan, default to current server.
    * @returns Returns an array of hostnames.
    */


### PR DESCRIPTION
This PR changes the documentation of the function `ns.scan()` as follows:

1. Commit 67f5d601162f3600e7cde6abbae2b2106e7b3ea9.  Some typographical fixes in the parameter and return value of the function.
2. Commit b03288a7003404814b7d9e21ce84defdc375bbf4.  Two examples on using `ns.scan()`.  The first example uses `ns.scan()` without an argument.  The second example uses `ns.scan()` by passing the hostname of a target server.  These examples can be written more concisely by using the `forEach()` method of array, but for the purposes of illustration we use a `for` loop to make it easier for beginners to read.
3. ~Commit e3c466e2ecf8c8bedb3e75fd6a03d9355151c0a2.  Add an example on how to use the function to navigate all servers in the game.~