### PR TITLE
MISC: Adjust write() documentation, only accepts strings now

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6247,7 +6247,7 @@ export interface NS {
    * @param data - Data to write.
    * @param mode - Defines the write mode.
    */
-  write(filename: string, data?: string[] | number | string, mode?: "w" | "a"): void;
+  write(filename: string, data?: string, mode?: "w" | "a"): void;
 
   /**
    * Attempt to write to a port.


### PR DESCRIPTION
write() only accepts strings now.

closes #4239