### PR TITLE
SLEEVE: Fix #4194 sleeves not being awarded xp when working on BB's Contracts

### DIFF
--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -61,6 +61,9 @@ export class SleeveBladeburnerWork extends Work {
         if (!exp) throw new Error(`Somehow there was no exp for action ${this.actionType} ${this.actionName}`);
         applySleeveGains(sleeve, exp, 1);
       }
+      if (this.actionType === "Contracts") {
+        sleeve.gainStats(retValue);
+      }
       Player.gainMoney(retValue.money, "sleeves");
       Player.gainStats(retValue);
       this.cyclesWorked -= this.cyclesNeeded(sleeve);

--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -63,9 +63,9 @@ export class SleeveBladeburnerWork extends Work {
       }
       if (this.actionType === "Contracts") {
         sleeve.gainStats(retValue);
+        Player.gainMoney(retValue.money, "sleeves");
+        Player.gainStats(retValue);
       }
-      Player.gainMoney(retValue.money, "sleeves");
-      Player.gainStats(retValue);
       this.cyclesWorked -= this.cyclesNeeded(sleeve);
     }
     return 0;


### PR DESCRIPTION
Fix #4194

Also fix "General" Bladeburner's work awarding too much xp to the Player main body.
(as it was awarded both normal xp, and sleeve's synced xp, erroneously)