### PR TITLE
NETSCRIPT: Fix ns.prompt typechecking

### DIFF
--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -65,9 +65,8 @@ export const helpers = {
   failOnHacknetServer,
 };
 
-
 /** Will probably remove the below function in favor of a different approach to object type assertion.
- *  This method cannot be used to handle optional properties. */ 
+ *  This method cannot be used to handle optional properties. */
 export function assertObjectType<T extends object>(
   ctx: NetscriptContext,
   name: string,

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -65,6 +65,9 @@ export const helpers = {
   failOnHacknetServer,
 };
 
+
+/** Will probably remove the below function in favor of a different approach to object type assertion.
+ *  This method cannot be used to handle optional properties. */ 
 export function assertObjectType<T extends object>(
   ctx: NetscriptContext,
   name: string,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1758,11 +1758,11 @@ const base: InternalAPI<NS> = {
     _options ??= options;
     const txt = helpers.string(ctx, "txt", _txt);
     assert(_options, objectAssert, (type) =>
-      helpers.makeRuntimeErrorMsg(ctx, `Invalid type for options: ${type}, should be object.`, "TYPE"),
+      helpers.makeRuntimeErrorMsg(ctx, `Invalid type for options: ${type}. Should be object.`, "TYPE"),
     );
     if (_options.type !== undefined) {
       assert(_options.type, stringAssert, (type) =>
-        helpers.makeRuntimeErrorMsg(ctx, `Invalid type for options.type: ${type}, should be string.`, "TYPE"),
+        helpers.makeRuntimeErrorMsg(ctx, `Invalid type for options.type: ${type}. Should be string.`, "TYPE"),
       );
       options.type = _options.type;
       const validTypes = ["boolean", "text", "select"];

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -61,14 +61,7 @@ import { NetscriptCorporation } from "./NetscriptFunctions/Corporation";
 import { NetscriptFormulas } from "./NetscriptFunctions/Formulas";
 import { NetscriptStockMarket } from "./NetscriptFunctions/StockMarket";
 import { NetscriptGrafting } from "./NetscriptFunctions/Grafting";
-import {
-  NS,
-  RecentScript as IRecentScript,
-  BasicHGWOptions,
-  ProcessInfo,
-  MoneySource as IMoneySource,
-  MoneySources as IMoneySources,
-} from "./ScriptEditor/NetscriptDefinitions";
+import { NS, RecentScript as IRecentScript, BasicHGWOptions, ProcessInfo } from "./ScriptEditor/NetscriptDefinitions";
 import { NetscriptSingularity } from "./NetscriptFunctions/Singularity";
 
 import { dialogBoxCreate } from "./ui/React/DialogBox";
@@ -83,6 +76,7 @@ import { InternalAPI, wrapAPI } from "./Netscript/APIWrapper";
 import { INetscriptExtra } from "./NetscriptFunctions/Extra";
 import { ScriptDeath } from "./Netscript/ScriptDeath";
 import { getBitNodeMultipliers } from "./BitNode/BitNode";
+import { assert, arrayAssert, stringAssert, objectAssert } from "./utils/helpers/typeAssertion";
 
 // "Enums" as object
 export const enums = {
@@ -1759,60 +1753,81 @@ const base: InternalAPI<NS> = {
         throw new Error(`variant must be one of ${Object.values(ToastVariant).join(", ")}`);
       SnackbarEvents.emit(message, variant as ToastVariant, duration);
     },
-  prompt:
-    (ctx) =>
-    (_txt, options = {}) => {
-      const txt = helpers.string(ctx, "txt", _txt);
-      const optionsValidator: { type?: string; options?: string[] } = {};
-      assertObjectType(ctx, "options", options, optionsValidator);
-
-      return new Promise(function (resolve) {
-        PromptEvent.emit({
-          txt: txt,
-          options,
-          resolve: resolve,
-        });
-      });
-    },
-  wget:
-    (ctx) =>
-    async (_url, _target, _hostname = ctx.workerScript.hostname) => {
-      const url = helpers.string(ctx, "url", _url);
-      const target = helpers.string(ctx, "target", _target);
-      const hostname = helpers.string(ctx, "hostname", _hostname);
-      if (!isScriptFilename(target) && !target.endsWith(".txt")) {
-        helpers.log(ctx, () => `Invalid target file: '${target}'. Must be a script or text file.`);
-        return Promise.resolve(false);
+  prompt: (ctx) => (_txt, _options) => {
+    const options: { type?: string; choices?: string[] } = {};
+    _options ??= options;
+    const txt = helpers.string(ctx, "txt", _txt);
+    assert(_options, objectAssert, (type) =>
+      helpers.makeRuntimeErrorMsg(ctx, `Invalid type for options: ${type}, should be object.`, "TYPE"),
+    );
+    if (_options.type !== undefined) {
+      assert(_options.type, stringAssert, (type) =>
+        helpers.makeRuntimeErrorMsg(ctx, `Invalid type for options.type: ${type}, should be string.`, "TYPE"),
+      );
+      options.type = _options.type;
+      const validTypes = ["boolean", "text", "select"];
+      if (!["boolean", "text", "select"].includes(options.type)) {
+        throw helpers.makeRuntimeErrorMsg(
+          ctx,
+          `Invalid value for options.type: ${options.type}. Must be one of ${validTypes.join(", ")}.`,
+        );
       }
-      const s = helpers.getServer(ctx, hostname);
-      return new Promise(function (resolve) {
-        $.get(
-          url,
-          function (data) {
-            let res;
-            if (isScriptFilename(target)) {
-              res = s.writeToScriptFile(target, data);
-            } else {
-              res = s.writeToTextFile(target, data);
-            }
-            if (!res.success) {
-              helpers.log(ctx, () => "Failed.");
-              return resolve(false);
-            }
-            if (res.overwritten) {
-              helpers.log(ctx, () => `Successfully retrieved content and overwrote '${target}' on '${hostname}'`);
-              return resolve(true);
-            }
-            helpers.log(ctx, () => `Successfully retrieved content to new file '${target}' on '${hostname}'`);
-            return resolve(true);
-          },
-          "text",
-        ).fail(function (e) {
-          helpers.log(ctx, () => JSON.stringify(e));
-          return resolve(false);
-        });
+      if (options.type === "select") {
+        assert(_options.choices, arrayAssert, (type) =>
+          helpers.makeRuntimeErrorMsg(
+            ctx,
+            `Invalid type for options.choices: ${type}. If options.type is "select", options.choices must be an array.`,
+            "TYPE",
+          ),
+        );
+        options.choices = _options.choices.map((choice, i) => helpers.string(ctx, `options.choices[${i}]`, choice));
+      }
+    }
+    return new Promise(function (resolve) {
+      PromptEvent.emit({
+        txt: txt,
+        options,
+        resolve: resolve,
       });
-    },
+    });
+  },
+  wget: (ctx) => async (_url, _target, _hostname) => {
+    const url = helpers.string(ctx, "url", _url);
+    const target = helpers.string(ctx, "target", _target);
+    const hostname = _hostname ? helpers.string(ctx, "hostname", _hostname) : ctx.workerScript.hostname;
+    if (!isScriptFilename(target) && !target.endsWith(".txt")) {
+      helpers.log(ctx, () => `Invalid target file: '${target}'. Must be a script or text file.`);
+      return Promise.resolve(false);
+    }
+    const s = helpers.getServer(ctx, hostname);
+    return new Promise(function (resolve) {
+      $.get(
+        url,
+        function (data) {
+          let res;
+          if (isScriptFilename(target)) {
+            res = s.writeToScriptFile(target, data);
+          } else {
+            res = s.writeToTextFile(target, data);
+          }
+          if (!res.success) {
+            helpers.log(ctx, () => "Failed.");
+            return resolve(false);
+          }
+          if (res.overwritten) {
+            helpers.log(ctx, () => `Successfully retrieved content and overwrote '${target}' on '${hostname}'`);
+            return resolve(true);
+          }
+          helpers.log(ctx, () => `Successfully retrieved content to new file '${target}' on '${hostname}'`);
+          return resolve(true);
+        },
+        "text",
+      ).fail(function (e) {
+        helpers.log(ctx, () => JSON.stringify(e));
+        return resolve(false);
+      });
+    });
+  },
   getFavorToDonate: () => () => {
     return Math.floor(CONSTANTS.BaseFavorToDonate * BitNodeMultipliers.RepToDonateToFaction);
   },

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6613,7 +6613,7 @@ export interface NS {
    */
   prompt(
     txt: string,
-    options?: { type?: "boolean" | "text" | "select" | undefined; choices?: string[] },
+    options?: { type?: "boolean" | "text" | "select"; choices?: string[] },
   ): Promise<boolean | string>;
 
   /**

--- a/src/utils/helpers/typeAssertion.ts
+++ b/src/utils/helpers/typeAssertion.ts
@@ -12,7 +12,7 @@ export function assert<T>(
   try {
     assertFn(v);
   } catch (type: unknown) {
-    if (type !== "string") type = "unknown";
+    if (typeof type !== "string") type = "unknown";
     throw msgFn(type as string);
   }
 }

--- a/src/utils/helpers/typeAssertion.ts
+++ b/src/utils/helpers/typeAssertion.ts
@@ -1,0 +1,42 @@
+// Various functions for asserting types.
+
+/** Function for providing custom error message to throw for a type assertion.
+ * @param v: Value to assert type of
+ * @param assertFn: Typechecking function to use for asserting type of v.
+ * @param msgFn: Function to use to generate an error message if an error is produced. */
+export function assert<T>(
+  v: unknown,
+  assertFn: (v: unknown) => asserts v is T,
+  msgFn: (type: string) => string,
+): asserts v is T {
+  try {
+    assertFn(v);
+  } catch (type: unknown) {
+    if (type !== "string") type = "unknown";
+    throw msgFn(type as string);
+  }
+}
+
+/** Returns the friendlyType of v. arrays are "array" and null is "null". */
+export function getFriendlyType(v: unknown): string {
+  return v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
+}
+
+//All assertion functions used here should return the friendlyType of the input.
+
+/** For non-objects, and for array/null, throws the friendlyType of v. */
+export function objectAssert(v: unknown): asserts v is Partial<Record<string, unknown>> {
+  const type = getFriendlyType(v);
+  if (type !== "object") throw type;
+}
+
+/** For non-string, throws the friendlyType of v. */
+export function stringAssert(v: unknown): asserts v is string {
+  const type = getFriendlyType(v);
+  if (type !== "string") throw type;
+}
+
+/** For non-array, throws the friendlyType of v. */
+export function arrayAssert(v: unknown): asserts v is unknown[] {
+  if (!Array.isArray(v)) throw getFriendlyType(v);
+}


### PR DESCRIPTION
Fix #4246

Introduced and used some new type assertion functions, possibly an initial step in further type safety improvements.

Also removed the |undefined in the documentation for the `type?`, as that is already implied by the ?.

I also just moved the default value for hostname in wget (and adjacent function) to below the function definition, because prettier is then fine with the wrapped function definition on one line. Didn't actually modify the functionality of wget, it's just an indentation shift.

Error when passing a non-object as ns.prompt options: `await ns.prompt("test", "test");`:
![image](https://user-images.githubusercontent.com/84951833/195879978-e7ded488-687a-47ea-9f3e-b079bdd8cd83.png)

Error when passing a non-string as options.type: `await ns.prompt("test", {type: 1});`
![image](https://user-images.githubusercontent.com/84951833/195880441-eb361871-609a-44d3-a87d-6a4d9fc88e24.png)

Error when passing an invalid string for options.type: `await ns.prompt("test", {type:"final exam"});`
![image](https://user-images.githubusercontent.com/84951833/195880699-bacb73df-1dc7-4ccc-b95e-2298e77b7f9f.png)

Error when passing "select" as options.type but not providing an array for options.choices: `await ns.prompt("test", {type:"select"});`
![image](https://user-images.githubusercontent.com/84951833/195881101-0a7baf76-fcaf-45f8-a73c-38aafb3994fe.png)

Error when one of the choices is not a string (or cannot be converted to string with helpers.string): `await ns.prompt("test", {type:"select", choices:["choice1", ["choice2?"]]});`
![image](https://user-images.githubusercontent.com/84951833/195881508-ecf90016-c7db-4fb0-a89e-c3d3b3080722.png)

All normal uses work normally with no error messages.