### PR TITLE
SOA: Fix #3884 Implement unused SoARepMult constant to SoA's augmentations price + linked UI modification

### DIFF
--- a/src/Augmentation/Augmentation.tsx
+++ b/src/Augmentation/Augmentation.tsx
@@ -548,13 +548,12 @@ export class Augmentation {
       }
     } else if (augmentationReference.factions.includes(FactionNames.ShadowsOfAnarchy)) {
       const soaAugmentationNames = initSoAAugmentations().map((augmentation) => augmentation.name);
-      const soaMultiplier = Math.pow(
-        CONSTANTS.SoACostMult,
-        soaAugmentationNames.filter((augmentationName) => Player.hasAugmentation(augmentationName)).length,
-      );
-      moneyCost = augmentationReference.baseCost * soaMultiplier;
+      const soaAugCount = soaAugmentationNames.filter((augmentationName) =>
+        Player.hasAugmentation(augmentationName),
+      ).length;
+      moneyCost = augmentationReference.baseCost * Math.pow(CONSTANTS.SoACostMult, soaAugCount);
       if (soaAugmentationNames.find((augmentationName) => augmentationName === augmentationReference.name)) {
-        repCost = augmentationReference.baseRepRequirement * soaMultiplier;
+        repCost = augmentationReference.baseRepRequirement * Math.pow(CONSTANTS.SoARepMult, soaAugCount);
       }
     } else {
       moneyCost =

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -14,6 +14,7 @@ import { Reputation } from "../../ui/React/Reputation";
 import { FactionNames } from "../data/FactionNames";
 import { Faction } from "../Faction";
 import { getFactionAugmentationsFiltered, hasAugmentationPrereqs, purchaseAugmentation } from "../FactionHelpers";
+import { CONSTANTS } from "../../Constants";
 
 type IProps = {
   faction: Faction;
@@ -130,11 +131,45 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
 
   const multiplierComponent =
     props.faction.name !== FactionNames.ShadowsOfAnarchy ? (
-      <Typography>
-        <b>Price multiplier:</b> x {numeralWrapper.formatReallyBigNumber(getGenericAugmentationPriceMultiplier())}
-      </Typography>
+      <Tooltip
+        title={
+          <Typography>
+            The price of every Augmentation increases for every queued Augmentation and it is reset when you install
+            them.
+          </Typography>
+        }
+      >
+        <Typography>
+          <b>Price multiplier:</b> x {numeralWrapper.formatReallyBigNumber(getGenericAugmentationPriceMultiplier())}
+        </Typography>
+      </Tooltip>
     ) : (
-      <></>
+      <Tooltip
+        title={
+          <Typography>
+            The prices of Shadows of Anarchy's Augmentations increases for every one already bought. These price are NOT
+            reset when installing augmentations.
+          </Typography>
+        }
+      >
+        <Typography>
+          <b>Price multiplier:</b> x{" "}
+          {numeralWrapper.formatReallyBigNumber(
+            Math.pow(
+              CONSTANTS.SoACostMult,
+              augs.filter((augmentationName) => Player.hasAugmentation(augmentationName)).length,
+            ),
+          )}
+          <br />
+          <b>Reputation multiplier:</b> x{" "}
+          {numeralWrapper.formatReallyBigNumber(
+            Math.pow(
+              CONSTANTS.SoARepMult,
+              augs.filter((augmentationName) => Player.hasAugmentation(augmentationName)).length,
+            ),
+          )}
+        </Typography>
+      </Tooltip>
     );
 
   return (
@@ -156,20 +191,10 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
               my: 1,
             }}
           >
-            <Tooltip
-              title={
-                <Typography>
-                  The price of every Augmentation increases for every queued Augmentation and it is reset when you
-                  install them.
-                </Typography>
-              }
-            >
-              {multiplierComponent}
-            </Tooltip>
+            <>{multiplierComponent}</>
             <Typography>
               <b>Reputation:</b> <Reputation reputation={props.faction.playerReputation} />
-            </Typography>
-            <Typography>
+              <br />
               <b>Favor:</b> <Favor favor={Math.floor(props.faction.favor)} />
             </Typography>
           </Box>

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -147,8 +147,8 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
       <Tooltip
         title={
           <Typography>
-            {FactionNames.ShadowsOfAnarchy} augmentations prices increase for every one already bought. These prices are
-            NOT reset when installing augmentations.
+            This price multiplier increases for each {FactionNames.ShadowsOfAnarchy} augmentation already purchased. The
+            multiplier is NOT reset when installing augmentations.
           </Typography>
         }
       >

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -147,7 +147,8 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
       <Tooltip
         title={
           <Typography>
-            {FactionNames.ShadowsOfAnarchy} augmentations prices increase for every one already bought. These prices are NOT reset when installing augmentations.
+            {FactionNames.ShadowsOfAnarchy} augmentations prices increase for every one already bought. These prices are
+            NOT reset when installing augmentations.
           </Typography>
         }
       >

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -147,8 +147,7 @@ export function AugmentationsPage(props: IProps): React.ReactElement {
       <Tooltip
         title={
           <Typography>
-            The prices of Shadows of Anarchy's Augmentations increases for every one already bought. These price are NOT
-            reset when installing augmentations.
+            {FactionNames.ShadowsOfAnarchy} augmentations prices increase for every one already bought. These prices are NOT reset when installing augmentations.
           </Typography>
         }
       >


### PR DESCRIPTION
Fix #3884 : Implement an unused constant meant for SoA's aug reputation costs increase.

Updated the Augmentation page to reflect that change : (only affect SoA's page)

![image](https://user-images.githubusercontent.com/104104269/195135102-671fafd0-7a08-4ed4-a336-569b79abcaf7.png)
