### PR TITLE
UI: Fix #3719 Inconsistent colors of reputation gains on Install Augmentations screen

### DIFF
--- a/src/Augmentation/ui/PlayerMultipliers.tsx
+++ b/src/Augmentation/ui/PlayerMultipliers.tsx
@@ -221,12 +221,14 @@ export function PlayerMultipliers(): React.ReactElement {
       mult: "Company Reputation Gain",
       current: Player.mults.company_rep,
       augmented: Player.mults.company_rep * mults.company_rep,
+      color: Settings.theme.combat,
     },
     {
       mult: "Faction Reputation Gain",
       current: Player.mults.faction_rep,
       augmented: Player.mults.faction_rep * mults.faction_rep,
       bnMult: BitNodeMultipliers.FactionWorkRepGain,
+      color: Settings.theme.combat,
     },
     {
       mult: "Salary",


### PR DESCRIPTION
Fix #3719 : Company & Faction reputation now use the "combat" theme's color on the augmentations page. (like the stat page)

![image](https://user-images.githubusercontent.com/104104269/195146860-b3563916-d8a8-489b-bfd2-8de4c8ca4c34.png)
