### PR TITLE
NETSCRIPT: remove unused variables

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -61,14 +61,7 @@ import { NetscriptCorporation } from "./NetscriptFunctions/Corporation";
 import { NetscriptFormulas } from "./NetscriptFunctions/Formulas";
 import { NetscriptStockMarket } from "./NetscriptFunctions/StockMarket";
 import { NetscriptGrafting } from "./NetscriptFunctions/Grafting";
-import {
-  NS,
-  RecentScript as IRecentScript,
-  BasicHGWOptions,
-  ProcessInfo,
-  MoneySource as IMoneySource,
-  MoneySources as IMoneySources,
-} from "./ScriptEditor/NetscriptDefinitions";
+import { NS, RecentScript as IRecentScript, BasicHGWOptions, ProcessInfo } from "./ScriptEditor/NetscriptDefinitions";
 import { NetscriptSingularity } from "./NetscriptFunctions/Singularity";
 
 import { dialogBoxCreate } from "./ui/React/DialogBox";


### PR DESCRIPTION
The linter shows some unused variables:
```sh
$ npm run lint

> bitburner@2.1.0 lint
> eslint --fix --ext js,jsx,ts,tsx --max-warnings 0 src


C:\cygwin64\home\quacksouls\bb\src\NetscriptFunctions.ts
  69:18  error  'IMoneySource' is defined but never used. Allowed unused vars must match /^__/u   @typescript-eslint/no-unused-vars
  70:19  error  'IMoneySources' is defined but never used. Allowed unused vars must match /^__/u  @typescript-eslint/no-unused-vars

✖ 2 problems (2 errors, 0 warnings)
```
The PR removes the unused variables.