### PR TITLE
TERMINAL: Provide (unsupported) method for printing arbitrary rich content to terminal via React

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -546,6 +546,7 @@ export const RamCosts: RamCostTree<Omit<NSFull, "args" | "enums">> = {
     // Easter egg function
     break: 0,
   },
+  iKnowWhatImDoing: 0,
 
   formulas: {
     mockServer: 0,

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -546,6 +546,7 @@ export const RamCosts: RamCostTree<Omit<NSFull, "args" | "enums">> = {
     // Easter egg function
     break: 0,
   },
+  printRaw: 0,
 
   formulas: {
     mockServer: 0,

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -546,7 +546,6 @@ export const RamCosts: RamCostTree<Omit<NSFull, "args" | "enums">> = {
     // Easter egg function
     break: 0,
   },
-  printRaw: 0,
 
   formulas: {
     mockServer: 0,

--- a/src/NetscriptFunctions/Extra.ts
+++ b/src/NetscriptFunctions/Extra.ts
@@ -4,6 +4,7 @@ import * as bcrypt from "bcryptjs";
 import { Apr1Events as devMenu } from "../ui/Apr1";
 import { InternalAPI, NetscriptContext } from "../Netscript/APIWrapper";
 import { helpers } from "../Netscript/NetscriptHelpers";
+import { Terminal } from "../Terminal";
 
 export interface INetscriptExtra {
   heart: {
@@ -14,6 +15,7 @@ export interface INetscriptExtra {
   bypass(doc: Document): void;
   alterReality(): void;
   rainbow(guess: string): void;
+  iKnowWhatImDoing(): void;
 }
 
 export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
@@ -74,6 +76,11 @@ export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
         return false;
       }
       return tryGuess();
+    },
+    iKnowWhatImDoing: (ctx) => () => {
+      helpers.log(ctx, () => "Unlocking unsupported feature: window.tprintRaw");
+      // @ts-ignore window has no tprintRaw property defined
+      window.tprintRaw = Terminal.printRaw.bind(Terminal);
     },
   };
 }

--- a/src/NetscriptFunctions/Extra.ts
+++ b/src/NetscriptFunctions/Extra.ts
@@ -1,9 +1,11 @@
-import { Player as player } from "../Player";
+import { Player } from "../Player";
 import { Exploit } from "../Exploits/Exploit";
 import * as bcrypt from "bcryptjs";
 import { Apr1Events as devMenu } from "../ui/Apr1";
 import { InternalAPI, NetscriptContext } from "../Netscript/APIWrapper";
 import { helpers } from "../Netscript/NetscriptHelpers";
+import { ReactNode } from "react";
+import { Terminal } from "../Terminal";
 
 export interface INetscriptExtra {
   heart: {
@@ -14,39 +16,38 @@ export interface INetscriptExtra {
   bypass(doc: Document): void;
   alterReality(): void;
   rainbow(guess: string): void;
+  printRaw(node: ReactNode): void;
 }
 
 export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
   return {
     heart: {
       // Easter egg function
-      break: () => (): number => {
-        return player.karma;
+      break: () => () => {
+        return Player.karma;
       },
     },
-    openDevMenu: () => (): void => {
+    openDevMenu: () => () => {
       devMenu.emit();
     },
-    exploit: () => (): void => {
-      player.giveExploit(Exploit.UndocumentedFunctionCall);
+    exploit: () => () => {
+      Player.giveExploit(Exploit.UndocumentedFunctionCall);
     },
-    bypass:
-      (ctx: NetscriptContext) =>
-      (doc: unknown): void => {
-        // reset both fields first
-        type temporary = { completely_unused_field: unknown };
-        const d = doc as temporary;
-        d.completely_unused_field = undefined;
-        const real_document = document as unknown as temporary;
-        real_document.completely_unused_field = undefined;
-        // set one to true and check that it affected the other.
-        real_document.completely_unused_field = true;
-        if (d.completely_unused_field && ctx.workerScript.ramUsage === 1.6) {
-          player.giveExploit(Exploit.Bypass);
-        }
-        d.completely_unused_field = undefined;
-        real_document.completely_unused_field = undefined;
-      },
+    bypass: (ctx: NetscriptContext) => (doc: unknown) => {
+      // reset both fields first
+      type temporary = { completely_unused_field: unknown };
+      const d = doc as temporary;
+      d.completely_unused_field = undefined;
+      const real_document = document as unknown as temporary;
+      real_document.completely_unused_field = undefined;
+      // set one to true and check that it affected the other.
+      real_document.completely_unused_field = true;
+      if (d.completely_unused_field && ctx.workerScript.ramUsage === 1.6) {
+        Player.giveExploit(Exploit.Bypass);
+      }
+      d.completely_unused_field = undefined;
+      real_document.completely_unused_field = undefined;
+    },
     alterReality: () => (): void => {
       // We need to trick webpack into not optimizing a variable that is guaranteed to be false (and doesn't use prototypes)
       let x = false;
@@ -59,25 +60,27 @@ export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
       console.warn("I am sure that this variable is false.");
       if (x !== false) {
         console.warn("Reality has been altered!");
-        player.giveExploit(Exploit.RealityAlteration);
+        Player.giveExploit(Exploit.RealityAlteration);
       }
     },
-    rainbow:
-      (ctx: NetscriptContext) =>
-      (guess: unknown): boolean => {
-        function tryGuess(): boolean {
-          // eslint-disable-next-line no-sync
-          const verified = bcrypt.compareSync(
-            helpers.string(ctx, "guess", guess),
-            "$2a$10$aertxDEkgor8baVtQDZsLuMwwGYmkRM/ohcA6FjmmzIHQeTCsrCcO",
-          );
-          if (verified) {
-            player.giveExploit(Exploit.INeedARainbow);
-            return true;
-          }
-          return false;
+    rainbow: (ctx: NetscriptContext) => (guess: unknown) => {
+      function tryGuess(): boolean {
+        // eslint-disable-next-line no-sync
+        const verified = bcrypt.compareSync(
+          helpers.string(ctx, "guess", guess),
+          "$2a$10$aertxDEkgor8baVtQDZsLuMwwGYmkRM/ohcA6FjmmzIHQeTCsrCcO",
+        );
+        if (verified) {
+          Player.giveExploit(Exploit.INeedARainbow);
+          return true;
         }
-        return tryGuess();
-      },
+        return false;
+      }
+      return tryGuess();
+    },
+    printRaw: () => (node: unknown) => {
+      // Just wraps the internal function to allow player use - players can use at own risk
+      Terminal.printRaw(node as ReactNode);
+    },
   };
 }

--- a/src/NetscriptFunctions/Extra.ts
+++ b/src/NetscriptFunctions/Extra.ts
@@ -4,8 +4,6 @@ import * as bcrypt from "bcryptjs";
 import { Apr1Events as devMenu } from "../ui/Apr1";
 import { InternalAPI, NetscriptContext } from "../Netscript/APIWrapper";
 import { helpers } from "../Netscript/NetscriptHelpers";
-import { ReactNode } from "react";
-import { Terminal } from "../Terminal";
 
 export interface INetscriptExtra {
   heart: {
@@ -16,7 +14,6 @@ export interface INetscriptExtra {
   bypass(doc: Document): void;
   alterReality(): void;
   rainbow(guess: string): void;
-  printRaw(node: ReactNode): void;
 }
 
 export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
@@ -77,10 +74,6 @@ export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
         return false;
       }
       return tryGuess();
-    },
-    printRaw: () => (node: unknown) => {
-      // Just wraps the internal function to allow player use - players can use at own risk
-      Terminal.printRaw(node as ReactNode);
     },
   };
 }

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1,9 +1,2 @@
 import { Terminal as TTerminal } from "./Terminal/Terminal";
-import { ReactNode } from "react";
-declare global {
-  interface Window {
-    tprintRaw: (node: ReactNode) => void;
-  }
-}
 export const Terminal = new TTerminal();
-window["tprintRaw"] = Terminal.printRaw.bind(Terminal);

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1,3 +1,9 @@
 import { Terminal as TTerminal } from "./Terminal/Terminal";
-
+import { ReactNode } from "react";
+declare global {
+  interface Window {
+    tprintRaw: (node: ReactNode) => void;
+  }
+}
 export const Terminal = new TTerminal();
+window["tprintRaw"] = Terminal.printRaw.bind(Terminal);


### PR DESCRIPTION
A recent PR patched a common exploit that, among other things, allowed easy access to the Terminal internal object. This access to Terminal was the main way the player could print arbitrary rich content, via Terminal.printRaw.

~~This PR provides renewed access to the printRaw function through ns, as an undocumented function that is for use at a player's own risk. Because this function allows printing React content to the page, and React errors cause a recovery page, this is meant for advanced users only. Typechecking the input also would have been very difficult due to the broadness of the ReactNode type - so instead the input is assumed to be the right type (again, player's own risk).~~

As suggested, this has been moved to a global context (where React already resides) as window.tprintRaw.

~~TODO: Perhaps it should be hidden better, to make it more obvious this is not a "supported" feature.~~ TODO is done, see other comment.

Other than adding tprintRaw, it's just some minor formatting changes:
1. I removed the explicit return types from the Extra functions because ts already knows the return types implicitly. In some cases this meant a multiline wrapped function declaration could be moved to one line, which changed the indentation level of the entire wrapped function.
2. Un-decapitalized Player, just to match how it is right now in most of the codebase. If we decapitalize, it should be everywhere.

Example usage:

```js
/** @param {NS} ns */
export async function main(ns) {
  globalThis.tprintRaw(
    React.createElement("span",null,[
      "This ",
      React.createElement("i",null,"is "),
      React.createElement("b",null,"printRaw!!!")
    ])
  );
}
```
![image](https://user-images.githubusercontent.com/84951833/195191856-99509062-aa0c-4792-9d47-d01e950108b0.png)
