### PR TITLE
MISC: message formatting

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -1149,7 +1149,7 @@ export function gainCodingContractReward(
         if (!Factions[facName]) continue;
         Factions[facName].playerReputation += gainPerFaction;
       }
-      return `Gained ${gainPerFaction} reputation for each of the following factions: ${factions.toString()}`;
+      return `Gained ${gainPerFaction} reputation for each of the following factions: ${factions.join(", ")}`;
     case CodingContractRewardType.CompanyReputation: {
       if (reward.name == null || !Companies[reward.name]) {
         //If no/invalid company was designated, just give rewards to all factions


### PR DESCRIPTION
When the player successfully solved a coding contract and the reward was reputation for multiple factions, the method PlayerObjectGeneralMethods.ts#gainCodingContractReward() returned a string like
`Gained 1250 reputation for each of the following factions: BitRunners,The Black Hand,NiteSec`. 
Note the missing white space between faction names. I changed that behaviour so it now instead says:
`Gained 1250 reputation for each of the following factions: BitRunners, The Black Hand, NiteSec` 