### PR TITLE
DOC: `gang.canRecruitMember()`: typo fix and elaboration

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3378,6 +3378,14 @@ export interface Gang {
    *
    * Returns a boolean indicating whether a member can currently be recruited.
    *
+   * Once you have successfully created a gang by using the function
+   * {@link Gang.createGang | createGang}, you can immediately recruit a small
+   * number of members to your gang. After you have recruited the founding
+   * members, to recruit another member you must increase your respect. The
+   * more members you want to recruit, the more respect you require. If your
+   * gang has the maximum number of members, then this function would return
+   * false.
+   *
    * @returns True if a member can currently be recruited, false otherwise.
    */
   canRecruitMember(): boolean;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3376,7 +3376,7 @@ export interface Gang {
    * @remarks
    * RAM cost: 1 GB
    *
-   * Returns boolean indicating whether a member can currently be recruited
+   * Returns a boolean indicating whether a member can currently be recruited.
    *
    * @returns True if a member can currently be recruited, false otherwise.
    */


### PR DESCRIPTION
This PR changes the documentation of `ns.gang.canRecruitMember()` as follows:

1. Commit ac0e7c959558e3daf715a2788cdc084460ab5b45.  Some typographical fixes.
2. Commit 6f1822bf4d94d96a56e4b9f0f146d0e60463aacb.  Elaborate (vaguely) on various conditions under which the function would return true or false.