### PR TITLE
DOC: `ns.prompt()`: some cleanup and examples

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6609,7 +6609,7 @@ export interface NS {
    *
    * @param txt - Text to appear in the prompt dialog box.
    * @param options - Options to modify the prompt the player is shown.
-   * @returns True if the player click “Yes”; false if the player clicks “No”; or the value entered by the player.
+   * @returns True if the player clicks “Yes”; false if the player clicks “No”; or the value entered by the player.
    */
   prompt(
     txt: string,

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6624,6 +6624,57 @@ export interface NS {
    *   value other than `"select"`. The script's execution is halted until the player
    *   chooses one of the provided options and presses the "Confirm" button.
    *
+   * @example
+   * ```ts
+   * // NS1
+   * // A Yes/No question. The default is to create a boolean dialog box.
+   * var queryA = "Do you enjoy Bitburner?";
+   * var resultA = prompt(queryA);
+   * tprint(queryA + " " + resultA);
+   *
+   * // Another Yes/No question. Can also create a boolean dialog box by explicitly
+   * // passing the option {"type": "boolean"}.
+   * var queryB = "Is programming fun?";
+   * var resultB = prompt(queryB, { type: "boolean" });
+   * tprint(queryB + " " + resultB);
+   *
+   * // Free-form text box.
+   * var resultC = prompt("Please enter your name.", { type: "text" });
+   * tprint("Hello, " + resultC + ".");
+   *
+   * // A drop-down list.
+   * var resultD = prompt("Please select your favorite fruit.", {
+   *     type: "select",
+   *     choices: ["Apple", "Banana", "Orange", "Pear", "Strawberry"]
+   * });
+   * tprint("Your favorite fruit is " + resultD.toLowerCase() + ".");
+   * ```
+   * @example
+   * ```ts
+   * // NS2
+   * // A Yes/No question. The default is to create a boolean dialog box.
+   * const queryA = "Do you enjoy Bitburner?";
+   * const resultA = await ns.prompt(queryA);
+   * ns.tprint(`${queryA} ${resultA}`);
+   *
+   * // Another Yes/No question. Can also create a boolean dialog box by explicitly
+   * // passing the option {"type": "boolean"}.
+   * const queryB = "Is programming fun?";
+   * const resultB = await ns.prompt(queryB, { type: "boolean" });
+   * ns.tprint(`${queryB} ${resultB}`);
+   *
+   * // Free-form text box.
+   * const resultC = await ns.prompt("Please enter your name.", { type: "text" });
+   * ns.tprint(`Hello, ${resultC}.`);
+   *
+   * // A drop-down list.
+   * const resultD = await ns.prompt("Please select your favorite fruit.", {
+   *     type: "select",
+   *     choices: ["Apple", "Banana", "Orange", "Pear", "Strawberry"]
+   * });
+   * ns.tprint(`Your favorite fruit is ${resultD.toLowerCase()}.`);
+   * ```
+   *
    * @param txt - Text to appear in the prompt dialog box.
    * @param options - Options to modify the prompt the player is shown.
    * @returns True if the player clicks “Yes”; false if the player clicks “No”; or the value entered by the player.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6600,12 +6600,29 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * Prompts the player with a dialog box. If `options.type` is undefined or "boolean",
-   * the player is shown "Yes" and "No" prompts, which return true and false respectively.
-   * Passing a type of "text" will give the player a text field and a value of "select"
-   * will show a drop-down field. Choosing type "select" will require an array or object
-   * to be passed via the `options.choices` property.
-   * The script’s execution is halted until the player selects one of the options.
+   * Prompts the player with a dialog box. Here is an explanation of the various options.
+   *
+   * - `options.type` is not provided to the function. If `options.type` is left out and
+   *   only a string is passed to the function, then the default behavior is to create a
+   *   boolean dialog box.
+   *
+   * - `options.type` has value `undefined` or `"boolean"`. A boolean dialog box is
+   *   created. The player is shown "Yes" and "No" prompts, which return true and false
+   *   respectively. The script's execution is halted until the player presses either the
+   *   "Yes" or "No" button.
+   *
+   * - `options.type` has value `"text"`. The player is given a text field to enter
+   *   free-form text. The script's execution is halted until the player enters some text
+   *   and/or presses the "Confirm" button.
+   *
+   * - `options.type` has value `"select"`. The player is shown a drop-down field.
+   *   Choosing type `"select"` will require an array to be passed via the
+   *   `options.choices` property. The array can be an array of strings, an array of
+   *   numbers (not BigInt numbers), or a mixture of both numbers and strings. Any other
+   *   types of array elements will result in an error or an undefined/unexpected
+   *   behavior. The `options.choices` property will be ignored if `options.type` has a
+   *   value other than `"select"`. The script's execution is halted until the player
+   *   chooses one of the provided options and presses the "Confirm" button.
    *
    * @param txt - Text to appear in the prompt dialog box.
    * @param options - Options to modify the prompt the player is shown.


### PR DESCRIPTION
This PR is inspired by the confusion raised by the OP of this Steam post:

https://steamcommunity.com/app/1812820/discussions/0/6077070109425748796/

The PR proposes the following changes to the documentation of `ns.prompt()`:

1. Commit a368c6904e2378d6afa21ed06e53f5b6f2047e93.  A typographical fix.
2. Commit ~3db6e051db26ba37ceff083652fa4ee99a34bead~ 473e6a26749bce6abee18142fcb4c4bb0af4a6c6.  Explain the various values for the parameters of the function.  The explanation is broken into bullet points for clear presentation and easy reading.  This commit also documents the default behaviour when only a string is passed to the function `ns.prompt()`.
3. Commit ~f7a523d5a9da30070aed1356a84017bd028e8b1a~ 93090691b53a71cf262103200c0d8dacf532451d.  Some examples on how to create all the prompt dialog boxes.  These examples illustrate the various explicit options, including the default case.