### PR TITLE
DOC: `ns.sleeve.setToCommitCrime()`: add list of crimes a sleeve can commit

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3618,8 +3618,25 @@ export interface Sleeve {
    *
    * Returns false if an invalid action is specified.
    *
+   * You can set a sleeve to commit one of the following crimes. The crime names are not
+   * case sensitive. For example, you can pass in the crime name as `"Shoplift"`,
+   * `"shoplift"`, `"shopLift"`, or even `"SHOPLIFT"`.
+   *
+   * - Assassination
+   * - Bond forgery
+   * - Deal drugs
+   * - Grand theft auto
+   * - Heist
+   * - Homicide
+   * - Kidnap
+   * - Larceny
+   * - Mug
+   * - Rob store
+   * - Shoplift
+   * - Traffick arms
+   *
    * @param sleeveNumber - Index of the sleeve to start committing crime. Sleeves are numbered starting from 0.
-   * @param name - Name of the crime. Must be an exact match.
+   * @param name - Name of the crime. Must be an exact match. Refer to the list of crimes.
    * @returns True if this action was set successfully, false otherwise.
    */
   setToCommitCrime(sleeveNumber: number, name: string): boolean;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3618,7 +3618,7 @@ export interface Sleeve {
    *
    * Returns false if an invalid action is specified.
    *
-   * @param sleeveNumber - Index of the sleeve to start committing crime.
+   * @param sleeveNumber - Index of the sleeve to start committing crime. Sleeves are numbered starting from 0.
    * @param name - Name of the crime. Must be an exact match.
    * @returns True if this action was set successfully, false otherwise.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3635,6 +3635,27 @@ export interface Sleeve {
    * - Shoplift
    * - Traffick arms
    *
+   * @example
+   * ```ts
+   * // NS1
+   * // Assign the first 3 sleeves to commit various crimes.
+   * var crime = ["mug", "rob store", "shoplift"];
+   * for (var i = 0; i < crime.length; i++) {
+   *     tprintf("Sleeve %d commits crime: %s", i, crime[i]);
+   *     sleeve.setToCommitCrime(i, crime[i]);
+   * }
+   * ```
+   * @example
+   * ```ts
+   * // NS2
+   * // Assign the first 3 sleeves to commit various crimes.
+   * const crime = ["mug", "rob store", "shoplift"];
+   * for (let i = 0; i < crime.length; i++) {
+   *     ns.tprintf("Sleeve %d commits crime: %s", i, crime[i]);
+   *     ns.sleeve.setToCommitCrime(i, crime[i]);
+   * }
+   * ```
+   *
    * @param sleeveNumber - Index of the sleeve to start committing crime. Sleeves are numbered starting from 0.
    * @param name - Name of the crime. Must be an exact match. Refer to the list of crimes.
    * @returns True if this action was set successfully, false otherwise.


### PR DESCRIPTION
From the Bitburner server of Discord:
> Renbear — Yesterday at 11:09 PM
> Pardon me, but is this the proper channel to report missing API documentation? The Sleeve crime calls require exact matches of the crime names, but said crime names are not documented in an obvious way. (Yes, I realized it seemed to use the same identifiers as player crime, at least for the one crime I was attempting. I got it working, but it was via guesswork, rather than API documentation.)
Aaaaand now I just realized the crime names are given in the UI when you do it by hand. Argh. Sorry about that. Still, documentation would be a Good Thing.

This PR proposes the following changes to the documentation of `ns.sleeve.setToCommitCrime()`:

1. Commit 304b7645b0bb8506dc5ea9df824de16c97eb7860.  Document the index of the first sleeve.  Might be obvious to most (if not all) programmers to start the index at 0, but not necessarily obvious to new players who have little experience in programming.

2. Commit c728c550f5b983eff23b2d3bb8d6a68ad39f3fdb.  Add a list of crimes that a sleeve can commit.  I used the list from the file:
https://github.com/danielyxie/bitburner/blob/dev/src/Crime/Crimes.ts
and tested that all crimes listed therein can be commited by a sleeve.  Note that the list, once converted to Markdown, does not render properly in VSC.  See the attached image.  The reason is because API Extractor does not currently (as of 2022-10-10) support Markdown flavoured lists.  It does to an extent if the commented list is written as:
```js
* - Assassination
* 
* - Bond forgery
* 
* - Deal drugs
* 
* - Grand theft auto
* 
* - Heist
* 
* - Homicide
* 
* - Kidnap
* 
* - Larceny
* 
* - Mug
* 
* - Rob store
* 
* - Shoplift
* 
* - Traffick arms
```
The rendered list, as extracted and generated by API Extractor, looks rather silly because there would be a large vertical spacing between adjacent list items.  Anyway, it's a bug or missing feature in API Extractor as documented at #3033, microsoft/rushstack#1441, and microsoft/tsdoc#178.

3. Commit afe6a837c36be43c2efa9d21f398759e8c13f2d3.  This adds 1 example on how to set a sleeve to commit a crime.  The example also shows that the first sleeve has index 0, the second sleeve has index 1, and so on.

![crime-rendered](https://user-images.githubusercontent.com/66396308/194792503-4834881d-9512-47a5-8ca7-c2540d4719c1.png)
