### PR TITLE
UI: swapped the icons on "Import Game" and "Export Game" buttons

### DIFF
--- a/src/GameOptions/ui/GameOptionsSidebar.tsx
+++ b/src/GameOptions/ui/GameOptionsSidebar.tsx
@@ -130,7 +130,7 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
           <DeleteGameButton />
         </Box>
         <Tooltip title={<Typography>Export your game to a text file.</Typography>}>
-          <Button onClick={() => props.export()} startIcon={<Download />} sx={{ gridArea: "export" }}>
+          <Button onClick={() => props.export()} startIcon={<Upload />} sx={{ gridArea: "export" }}>
             Export Game
           </Button>
         </Tooltip>
@@ -143,7 +143,7 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
             </Typography>
           }
         >
-          <Button onClick={startImport} startIcon={<Upload />} sx={{ gridArea: "import" }}>
+          <Button onClick={startImport} startIcon={<Download />} sx={{ gridArea: "import" }}>
             Import Game
             <input ref={importInput} id="import-game-file-selector" type="file" hidden onChange={onImport} />
           </Button>


### PR DESCRIPTION
# UI: swapped the icons on "Import Game" and "Export Game" buttons to make more sense

## Linked issues

fixes #4269 

## Bug fix

before the fix:
![image of the buttons before the fix](https://user-images.githubusercontent.com/74354294/199586830-92f0aaf0-09f5-4c63-9bcc-63cda5f03aa4.png)
after the fix:
![image of the buttons after the fix](https://user-images.githubusercontent.com/74354294/199586823-77118107-b067-4475-8826-b888879bbfbc.png)